### PR TITLE
chore: switch back to fxamacker/cbor

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/Withdrawal"
 	"github.com/Salvionied/apollo/txBuilding/Backend/Base"
 	"github.com/Salvionied/apollo/txBuilding/Utils"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/exp/slices"
 )
 

--- a/ApolloBuilder_test.go
+++ b/ApolloBuilder_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Salvionied/apollo/txBuilding/Backend/BlockFrostChainContext"
 	"github.com/Salvionied/apollo/txBuilding/Backend/FixedChainContext"
 	"github.com/Salvionied/apollo/txBuilding/TxBuilder"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type Network int

--- a/coverage.html
+++ b/coverage.html
@@ -149,7 +149,7 @@ import (
         "github.com/Salvionied/apollo/txBuilding/Backend/Base"
         "github.com/Salvionied/apollo/txBuilding/Backend/BlockFrostChainContext"
         "github.com/Salvionied/apollo/txBuilding/Utils"
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
         "golang.org/x/exp/slices"
 )
 
@@ -2328,7 +2328,7 @@ import (
         "github.com/Salvionied/apollo/serialization"
         "github.com/Salvionied/apollo/serialization/Address"
         "github.com/Salvionied/apollo/serialization/PlutusData"
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 func GetAddressPlutusData(address Address.Address) (*PlutusData.PlutusData, error) <span class="cov8" title="1">{
@@ -3217,7 +3217,7 @@ import (
         "github.com/Salvionied/apollo/crypto/bech32"
         "github.com/Salvionied/apollo/serialization"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 const (
@@ -3778,7 +3778,7 @@ import (
         "encoding/hex"
         "errors"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type AssetName struct {
@@ -4102,7 +4102,7 @@ import (
         "github.com/Salvionied/apollo/crypto/bip32"
         "github.com/Salvionied/apollo/serialization"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
         "golang.org/x/crypto/blake2b"
 )
 
@@ -4346,7 +4346,7 @@ import (
 
         "github.com/Salvionied/apollo/serialization"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type MinimalMetadata map[string]any
@@ -4696,7 +4696,7 @@ func (ma MultiAsset[V]) Filter(f func(policy Policy.PolicyId, asset AssetName.As
 import (
         "github.com/Salvionied/apollo/serialization"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
         "golang.org/x/crypto/blake2b"
 )
 
@@ -4904,7 +4904,7 @@ import (
         "github.com/Salvionied/apollo/serialization"
         "github.com/Salvionied/apollo/serialization/Address"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 
         "golang.org/x/crypto/blake2b"
 )
@@ -6115,7 +6115,7 @@ import (
         "encoding/hex"
         "errors"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type PolicyId struct {
@@ -6322,7 +6322,7 @@ import (
         "github.com/Salvionied/apollo/serialization/Metadata"
         "github.com/Salvionied/apollo/serialization/TransactionBody"
         "github.com/Salvionied/apollo/serialization/TransactionWitnessSet"
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type Transaction struct {
@@ -6372,7 +6372,7 @@ import (
         "github.com/Salvionied/apollo/serialization/TransactionOutput"
         "github.com/Salvionied/apollo/serialization/Withdrawal"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
         "golang.org/x/crypto/blake2b"
 )
 
@@ -6504,7 +6504,7 @@ import (
         "github.com/Salvionied/apollo/serialization/PlutusData"
         "github.com/Salvionied/apollo/serialization/Value"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type TransactionOutputAlonzo struct {
@@ -7007,7 +7007,7 @@ import (
         "github.com/Salvionied/apollo/serialization/PlutusData"
         "github.com/Salvionied/apollo/serialization/Redeemer"
         "github.com/Salvionied/apollo/serialization/VerificationKeyWitness"
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type normaltws struct {
@@ -7148,7 +7148,7 @@ import (
         "github.com/Salvionied/apollo/serialization/Amount"
         "github.com/Salvionied/apollo/serialization/MultiAsset"
 
-        "github.com/Salvionied/cbor/v2"
+        "github.com/fxamacker/cbor/v2"
 )
 
 type Value struct {

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/Salvionied/apollo
 go 1.20
 
 require (
-	github.com/Salvionied/cbor/v2 v2.6.0
 	github.com/SundaeSwap-finance/kugo v1.1.0
 	github.com/SundaeSwap-finance/ogmigo v0.9.0
 	github.com/fatih/color v1.18.0
+	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.8.1
@@ -18,7 +18,6 @@ require (
 require (
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/Salvionied/cbor/v2 v2.6.0 h1:OEwlZLiodLdNeM9wFoSydLvj6/rHRaxu5G8VzwXSeuY=
-github.com/Salvionied/cbor/v2 v2.6.0/go.mod h1:oFxaUo/mQ5sG1k459nzctGdYa80jy0ZqZ9pln9C/fGw=
 github.com/SundaeSwap-finance/kugo v1.1.0 h1:9fzzqiRcyOD8NF2L7I8aJArtyiYg9pu54SEoFKLs8JI=
 github.com/SundaeSwap-finance/kugo v1.1.0/go.mod h1:J3ePLSTzrEL3wqphzuMeq2KLe3jN0i69gVt3UHUAvhY=
 github.com/SundaeSwap-finance/ogmigo v0.9.0 h1:+W9XuZfyMy2Kx7A4wZAmuks7hyq5TdfvBlUb1JSRP50=

--- a/plutusencoder/plutus.go
+++ b/plutusencoder/plutus.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Salvionied/apollo/serialization"
 	"github.com/Salvionied/apollo/serialization/Address"
 	"github.com/Salvionied/apollo/serialization/PlutusData"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func MarshalPlutus(v interface{}) (*PlutusData.PlutusData, error) {

--- a/plutusencoder/plutusencoder_test.go
+++ b/plutusencoder/plutusencoder_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Salvionied/apollo/serialization"
 	"github.com/Salvionied/apollo/serialization/Address"
 	"github.com/Salvionied/apollo/serialization/PlutusData"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type TestAddress struct {

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ import (
     "encoding/hex"
     "fmt"
 
-    "github.com/Salvionied/cbor/v2"
+    "github.com/fxamacker/cbor/v2"
     "github.com/Salvionied/apollo"
     "github.com/Salvionied/apollo/txBuilding/Backend/BlockFrostChainContext"
 )

--- a/serialization/Address/Address.go
+++ b/serialization/Address/Address.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Salvionied/apollo/crypto/bech32"
 	"github.com/Salvionied/apollo/serialization"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 const (

--- a/serialization/Amount/Amount_test.go
+++ b/serialization/Amount/Amount_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/AssetName"
 	"github.com/Salvionied/apollo/serialization/MultiAsset"
 	"github.com/Salvionied/apollo/serialization/Policy"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 var policy = Policy.PolicyId{Value: "fc11a9ef431f81b837736be5f53e4da29b9469c983d07f321262ce61"}

--- a/serialization/AssetName/AssetName.go
+++ b/serialization/AssetName/AssetName.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type AssetName struct {

--- a/serialization/AssetName/AssetName_test.go
+++ b/serialization/AssetName/AssetName_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Salvionied/apollo/serialization/AssetName"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestAssetNameCreators(t *testing.T) {

--- a/serialization/Key/Key.go
+++ b/serialization/Key/Key.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Salvionied/apollo/crypto/bip32"
 	"github.com/Salvionied/apollo/serialization"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/serialization/Key/Key_test.go
+++ b/serialization/Key/Key_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Salvionied/apollo/serialization/Key"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 var VkeyHex = "694c01268746fccf4a8b94213649a7041b7e20aa4e83b0df2397cadf7c85c5ac"

--- a/serialization/Metadata/Metadata.go
+++ b/serialization/Metadata/Metadata.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Salvionied/apollo/serialization"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type MinimalMetadata map[string]any

--- a/serialization/Metadata/Metadata_test.go
+++ b/serialization/Metadata/Metadata_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Salvionied/apollo/serialization/Metadata"
 	"github.com/Salvionied/apollo/serialization/NativeScript"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestAuxiliaryData(t *testing.T) {

--- a/serialization/NativeScript/NativeScript.go
+++ b/serialization/NativeScript/NativeScript.go
@@ -3,7 +3,7 @@ package NativeScript
 import (
 	"github.com/Salvionied/apollo/serialization"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/serialization/NativeScript/NativeScript_test.go
+++ b/serialization/NativeScript/NativeScript_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/Salvionied/apollo/serialization/NativeScript"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestNativeScriptsSerializationAndHash(t *testing.T) {

--- a/serialization/PlutusData/PlutusData.go
+++ b/serialization/PlutusData/PlutusData.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Salvionied/apollo/serialization"
 	"github.com/Salvionied/apollo/serialization/Address"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 
 	"golang.org/x/crypto/blake2b"
 )

--- a/serialization/PlutusData/PlutusData_test.go
+++ b/serialization/PlutusData/PlutusData_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Salvionied/apollo/serialization/PlutusData"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 // func TestScriptDataHash(t *testing.T) {

--- a/serialization/Policy/Policy.go
+++ b/serialization/Policy/Policy.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type PolicyId struct {

--- a/serialization/Policy/Policy_test.go
+++ b/serialization/Policy/Policy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Salvionied/apollo/serialization/Policy"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 const SAMPLE_POLICY = "95a427e384527065f2f8946f5e86320d0117839a5e98ea2c0b55fb00"

--- a/serialization/Redeemer/Redeemer_test.go
+++ b/serialization/Redeemer/Redeemer_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Salvionied/apollo/serialization/PlutusData"
 	"github.com/Salvionied/apollo/serialization/Redeemer"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestExecutionUnitsFunctions(t *testing.T) {

--- a/serialization/Transaction/Transaction.go
+++ b/serialization/Transaction/Transaction.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/Metadata"
 	"github.com/Salvionied/apollo/serialization/TransactionBody"
 	"github.com/Salvionied/apollo/serialization/TransactionWitnessSet"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type Transaction struct {

--- a/serialization/Transaction/Transaction_test.go
+++ b/serialization/Transaction/Transaction_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/TransactionBody"
 	"github.com/Salvionied/apollo/serialization/TransactionInput"
 	"github.com/Salvionied/apollo/serialization/TransactionWitnessSet"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestMarshalAndUnmarshal(t *testing.T) {

--- a/serialization/TransactionBody/TransactionBody.go
+++ b/serialization/TransactionBody/TransactionBody.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/TransactionOutput"
 	"github.com/Salvionied/apollo/serialization/Withdrawal"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/serialization/TransactionBody/TransactionBody_test.go
+++ b/serialization/TransactionBody/TransactionBody_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/TransactionInput"
 	"github.com/Salvionied/apollo/serialization/TransactionOutput"
 	"github.com/Salvionied/apollo/serialization/Value"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 var SAMPLE_ADDRESS, _ = Address.DecodeAddress("addr1qxajla3qcrwckzkur8n0lt02rg2sepw3kgkstckmzrz4ccfm3j9pqrqkea3tns46e3qy2w42vl8dvvue8u45amzm3rjqvv2nxh")

--- a/serialization/TransactionInput/TransactionInput_test.go
+++ b/serialization/TransactionInput/TransactionInput_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/Salvionied/apollo/serialization/TransactionInput"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 var SAMPLE_TX_IN = TransactionInput.TransactionInput{

--- a/serialization/TransactionOutput/TransactionOutput.go
+++ b/serialization/TransactionOutput/TransactionOutput.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/PlutusData"
 	"github.com/Salvionied/apollo/serialization/Value"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type TransactionOutputAlonzo struct {

--- a/serialization/TransactionOutput/TransactionOutput_test.go
+++ b/serialization/TransactionOutput/TransactionOutput_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/Transaction"
 	"github.com/Salvionied/apollo/serialization/TransactionOutput"
 	"github.com/Salvionied/apollo/serialization/Value"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 const TEST_POLICY = "115a3b670ea8b6b99d1c3d1d8041d7da9bd0b45532c24481cdbd9818"

--- a/serialization/TransactionWitnessSet/TransactionWitnessSet.go
+++ b/serialization/TransactionWitnessSet/TransactionWitnessSet.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/PlutusData"
 	"github.com/Salvionied/apollo/serialization/Redeemer"
 	"github.com/Salvionied/apollo/serialization/VerificationKeyWitness"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type normaltws struct {

--- a/serialization/TransactionWitnessSet/TransactionWitnessSet_test.go
+++ b/serialization/TransactionWitnessSet/TransactionWitnessSet_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Salvionied/apollo/serialization/PlutusData"
 	"github.com/Salvionied/apollo/serialization/TransactionWitnessSet"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestMarshalAndUnmarshalNoScripts(t *testing.T) {

--- a/serialization/Value/Value.go
+++ b/serialization/Value/Value.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/Amount"
 	"github.com/Salvionied/apollo/serialization/MultiAsset"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type Value struct {

--- a/serialization/Value/Value_test.go
+++ b/serialization/Value/Value_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/MultiAsset"
 	"github.com/Salvionied/apollo/serialization/Policy"
 	"github.com/Salvionied/apollo/serialization/Value"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func TestMarshalCBOR(t *testing.T) {

--- a/serialization/common.go
+++ b/serialization/common.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/txBuilding/Backend/Base/Base.go
+++ b/txBuilding/Backend/Base/Base.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/UTxO"
 	"github.com/Salvionied/apollo/serialization/Value"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type GenesisParameters struct {

--- a/txBuilding/Backend/BlockFrostChainContext/BlockFrostChainContext.go
+++ b/txBuilding/Backend/BlockFrostChainContext/BlockFrostChainContext.go
@@ -31,7 +31,7 @@ import (
 	"github.com/Salvionied/apollo/txBuilding/Backend/Base"
 	"github.com/Salvionied/apollo/txBuilding/Backend/Cache"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type BlockFrostChainContext struct {

--- a/txBuilding/Backend/FixedChainContext/FixedChainContext.go
+++ b/txBuilding/Backend/FixedChainContext/FixedChainContext.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/Value"
 	"github.com/Salvionied/apollo/txBuilding/Backend/Base"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 const TEST_ADDR = "addr_test1vr2p8st5t5cxqglyjky7vk98k7jtfhdpvhl4e97cezuhn0cqcexl7"

--- a/txBuilding/Backend/MaestroChainContext/MaestroChainContext.go
+++ b/txBuilding/Backend/MaestroChainContext/MaestroChainContext.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/TransactionOutput"
 	"github.com/Salvionied/apollo/serialization/UTxO"
 	"github.com/Salvionied/apollo/txBuilding/Backend/Base"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 	"github.com/maestro-org/go-sdk/client"
 	"github.com/maestro-org/go-sdk/utils"
 )

--- a/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
+++ b/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
@@ -31,7 +31,7 @@ import (
 	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync/num"
 	"github.com/SundaeSwap-finance/ogmigo/ouroboros/shared"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type OgmiosChainContext struct {

--- a/txBuilding/TxBuilder/TxBuilder.go
+++ b/txBuilding/TxBuilder/TxBuilder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/PlutusData"
 	"github.com/Salvionied/apollo/serialization/TransactionWitnessSet"
 	"github.com/Salvionied/apollo/txBuilding/Backend/Base"
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 // import (
@@ -44,7 +44,7 @@ import (
 // 	"github.com/Salvionied/apollo/txBuilding/Errors"
 // 	"github.com/Salvionied/apollo/txBuilding/Utils"
 
-// 	"github.com/Salvionied/cbor/v2"
+// 	"github.com/fxamacker/cbor/v2"
 // 	"golang.org/x/exp/slices"
 // )
 

--- a/txBuilding/Utils/Utils.go
+++ b/txBuilding/Utils/Utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Salvionied/apollo/serialization/UTxO"
 	"github.com/Salvionied/apollo/txBuilding/Backend/Base"
 
-	"github.com/Salvionied/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 func Contains[T UTxO.Container[any]](container []T, contained T) bool {


### PR DESCRIPTION
This removes the second/forked implementation and returns to the upstream while also updating to the latest version used in other parts of the ecosystem.