### PR TITLE
fix: incorrect conversion between integer types

### DIFF
--- a/serialization/HDWallet/HDWallet.go
+++ b/serialization/HDWallet/HDWallet.go
@@ -158,7 +158,7 @@ func (hd *HDWallet) DerivePath(path string) (*HDWallet, error) {
 	derived_wallet := hd.copy()
 	for _, index := range strings.Split(strings.TrimLeft(path, "m/"), "/") {
 		if strings.HasSuffix(index, "'") {
-			ind_val, err := strconv.Atoi(string(index[:len(index)-1]))
+			ind_val, err := strconv.ParseUint(string(index[:len(index)-1]), 10, 32)
 
 			if err != nil {
 				return nil, err
@@ -167,7 +167,7 @@ func (hd *HDWallet) DerivePath(path string) (*HDWallet, error) {
 				uint32(ind_val), true,
 			)
 		} else {
-			ind_val, err := strconv.Atoi(index)
+			ind_val, err := strconv.ParseUint(index, 10, 32)
 			if err != nil {
 				return nil, err
 			}

--- a/serialization/HDWallet/HDWallet.go
+++ b/serialization/HDWallet/HDWallet.go
@@ -200,7 +200,7 @@ func (hd *HDWallet) Derive(index uint32, hardened bool) *HDWallet {
 	return &HDWallet{
 		RootXprivKey: hd.RootXprivKey,
 		XPrivKey:     derived_xprivkey,
-		Path:         hd.Path + "/" + strconv.Itoa(int(index)),
+		Path:         hd.Path + "/" + strconv.FormatUint(uint64(index), 10),
 		Seed:         hd.Seed,
 		Mnemonic:     hd.Mnemonic,
 		Passphrase:   hd.Passphrase,

--- a/serialization/common.go
+++ b/serialization/common.go
@@ -3,6 +3,7 @@ package serialization
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 
@@ -115,6 +116,9 @@ func (cb *CustomBytes) Int() (int, error) {
 		value, err := strconv.ParseInt(cb.Value, 10, 64)
 		if err != nil {
 			return 0, err
+		}
+		if value < math.MinInt || value > math.MaxInt {
+			return 0, fmt.Errorf("value out of int range")
 		}
 		return int(value), nil
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Salvionied/apollo/security/code-scanning/1](https://github.com/Salvionied/apollo/security/code-scanning/1)

To fix the problem, we need to ensure that the integer value parsed from the string is within the bounds of a `uint32` before performing the conversion. This can be done by using `strconv.ParseUint` with a bit size of 32, which directly returns a `uint64` that can be safely cast to `uint32` after bounds checking.

1. Replace the use of `strconv.Atoi` with `strconv.ParseUint` specifying a bit size of 32.
2. Check the bounds of the parsed value to ensure it fits within the `uint32` range.
3. Perform the conversion to `uint32` only after ensuring the value is within bounds.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
