### PR TITLE
fix: preallocate byte array

### DIFF
--- a/crypto/bech32/crypto.go
+++ b/crypto/bech32/crypto.go
@@ -207,7 +207,7 @@ func bech32Checksum(hrp string, data []byte) []byte {
 	values := append(bech32HrpExpand(hrp), integers...)
 	values = append(values, []int{0, 0, 0, 0, 0, 0}...)
 	polymod := bech32Polymod(values) ^ 1
-	var res []byte
+	res := []byte{}
 	for i := 0; i < 6; i++ {
 		res = append(res, byte((polymod>>uint(5*(5-i)))&31))
 	}


### PR DESCRIPTION
This makes golangci-lint happy.