### PR TITLE
fix: Ogmios script ref format

### DIFF
--- a/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
+++ b/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
@@ -131,10 +131,18 @@ func scriptRef_OgmigoToApollo(script json.RawMessage) (*PlutusData.ScriptRef, er
 	if len(script) == 0 {
 		return nil, nil
 	}
-	var ref PlutusData.ScriptRef
-	if err := json.Unmarshal(script, &ref); err != nil {
+	var tmpData struct {
+		Language string `json:"language"`
+		Cbor     string `json:"cbor"`
+	}
+	if err := json.Unmarshal(script, &tmpData); err != nil {
 		return nil, err
 	}
+	scriptBytes, err := hex.DecodeString(tmpData.Cbor)
+	if err != nil {
+		return nil, err
+	}
+	ref := PlutusData.ScriptRef(scriptBytes)
 	return &ref, nil
 }
 

--- a/txBuilding/Utils/Utils.go
+++ b/txBuilding/Utils/Utils.go
@@ -73,7 +73,10 @@ func Fee(context Base.ChainContext, txSize int, steps int64, mem int64, refInput
 			if utxo == nil {
 				continue
 			}
-			refInputsSize += utxo.Output.GetScriptRef().Len()
+			scriptRef := utxo.Output.GetScriptRef()
+			if scriptRef != nil {
+				refInputsSize += scriptRef.Len()
+			}
 		}
 
 	}


### PR DESCRIPTION
This updates the Ogmios backend script ref decoding to account for the updated object format from the Ogmios v6 API. It also fixes a nil pointer panic when adding a reference input that doesn't contain a script ref.