### PR TITLE
fix: LoadTxCbor should hex decode the cbor string

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -1533,7 +1533,11 @@ func (b *Apollo) Submit() (serialization.TransactionId, error) {
 */
 func (b *Apollo) LoadTxCbor(txCbor string) (*Apollo, error) {
 	tx := Transaction.Transaction{}
-	err := cbor.Unmarshal([]byte(txCbor), &tx)
+  cborBytes, err := hex.DecodeString(txCbor)
+  if err != nil {
+    return nil, err
+  }
+	err = cbor.Unmarshal(cborBytes, &tx)
 	if err != nil {
 		return b, err
 	}


### PR DESCRIPTION
LoadTxCbor should not be casting the cbor string into bytes but actually hex decoding it. Otherwise it was failing when trying to load from a valid cbor transaction