### PR TITLE
Fix a bug with min-utxo outputs

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -219,7 +219,7 @@ func (b *Apollo) AddRequiredSignerFromAddress(address Address.Address, addPaymen
 func (b *Apollo) buildOutputs() []TransactionOutput.TransactionOutput {
 	outputs := make([]TransactionOutput.TransactionOutput, 0)
 	for _, payment := range b.payments {
-		outputs = append(outputs, *payment.ToTxOut(&b.Context))
+		outputs = append(outputs, *payment.ToTxOut())
 	}
 	return outputs
 
@@ -494,6 +494,7 @@ func (b *Apollo) Complete() (*Apollo, error) {
 	// }
 	requestedAmount := Value.Value{}
 	for _, payment := range b.payments {
+		payment.EnsureMinUTXO(b.Context)
 		requestedAmount = requestedAmount.Add(payment.ToValue())
 	}
 	requestedAmount.AddLovelace(b.estimateFee())


### PR DESCRIPTION
For convenience, we want to allow payments to be constructed without worrying about the minUTXO; if the calculated amount falls below the minUTXO, we increase it to the minimum, and let tx balancing find the ada to cover it.  However, in the current implementation, we were coercing the minutxo amount when calculating the `requestedAmount`, in .ToValue.  But, we weren't doing the same thing in .ToTxOut(), which would leave the tx imbalanced.  To solve this, I've created a dedicated EnsureMinUTXO method, which ensures that after it gets massaged, it'll be consistent across all future uses