### PR TITLE
Avoid creating change with 0 asset amounts

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -590,11 +590,13 @@ func (b *Apollo) addChangeAndFee() *Apollo {
 	}
 	for policy, assets := range change.GetAssets() {
 		for asset, amt := range assets {
-			payment.Units = append(payment.Units, Unit{
-				PolicyId: policy.String(),
-				Name:     asset.String(),
-				Quantity: int(amt),
-			})
+			if amt > 0 {
+				payment.Units = append(payment.Units, Unit{
+					PolicyId: policy.String(),
+					Name:     asset.String(),
+					Quantity: int(amt),
+				})
+			}
 		}
 	}
 	b.payments = append(b.payments, &payment)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/Salvionied/apollo
+module github.com/SundaeSwap-finance/apollo
 
 go 1.20
 
 require (
-	github.com/Salvionied/cbor/v2 v2.6.0
+	github.com/SundaeSwap-finance/cbor/v2 v2.6.0
 	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/text v0.9.0


### PR DESCRIPTION
While technically valid on chain, the tx builder probably shouldn't produce change with 0 value multi-assets, as it takes up bytes and costs the user a few lovelace.

There might also be a more extensive solution where this is applied to all outputs somewhere, but it was outside of my familiarity with the library to hunt down where that should go.