### PR TITLE
fix: update kugo from main to include matches parsing fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Salvionied/cbor/v2 v2.6.0
-	github.com/SundaeSwap-finance/kugo v1.0.6-0.20250113214905-5e85003d6383
+	github.com/SundaeSwap-finance/kugo v1.0.6-0.20250116035512-6686234216f0
 	github.com/SundaeSwap-finance/ogmigo v0.8.2-0.20250113211512-19cbb328b538
 	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go v1.55.5 // indirect
+	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,14 @@ github.com/Salvionied/cbor/v2 v2.6.0 h1:OEwlZLiodLdNeM9wFoSydLvj6/rHRaxu5G8VzwXS
 github.com/Salvionied/cbor/v2 v2.6.0/go.mod h1:oFxaUo/mQ5sG1k459nzctGdYa80jy0ZqZ9pln9C/fGw=
 github.com/SundaeSwap-finance/kugo v1.0.6-0.20250113214905-5e85003d6383 h1:O/Q+o9m1X9LJxu9ilQQOsvmvNDP/qfkC6mDLdHIBMNU=
 github.com/SundaeSwap-finance/kugo v1.0.6-0.20250113214905-5e85003d6383/go.mod h1:2SHoDj4BVERXdcs3d3v/Y81WqZRZbNStAQ/tA6HVYGs=
+github.com/SundaeSwap-finance/kugo v1.0.6-0.20250116035512-6686234216f0 h1:jvKQLcVQiSjSQk4sL5e3LasbKuezI7QKwFzU9Wk48lE=
+github.com/SundaeSwap-finance/kugo v1.0.6-0.20250116035512-6686234216f0/go.mod h1:2SHoDj4BVERXdcs3d3v/Y81WqZRZbNStAQ/tA6HVYGs=
 github.com/SundaeSwap-finance/ogmigo v0.8.2-0.20250113211512-19cbb328b538 h1:1ZjhSdkEwP8BQvF05YuORR9C2ZBl3BgFlnafrDnMH3w=
 github.com/SundaeSwap-finance/ogmigo v0.8.2-0.20250113211512-19cbb328b538/go.mod h1:io/H+NvaSomJKmh4mbhjgT0RX4AdTTSxbImeRNZCCKs=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
+++ b/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
@@ -207,6 +207,19 @@ func statequeryValue_toAddressAmount(v shared.Value) []Base.AddressAmount {
 	return amts
 }
 
+func kugoValue_toSharedValue(v kugo.CompatibleValue) shared.Value {
+	result := shared.Value{}
+	for policyId, assets := range v {
+		for assetName, amt := range assets {
+			if _, ok := result[policyId]; !ok {
+				result[policyId] = map[string]num.Int{}
+			}
+			result[policyId][assetName] = amt
+		}
+	}
+	return result
+}
+
 func chainsyncValue_toAddressAmount(v shared.Value) []Base.AddressAmount {
 	// same as above
 	return statequeryValue_toAddressAmount(v)
@@ -294,7 +307,7 @@ func (occ *OgmiosChainContext) AddressUtxos(address string, gather bool) []Base.
 		addressUtxos = append(addressUtxos, Base.AddressUTXO{
 			TxHash:      match.TransactionID,
 			OutputIndex: match.OutputIndex,
-			Amount:      chainsyncValue_toAddressAmount(match.Value),
+			Amount:      chainsyncValue_toAddressAmount(kugoValue_toSharedValue(match.Value)),
 			// We probably don't need this info and kupo doesn't provide it in this query
 			Block:       "",
 			DataHash:    match.DatumHash,


### PR DESCRIPTION
The match parsing in kugo was improperly updated to the ogmigo v6 data shape when kupo still uses the older v5 shape. I've updated kugo, this pulls it into Apollo.