### PR TITLE
fix certificate by using interface according to latest cddl

### DIFF
--- a/serialization/Certificate/Certificate.go
+++ b/serialization/Certificate/Certificate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/Salvionied/apollo/serialization"
+	RelayPkg "github.com/Salvionied/apollo/serialization/Relay"
 	"github.com/fxamacker/cbor/v2"
 )
 
@@ -36,6 +37,10 @@ type UnitInterval struct {
 	Den int64
 }
 
+type Relay interface {
+	Kind() int
+}
+
 type PoolParams struct {
 	_             struct{} `cbor:",toarray"`
 	Operator      serialization.PubKeyHash
@@ -45,7 +50,7 @@ type PoolParams struct {
 	Margin        UnitInterval
 	RewardAccount []byte
 	PoolOwners    []serialization.PubKeyHash
-	Relays        []any
+	Relays        RelayPkg.Relays
 	PoolMetadata  *struct {
 		_    struct{} `cbor:",toarray"`
 		Url  string
@@ -267,9 +272,9 @@ func UnmarshalCert(data []byte) (CertificateInterface, error) {
 		return nil, errors.New("empty or invalid certificate")
 	}
 
-	kind, ok := rec[0].(int64)
-	if !ok {
-		return nil, errors.New("invalid certificate kind")
+	kind, err := RelayPkg.ReadKind(rec[0])
+	if err != nil {
+		return nil, err
 	}
 
 	re := func(v any, out any) error {

--- a/serialization/Certificate/Certificate_test.go
+++ b/serialization/Certificate/Certificate_test.go
@@ -1,0 +1,682 @@
+package Certificate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Salvionied/apollo/serialization"
+	RelayPkg "github.com/Salvionied/apollo/serialization/Relay"
+	"github.com/fxamacker/cbor/v2"
+)
+
+func mustMarshalCert(t *testing.T, cert CertificateInterface) []byte {
+	t.Helper()
+	bz, err := cert.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	return bz
+}
+
+func roundTrip(t *testing.T, cert CertificateInterface) CertificateInterface {
+	t.Helper()
+	bz := mustMarshalCert(t, cert)
+	decoded, err := UnmarshalCert(bz)
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	// Re-marshal and compare bytes for stability and semantic equality
+	bz2, err := decoded.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("re-marshal error: %v", err)
+	}
+	// Compare via decoded canonical arrays (avoid differences in CBOR head encodings)
+	var v1, v2 any
+	if err := cbor.Unmarshal(bz, &v1); err != nil {
+		t.Fatalf("unmarshal compare v1: %v", err)
+	}
+	if err := cbor.Unmarshal(bz2, &v2); err != nil {
+		t.Fatalf("unmarshal compare v2: %v", err)
+	}
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatalf("round-trip mismatch:\norig=%#v\ndeco=%#v", v1, v2)
+	}
+	return decoded
+}
+
+// DeepEqual helper using reflect; placed here to avoid importing reflect throughout
+// but use central serialization if available; fallback minimal here.
+
+func TestStakeRegistrationRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{1, 2, 3}}}
+	cert := StakeRegistration{Stake: cred}
+	_ = roundTrip(t, cert)
+}
+
+func TestPoolRegistrationWithRelaysRoundTrip(t *testing.T) {
+	// Build sample PoolParams with multiple relay variants
+	op := serialization.PubKeyHash{}
+	op[0] = 0xAA
+	params := PoolParams{
+		Operator:      op,
+		VrfKeyHash:    []byte{0x01, 0x02, 0x03},
+		Pledge:        1_000,
+		Cost:          5,
+		Margin:        UnitInterval{Num: 1, Den: 2},
+		RewardAccount: []byte{0xAB, 0xCD},
+		PoolOwners:    []serialization.PubKeyHash{op},
+		Relays: RelayPkg.Relays{
+			RelayPkg.SingleHostAddr{Port: uint16Ptr(3000), Ipv4: []byte{1, 2, 3, 4}, Ipv6: nil},
+			RelayPkg.SingleHostName{Port: uint16Ptr(6000), DnsName: "relay.example.com"},
+			RelayPkg.MultiHostName{DnsName: "pool.example.net"},
+		},
+		PoolMetadata: &struct {
+			_    struct{} `cbor:",toarray"`
+			Url  string
+			Hash []byte
+		}{Url: "https://meta.example", Hash: []byte{0x10, 0x20}},
+	}
+	cert := PoolRegistration{Params: params}
+	_ = roundTrip(t, cert)
+}
+
+func TestRegDRepCertAnchorsRoundTrip(t *testing.T) {
+	// With nil anchor
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0xDE, 0xAD}}}
+	certNil := RegDRepCert{DrepCredential: cred, Coin: 42, Anchor: nil}
+	_ = roundTrip(t, certNil)
+
+	// With anchor present
+	anch := &Anchor{Url: "https://anchor", DataHash: []byte{0x01, 0x02}}
+	certWith := RegDRepCert{DrepCredential: cred, Coin: 42, Anchor: anch}
+	_ = roundTrip(t, certWith)
+}
+
+func TestStakeVoteDelegCertRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x01}}}
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x11
+	drep := Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: []byte{0xBE, 0xEF}}}
+	cert := StakeVoteDelegCert{Stake: cred, PoolKeyHash: pool, Drep: drep}
+	_ = roundTrip(t, cert)
+}
+
+func TestPoolRegistrationVariants(t *testing.T) {
+	ownerA := serialization.PubKeyHash{}
+	ownerA[0] = 0xA1
+	ownerB := serialization.PubKeyHash{}
+	ownerB[0] = 0xB2
+
+	cases := []PoolParams{
+		{
+			Operator:      ownerA,
+			VrfKeyHash:    []byte{0x01},
+			Pledge:        0,
+			Cost:          0,
+			Margin:        UnitInterval{Num: 0, Den: 1},
+			RewardAccount: nil,
+			PoolOwners:    nil,
+			Relays:        RelayPkg.Relays{},
+			PoolMetadata:  nil,
+		},
+		{
+			Operator:      ownerB,
+			VrfKeyHash:    []byte{0xFF, 0xEE},
+			Pledge:        123,
+			Cost:          456,
+			Margin:        UnitInterval{Num: 1, Den: 1},
+			RewardAccount: []byte{},
+			PoolOwners:    []serialization.PubKeyHash{ownerA, ownerB},
+			Relays: RelayPkg.Relays{
+				RelayPkg.SingleHostAddr{Port: nil, Ipv4: nil, Ipv6: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+			},
+			PoolMetadata: &struct {
+				_    struct{} `cbor:",toarray"`
+				Url  string
+				Hash []byte
+			}{Url: "", Hash: []byte{}},
+		},
+	}
+
+	for i, params := range cases {
+		cert := PoolRegistration{Params: params}
+		_ = roundTrip(t, cert)
+		_ = i // keep i referenced for clarity; subtests not needed here
+	}
+}
+
+func TestCoinsAndEpochEdges(t *testing.T) {
+	cred := Credential{Code: 1, Hash: serialization.ConstrainedBytes{Payload: []byte{0xCA, 0xFE}}}
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x99
+
+	// coin edges
+	_ = roundTrip(t, RegCert{Stake: cred, Coin: 0})
+	_ = roundTrip(t, UnregCert{Stake: cred, Coin: 0})
+	_ = roundTrip(t, RegCert{Stake: cred, Coin: 1 << 40})
+	_ = roundTrip(t, UnregCert{Stake: cred, Coin: 1 << 40})
+
+	// epoch edges
+	_ = roundTrip(t, PoolRetirement{PoolKeyHash: pool, EpochNo: 0})
+	_ = roundTrip(t, PoolRetirement{PoolKeyHash: pool, EpochNo: 1 << 40})
+}
+
+func TestDrepVariants(t *testing.T) {
+	stake := Credential{Code: 2, Hash: serialization.ConstrainedBytes{Payload: []byte{0xDE}}}
+	// drep with bytes cred
+	drepBytes := Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: []byte{0x01}}}
+	_ = roundTrip(t, VoteDelegCert{Stake: stake, Drep: drepBytes})
+	// drep with nil cred (should still round-trip as structure allows nil pointer)
+	drepNil := Drep{Code: 3, Credential: nil}
+	_ = roundTrip(t, VoteDelegCert{Stake: stake, Drep: drepNil})
+}
+
+func TestStakeVoteRegDelegCombinations(t *testing.T) {
+	stake := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{}}}
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x01
+	drep := Drep{Code: 2, Credential: &serialization.ConstrainedBytes{Payload: []byte{0xAA, 0xBB}}}
+
+	_ = roundTrip(t, StakeVoteDelegCert{Stake: stake, PoolKeyHash: pool, Drep: drep})
+	_ = roundTrip(t, StakeRegDelegCert{Stake: stake, PoolKeyHash: pool, Coin: 1})
+	_ = roundTrip(t, VoteRegDelegCert{Stake: stake, Drep: drep, Coin: 2})
+	_ = roundTrip(t, StakeVoteRegDelegCert{Stake: stake, PoolKeyHash: pool, Drep: drep, Coin: 3})
+}
+
+// Negative/expect-error tests
+
+func TestUnmarshalCert_InvalidEmptyArray(t *testing.T) {
+	// CBOR for empty array []
+	bz, _ := cbor.Marshal([]any{})
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for empty array")
+	}
+}
+
+func TestUnmarshalCert_InvalidKindType(t *testing.T) {
+	// kind is string -> invalid
+	bz, _ := cbor.Marshal([]any{"not-an-int"})
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for invalid kind type")
+	}
+}
+
+func TestUnmarshalCert_NegativeKind(t *testing.T) {
+	// kind is negative int64 -> invalid per ReadKind
+	bz, _ := cbor.Marshal([]any{int64(-1)})
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for negative kind")
+	}
+}
+
+func TestUnmarshalCert_KindOutOfRange(t *testing.T) {
+	// kind is very large uint64 -> out of int range
+	bz, _ := cbor.Marshal([]any{^uint64(0)})
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for out-of-range kind")
+	}
+}
+
+func TestUnmarshalCert_WrongLengths(t *testing.T) {
+	// StakeRegistration requires 2 elements
+	bz, _ := cbor.Marshal([]any{uint64(0)})
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for stake_registration wrong length")
+	}
+	// StakeDelegation requires 3 elements
+	wrong, _ := cbor.Marshal([]any{uint64(2), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for stake_delegation wrong length")
+	}
+	// PoolRegistration requires 2
+	wrong, _ = cbor.Marshal([]any{uint64(3)})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for pool_registration wrong length")
+	}
+	// PoolRetirement requires 3
+	wrong, _ = cbor.Marshal([]any{uint64(4), serialization.PubKeyHash{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for pool_retirement wrong length")
+	}
+	// RegCert requires 3
+	wrong, _ = cbor.Marshal([]any{uint64(7), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for reg_cert wrong length")
+	}
+	// UnregCert requires 3
+	wrong, _ = cbor.Marshal([]any{uint64(8), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for unreg_cert wrong length")
+	}
+	// VoteDelegCert requires 3
+	wrong, _ = cbor.Marshal([]any{uint64(9), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for vote_deleg_cert wrong length")
+	}
+	// StakeVoteDelegCert requires 4
+	wrong, _ = cbor.Marshal([]any{uint64(10), Credential{}, serialization.PubKeyHash{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for stake_vote_deleg_cert wrong length")
+	}
+	// StakeRegDelegCert requires 4
+	wrong, _ = cbor.Marshal([]any{uint64(11), Credential{}, serialization.PubKeyHash{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for stake_reg_deleg_cert wrong length")
+	}
+	// VoteRegDelegCert requires 4
+	wrong, _ = cbor.Marshal([]any{uint64(12), Credential{}, Drep{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for vote_reg_deleg_cert wrong length")
+	}
+	// StakeVoteRegDelegCert requires 5
+	wrong, _ = cbor.Marshal([]any{uint64(13), Credential{}, serialization.PubKeyHash{}, Drep{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for stake_vote_reg_deleg_cert wrong length")
+	}
+	// AuthCommitteeHotCert requires 3
+	wrong, _ = cbor.Marshal([]any{uint64(14), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for auth_committee_hot_cert wrong length")
+	}
+	// ResignCommitteeColdCert requires >=2
+	wrong, _ = cbor.Marshal([]any{uint64(15)})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for resign_committee_cold_cert wrong length")
+	}
+	// RegDRepCert requires >=3
+	wrong, _ = cbor.Marshal([]any{uint64(16), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for reg_drep_cert wrong length")
+	}
+	// UnregDRepCert requires 3
+	wrong, _ = cbor.Marshal([]any{uint64(17), Credential{}})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for unreg_drep_cert wrong length")
+	}
+	// UpdateDRepCert requires >=2
+	wrong, _ = cbor.Marshal([]any{uint64(18)})
+	if _, err := UnmarshalCert(wrong); err == nil {
+		t.Fatalf("expected error for update_drep_cert wrong length")
+	}
+}
+
+func TestUnmarshalCert_WrongTypes(t *testing.T) {
+	// pool_retirement expects (4, pool_keyhash(bytes[28]), epoch(uint))
+	// give wrong types
+	bz, _ := cbor.Marshal([]any{uint64(4), "not-bytes", "not-epoch"})
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for pool_retirement wrong types")
+	}
+
+	// reg_drep_cert expects (16, drep_credential, coin, anchor?/nil)
+	// give anchor wrong type
+	bz2, _ := cbor.Marshal([]any{uint64(16), Credential{}, int64(1), "bad-anchor"})
+	if _, err := UnmarshalCert(bz2); err == nil {
+		t.Fatalf("expected error for reg_drep wrong anchor type")
+	}
+
+	// stake_vote_deleg_cert expects (10, stake_credential, pool_keyhash, drep)
+	// supply wrong pool key type (string)
+	bz3, _ := cbor.Marshal([]any{uint64(10), Credential{}, "bad-pool", Drep{}})
+	if _, err := UnmarshalCert(bz3); err == nil {
+		t.Fatalf("expected error for stake_vote_deleg_cert wrong pool key type")
+	}
+}
+
+func TestUnmarshalCert_PoolRegistration_InvalidRelays(t *testing.T) {
+	// Build pool params with an invalid relay item encoded manually
+	// Invalid: relay kind 0 but ipv4 length wrong (3 bytes)
+	invalidRelay := []any{uint64(0), nil, []byte{1, 2, 3}, nil}
+	params := []any{
+		uint64(3), // pool_registration kind
+		[]any{
+			// PoolParams as array per toarray tag, fields in order
+			serialization.PubKeyHash{},       // Operator
+			[]byte{0x01},                     // VrfKeyHash
+			int64(1),                         // Pledge
+			int64(1),                         // Cost
+			[]any{int64(0), int64(1)},        // UnitInterval {Num, Den}
+			[]byte{0xAA},                     // RewardAccount
+			[]any{},                          // PoolOwners (empty)
+			[]any{invalidRelay},              // Relays array with one invalid relay
+			[]any{"https://x", []byte{0x01}}, // PoolMetadata
+		},
+	}
+	bz, _ := cbor.Marshal(params)
+	if _, err := UnmarshalCert(bz); err == nil {
+		t.Fatalf("expected error for pool_registration with invalid relay")
+	}
+}
+
+func TestCertificates_InvalidItem(t *testing.T) {
+	// certificates array containing an item with bad kind type
+	arr := []any{
+		[]any{"bad-kind"},
+	}
+	bz, _ := cbor.Marshal(arr)
+	var cs Certificates
+	if err := cs.UnmarshalCBOR(bz); err == nil {
+		t.Fatalf("expected error when certificates contain invalid item")
+	}
+	// certificates array containing item with wrong length for known kind
+	arr = []any{
+		[]any{uint64(7), []any{int64(0), []byte{}}}, // malformed inner array (won't map to Credential properly)
+	}
+	bz, _ = cbor.Marshal(arr)
+	if err := cs.UnmarshalCBOR(bz); err == nil {
+		t.Fatalf("expected error for certificates item with wrong structure")
+	}
+}
+
+func TestStakeDeregistrationRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x04}}}
+	cert := StakeDeregistration{Stake: cred}
+	_ = roundTrip(t, cert)
+}
+
+func TestStakeDelegationRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x05}}}
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x21
+	cert := StakeDelegation{Stake: cred, PoolKeyHash: pool}
+	_ = roundTrip(t, cert)
+}
+
+func TestPoolRetirementRoundTrip(t *testing.T) {
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x33
+	cert := PoolRetirement{PoolKeyHash: pool, EpochNo: 123456789}
+	_ = roundTrip(t, cert)
+}
+
+func TestRegAndUnregCertRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x06}}}
+	_ = roundTrip(t, RegCert{Stake: cred, Coin: 100})
+	_ = roundTrip(t, UnregCert{Stake: cred, Coin: 50})
+}
+
+func TestVoteDelegCertRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x07}}}
+	drep := Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: []byte{0x01, 0x02, 0x03}}}
+	cert := VoteDelegCert{Stake: cred, Drep: drep}
+	_ = roundTrip(t, cert)
+}
+
+func TestStakeRegDelegCertRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x08}}}
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x44
+	cert := StakeRegDelegCert{Stake: cred, PoolKeyHash: pool, Coin: 500}
+	_ = roundTrip(t, cert)
+}
+
+func TestVoteRegDelegCertRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x09}}}
+	drep := Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: []byte{0x0A}}}
+	cert := VoteRegDelegCert{Stake: cred, Drep: drep, Coin: 250}
+	_ = roundTrip(t, cert)
+}
+
+func TestStakeVoteRegDelegCertRoundTrip(t *testing.T) {
+	cred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0x0B}}}
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x55
+	drep := Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: []byte{0x0C}}}
+	cert := StakeVoteRegDelegCert{Stake: cred, PoolKeyHash: pool, Drep: drep, Coin: 750}
+	_ = roundTrip(t, cert)
+}
+
+func TestAuthCommitteeHotCertRoundTrip(t *testing.T) {
+	cold := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0xAA}}}
+	hot := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0xBB}}}
+	cert := AuthCommitteeHotCert{Cold: cold, Hot: hot}
+	_ = roundTrip(t, cert)
+}
+
+func TestResignCommitteeColdCertAnchorsRoundTrip(t *testing.T) {
+	cold := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0xCC}}}
+	// nil anchor
+	_ = roundTrip(t, ResignCommitteeColdCert{Cold: cold, Anchor: nil})
+	// with anchor
+	anch := &Anchor{Url: "https://resign", DataHash: []byte{0xAA, 0xBB}}
+	_ = roundTrip(t, ResignCommitteeColdCert{Cold: cold, Anchor: anch})
+}
+
+func TestUnregDRepCertRoundTrip(t *testing.T) {
+	drepCred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0xDD}}}
+	cert := UnregDRepCert{DrepCredential: drepCred, Coin: 5}
+	_ = roundTrip(t, cert)
+}
+
+func TestUpdateDRepCertAnchorsRoundTrip(t *testing.T) {
+	drepCred := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{0xEE}}}
+	// nil anchor
+	_ = roundTrip(t, UpdateDRepCert{DrepCredential: drepCred, Anchor: nil})
+	// with anchor
+	anch := &Anchor{Url: "https://update", DataHash: []byte{0x01}}
+	_ = roundTrip(t, UpdateDRepCert{DrepCredential: drepCred, Anchor: anch})
+}
+
+// Helpers
+func uint16Ptr(v uint16) *uint16 { return &v }
+
+// ---- Certificates (collection) tests ----
+
+func TestCertificatesCollection_RoundTrip_AllKinds(t *testing.T) {
+	// Build one of each kind to ensure the collection codec works end-to-end
+	owner := serialization.PubKeyHash{}
+	owner[0] = 0x42
+	pool := serialization.PubKeyHash{}
+	pool[0] = 0x24
+
+	relays := RelayPkg.Relays{
+		RelayPkg.SingleHostAddr{Port: uint16Ptr(1234), Ipv4: []byte{9, 8, 7, 6}},
+		RelayPkg.SingleHostName{Port: nil, DnsName: "mix.example"},
+	}
+	params := PoolParams{
+		Operator:      owner,
+		VrfKeyHash:    []byte{0xAA},
+		Pledge:        10,
+		Cost:          20,
+		Margin:        UnitInterval{Num: 1, Den: 10},
+		RewardAccount: []byte{0x01},
+		PoolOwners:    []serialization.PubKeyHash{owner},
+		Relays:        relays,
+		PoolMetadata: &struct {
+			_    struct{} `cbor:",toarray"`
+			Url  string
+			Hash []byte
+		}{Url: "https://pool.meta", Hash: []byte{0xCA}},
+	}
+
+	stake := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{1}}}
+	credA := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{2}}}
+	credB := Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{3}}}
+	drep := Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: []byte{0xAA}}}
+	anch := &Anchor{Url: "https://anch", DataHash: []byte{0x01}}
+
+	all := Certificates{
+		StakeRegistration{Stake: stake},                                             // 0
+		StakeDeregistration{Stake: credA},                                           // 1
+		StakeDelegation{Stake: credA, PoolKeyHash: pool},                            // 2
+		PoolRegistration{Params: params},                                            // 3
+		PoolRetirement{PoolKeyHash: pool, EpochNo: 99},                              // 4
+		RegCert{Stake: stake, Coin: 7},                                              // 7
+		UnregCert{Stake: stake, Coin: 3},                                            // 8
+		VoteDelegCert{Stake: stake, Drep: drep},                                     // 9
+		StakeVoteDelegCert{Stake: credB, PoolKeyHash: pool, Drep: drep},             // 10
+		StakeRegDelegCert{Stake: stake, PoolKeyHash: pool, Coin: 1},                 // 11
+		VoteRegDelegCert{Stake: stake, Drep: drep, Coin: 2},                         // 12
+		StakeVoteRegDelegCert{Stake: stake, PoolKeyHash: pool, Drep: drep, Coin: 3}, // 13
+		AuthCommitteeHotCert{Cold: credA, Hot: credB},                               // 14
+		ResignCommitteeColdCert{Cold: credA, Anchor: anch},                          // 15
+		RegDRepCert{DrepCredential: credA, Coin: 5, Anchor: anch},                   // 16
+		UnregDRepCert{DrepCredential: credB, Coin: 6},                               // 17
+		UpdateDRepCert{DrepCredential: credA, Anchor: nil},                          // 18
+	}
+
+	// round trip collection
+	bz, err := all.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal certificates: %v", err)
+	}
+	var got Certificates
+	if err := (&got).UnmarshalCBOR(bz); err != nil {
+		t.Fatalf("unmarshal certificates: %v", err)
+	}
+
+	// Re-marshal and compare canonical decoded structures
+	bz2, err := got.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("re-marshal certificates: %v", err)
+	}
+	var v1, v2 any
+	if err := cbor.Unmarshal(bz, &v1); err != nil {
+		t.Fatalf("unmarshal v1: %v", err)
+	}
+	if err := cbor.Unmarshal(bz2, &v2); err != nil {
+		t.Fatalf("unmarshal v2: %v", err)
+	}
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatalf("certificates round-trip mismatch:\norig=%#v\nrt=%#v", v1, v2)
+	}
+}
+
+func TestCertificatesCollection_EmptyAndMixed(t *testing.T) {
+	// Empty
+	empty := Certificates{}
+	bz, err := empty.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	var got Certificates
+	if err := (&got).UnmarshalCBOR(bz); err != nil {
+		t.Fatalf("unmarshal empty: %v", err)
+	}
+
+	// Mixed order small set
+	pool := serialization.PubKeyHash{}
+	pool[0] = 7
+	mixed := Certificates{
+		UnregDRepCert{DrepCredential: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{1}}}, Coin: 0},
+		StakeRegistration{Stake: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{2}}}},
+		PoolRetirement{PoolKeyHash: pool, EpochNo: 1},
+	}
+	bz2, err := mixed.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal mixed: %v", err)
+	}
+	var got2 Certificates
+	if err := (&got2).UnmarshalCBOR(bz2); err != nil {
+		t.Fatalf("unmarshal mixed: %v", err)
+	}
+}
+
+// ---- Fuzz tests (non-panicking guarantees and round-trip where parseable) ----
+
+func FuzzUnmarshalCert(f *testing.F) {
+	// Seed with a few valid encodings
+	seed := []CertificateInterface{
+		StakeRegistration{Stake: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{1}}}},
+		PoolRegistration{Params: PoolParams{Operator: serialization.PubKeyHash{}, Relays: RelayPkg.Relays{}}},
+		RegDRepCert{DrepCredential: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{2}}}, Coin: 1, Anchor: nil},
+	}
+	for _, s := range seed {
+		if bz, err := s.MarshalCBOR(); err == nil {
+			f.Add(bz)
+		}
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cert, err := UnmarshalCert(data)
+		if err != nil {
+			return // reject invalid inputs; only assert no panic
+		}
+		// round-trip stability: re-encode and re-decode
+		bz2, err := cert.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("marshal after parse: %v", err)
+		}
+		cert2, err := UnmarshalCert(bz2)
+		if err != nil {
+			t.Fatalf("unmarshal re-encoded: %v", err)
+		}
+		// Compare semantic equivalence: same kind and re-encode to same bytes
+		if cert.Kind() != cert2.Kind() {
+			t.Fatalf("kind mismatch after round-trip: %d vs %d", cert.Kind(), cert2.Kind())
+		}
+		bz3, err := cert2.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("marshal re-decoded: %v", err)
+		}
+		// Compare canonical CBOR structures (may differ from input due to normalization)
+		var v2, v3 any
+		if err := cbor.Unmarshal(bz2, &v2); err != nil {
+			t.Fatalf("unmarshal bz2: %v", err)
+		}
+		if err := cbor.Unmarshal(bz3, &v3); err != nil {
+			t.Fatalf("unmarshal bz3: %v", err)
+		}
+		if !reflect.DeepEqual(v2, v3) {
+			t.Fatalf("round-trip not idempotent: %#v vs %#v", v2, v3)
+		}
+	})
+}
+
+func FuzzCertificatesUnmarshal(f *testing.F) {
+	// Seeds: empty, one, multi
+	empty := Certificates{}
+	if bz, err := empty.MarshalCBOR(); err == nil {
+		f.Add(bz)
+	}
+	one := Certificates{StakeRegistration{Stake: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{3}}}}}
+	if bz, err := one.MarshalCBOR(); err == nil {
+		f.Add(bz)
+	}
+	multi := Certificates{
+		StakeRegistration{Stake: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{1}}}},
+		UnregDRepCert{DrepCredential: Credential{Code: 0, Hash: serialization.ConstrainedBytes{Payload: []byte{2}}}, Coin: 0},
+	}
+	if bz, err := multi.MarshalCBOR(); err == nil {
+		f.Add(bz)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var cs Certificates
+		if err := cs.UnmarshalCBOR(data); err != nil {
+			return
+		}
+		// round-trip: re-encode and re-decode
+		bz2, err := cs.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("marshal after parse: %v", err)
+		}
+		var cs2 Certificates
+		if err := cs2.UnmarshalCBOR(bz2); err != nil {
+			t.Fatalf("unmarshal re-encoded: %v", err)
+		}
+		// Compare semantic equivalence: same length and kinds
+		if len(cs) != len(cs2) {
+			t.Fatalf("length mismatch after round-trip: %d vs %d", len(cs), len(cs2))
+		}
+		for i := range cs {
+			if cs[i].Kind() != cs2[i].Kind() {
+				t.Fatalf("cert[%d] kind mismatch: %d vs %d", i, cs[i].Kind(), cs2[i].Kind())
+			}
+		}
+		// Verify idempotency: re-encode should produce same bytes
+		bz3, err := cs2.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("marshal re-decoded: %v", err)
+		}
+		var v2, v3 any
+		if err := cbor.Unmarshal(bz2, &v2); err != nil {
+			t.Fatalf("unmarshal bz2: %v", err)
+		}
+		if err := cbor.Unmarshal(bz3, &v3); err != nil {
+			t.Fatalf("unmarshal bz3: %v", err)
+		}
+		if !reflect.DeepEqual(v2, v3) {
+			t.Fatalf("round-trip not idempotent: %#v vs %#v", v2, v3)
+		}
+	})
+}

--- a/serialization/Relay/Relay.go
+++ b/serialization/Relay/Relay.go
@@ -1,0 +1,298 @@
+package Relay
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// ReadKind extracts the kind discriminator from a CBOR-decoded value.
+// fxamacker/cbor decodes positive integers as uint64 by default, so we
+// must accept both uint64 and int64 here.
+func ReadKind(v any) (int, error) {
+	switch n := v.(type) {
+	case uint64:
+		if n > uint64(^uint(0)>>1) { // guard: larger than max int
+			return 0, errors.New("kind out of range")
+		}
+		return int(n), nil
+	case int64:
+		if n < 0 {
+			return 0, errors.New("kind must be non-negative")
+		}
+		if n > int64(^uint(0)>>1) {
+			return 0, errors.New("kind out of range")
+		}
+		return int(n), nil
+	default:
+		return 0, errors.New("invalid type for kind; expected integer")
+	}
+}
+
+type RelayInterface interface {
+	Kind() int
+	MarshalCBOR() ([]byte, error)
+}
+
+type SingleHostAddr struct {
+	Port *uint16
+	Ipv4 []byte
+	Ipv6 []byte
+}
+
+func (v SingleHostAddr) Kind() int { return 0 }
+func (v SingleHostAddr) MarshalCBOR() ([]byte, error) {
+	if v.Ipv4 != nil && len(v.Ipv4) != 4 {
+		return nil, fmt.Errorf("ipv4 must be 4 bytes when set, got %d", len(v.Ipv4))
+	}
+	if v.Ipv6 != nil && len(v.Ipv6) != 16 {
+		return nil, fmt.Errorf("ipv6 must be 16 bytes when set, got %d", len(v.Ipv6))
+	}
+	return cbor.Marshal([]any{v.Kind(), v.Port, v.Ipv4, v.Ipv6})
+}
+func (v *SingleHostAddr) UnmarshalCBOR(data []byte) error {
+	var arr []any
+	if err := cbor.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	if len(arr) != 4 {
+		return fmt.Errorf("expected array of length 4, got %d", len(arr))
+	}
+	// kind discriminator
+	k, err := ReadKind(arr[0])
+	if err != nil {
+		return err
+	}
+	if k != 0 {
+		return fmt.Errorf("unexpected kind %d for SingleHostAddr", k)
+	}
+
+	if arr[1] == nil {
+		v.Port = nil
+	} else {
+		switch p := arr[1].(type) {
+		case uint64:
+			if p > 65535 {
+				return fmt.Errorf("port out of range: %d", p)
+			}
+			pv := uint16(p)
+			v.Port = &pv
+		default:
+			return errors.New("invalid type for port; expected unsigned integer or null")
+		}
+	}
+
+	// ipv4
+	if arr[2] == nil {
+		v.Ipv4 = nil
+	} else {
+		b, ok := arr[2].([]byte)
+		if !ok {
+			return errors.New("invalid type for ipv4; expected byte string or null")
+		}
+		if len(b) != 4 {
+			return fmt.Errorf("ipv4 must be 4 bytes, got %d", len(b))
+		}
+		v.Ipv4 = append([]byte(nil), b...)
+	}
+
+	// ipv6
+	if arr[3] == nil {
+		v.Ipv6 = nil
+	} else {
+		b, ok := arr[3].([]byte)
+		if !ok {
+			return errors.New("invalid type for ipv6; expected byte string or null")
+		}
+		if len(b) != 16 {
+			return fmt.Errorf("ipv6 must be 16 bytes, got %d", len(b))
+		}
+		v.Ipv6 = append([]byte(nil), b...)
+	}
+	return nil
+}
+
+type SingleHostName struct {
+	Port    *uint16
+	DnsName string
+}
+
+func (v SingleHostName) Kind() int { return 1 }
+func (v SingleHostName) MarshalCBOR() ([]byte, error) {
+	if len(v.DnsName) > 128 {
+		return nil, fmt.Errorf("dns name too long: %d", len(v.DnsName))
+	}
+	return cbor.Marshal([]any{v.Kind(), v.Port, v.DnsName})
+}
+func (v *SingleHostName) UnmarshalCBOR(data []byte) error {
+	var arr []any
+	if err := cbor.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	if len(arr) != 3 {
+		return fmt.Errorf("expected array of length 3, got %d", len(arr))
+	}
+	// kind discriminator
+	k, err := ReadKind(arr[0])
+	if err != nil {
+		return err
+	}
+	if k != 1 {
+		return fmt.Errorf("unexpected kind %d for SingleHostName", k)
+	}
+	// port
+	if arr[1] == nil {
+		v.Port = nil
+	} else {
+		switch p := arr[1].(type) {
+		case uint64:
+			if p > 65535 {
+				return fmt.Errorf("port out of range: %d", p)
+			}
+			pv := uint16(p)
+			v.Port = &pv
+		default:
+			return errors.New("invalid type for port; expected unsigned integer or null")
+		}
+	}
+
+	// dns name
+	switch d := arr[2].(type) {
+	case string:
+		if len(d) > 128 {
+			return fmt.Errorf("dns name too long: %d", len(d))
+		}
+		v.DnsName = d
+	default:
+		return errors.New("invalid type for dns name; expected string")
+	}
+	return nil
+}
+
+type MultiHostName struct {
+	DnsName string
+}
+
+func (v MultiHostName) Kind() int { return 2 }
+func (v MultiHostName) MarshalCBOR() ([]byte, error) {
+	if len(v.DnsName) > 128 {
+		return nil, fmt.Errorf("dns name too long: %d", len(v.DnsName))
+	}
+	return cbor.Marshal([]any{v.Kind(), v.DnsName})
+}
+func (v *MultiHostName) UnmarshalCBOR(data []byte) error {
+	var arr []any
+	if err := cbor.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	if len(arr) != 2 {
+		return fmt.Errorf("expected array of length 2, got %d", len(arr))
+	}
+	// kind discriminator
+	k, err := ReadKind(arr[0])
+	if err != nil {
+		return err
+	}
+	if k != 2 {
+		return fmt.Errorf("unexpected kind %d for MultiHostName", k)
+	}
+
+	// dns name
+	switch d := arr[1].(type) {
+	case string:
+		if len(d) > 128 {
+			return fmt.Errorf("dns name too long: %d", len(d))
+		}
+		v.DnsName = d
+	default:
+		return errors.New("invalid type for dns name; expected string")
+	}
+	return nil
+}
+
+// UnmarshalRelay unmarshals CBOR data into the appropriate Relay type based on the kind discriminator.
+// It returns a RelayInterface and an error.
+func UnmarshalRelay(data []byte) (RelayInterface, error) {
+	// First, unmarshal to get the kind discriminator
+	var arr []any
+	if err := cbor.Unmarshal(data, &arr); err != nil {
+		return nil, err
+	}
+	if len(arr) == 0 {
+		return nil, errors.New("empty array, cannot determine kind")
+	}
+
+	// Extract kind
+	kind, err := ReadKind(arr[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Dispatch based on kind
+	switch kind {
+	case 0: // single_host_addr = (0, port/ nil, ipv4/ nil, ipv6/ nil)
+		var result SingleHostAddr
+		if err := result.UnmarshalCBOR(data); err != nil {
+			return nil, err
+		}
+		return result, nil
+	case 1: // single_host_name = (1, port/ nil, dns_name)
+		var result SingleHostName
+		if err := result.UnmarshalCBOR(data); err != nil {
+			return nil, err
+		}
+		return result, nil
+	case 2: // multi_host_name = (2, dns_name)
+		var result MultiHostName
+		if err := result.UnmarshalCBOR(data); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unknown relay kind: %d", kind)
+	}
+}
+
+type Relays []RelayInterface
+
+func (v Relays) MarshalCBOR() ([]byte, error) {
+	arr := make([][]byte, 0, len(v))
+	for _, relay := range v {
+		bz, err := relay.MarshalCBOR()
+		if err != nil {
+			return nil, err
+		}
+		arr = append(arr, bz)
+	}
+	var out []any
+	for _, e := range arr {
+		var v any
+		if err := cbor.Unmarshal(e, &v); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return cbor.Marshal(out)
+}
+
+func (v *Relays) UnmarshalCBOR(data []byte) error {
+	var arr []any
+	if err := cbor.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	res := make(Relays, 0, len(arr))
+	for _, item := range arr {
+		marshaledRelay, err := cbor.Marshal(item)
+		if err != nil {
+			return err
+		}
+		relay, err := UnmarshalRelay(marshaledRelay)
+		if err != nil {
+			return err
+		}
+		res = append(res, relay)
+	}
+	*v = res
+	return nil
+}

--- a/serialization/Relay/Relay_test.go
+++ b/serialization/Relay/Relay_test.go
@@ -1,0 +1,332 @@
+package Relay_test
+
+import (
+	"testing"
+
+	"github.com/Salvionied/apollo/serialization/Relay"
+	"github.com/fxamacker/cbor/v2"
+)
+
+func u16ptr(v uint16) *uint16 { return &v }
+
+func TestSingleHostAddr_RoundTripAndErrors(t *testing.T) {
+	success := []Relay.SingleHostAddr{
+		{},
+		{Port: u16ptr(0)},
+		{Port: u16ptr(65535)},
+		{Ipv4: []byte{1, 2, 3, 4}},
+		{Ipv6: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+		{Port: u16ptr(8080), Ipv4: []byte{192, 168, 0, 1}},
+		{Port: u16ptr(8080), Ipv6: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}},
+		{Ipv4: []byte{10, 0, 0, 1}, Ipv6: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}},
+		{Port: u16ptr(6000), Ipv4: []byte{8, 8, 8, 8}, Ipv6: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}},
+	}
+	for i, v := range success {
+		t.Run("roundtrip_success_#"+string(rune('A'+i)), func(t *testing.T) {
+			data, err := v.MarshalCBOR()
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			var got Relay.SingleHostAddr
+			if err := got.UnmarshalCBOR(data); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			// compare
+			if (v.Port == nil) != (got.Port == nil) {
+				t.Fatalf("port nil mismatch: want %v got %v", v.Port, got.Port)
+			}
+			if v.Port != nil && got.Port != nil && *v.Port != *got.Port {
+				t.Fatalf("port mismatch: want %d got %d", *v.Port, *got.Port)
+			}
+			if string(v.Ipv4) != string(got.Ipv4) {
+				t.Fatalf("ipv4 mismatch: want %v got %v", v.Ipv4, got.Ipv4)
+			}
+			if string(v.Ipv6) != string(got.Ipv6) {
+				t.Fatalf("ipv6 mismatch: want %v got %v", v.Ipv6, got.Ipv6)
+			}
+		})
+	}
+
+	t.Run("marshal_error_ipv4_len", func(t *testing.T) {
+		_, err := (Relay.SingleHostAddr{Ipv4: []byte{1, 2, 3}}).MarshalCBOR()
+		if err == nil {
+			t.Fatal("expected error for ipv4 length != 4")
+		}
+	})
+	t.Run("marshal_error_ipv6_len", func(t *testing.T) {
+		_, err := (Relay.SingleHostAddr{Ipv6: make([]byte, 15)}).MarshalCBOR()
+		if err == nil {
+			t.Fatal("expected error for ipv6 length != 16")
+		}
+	})
+
+	t.Run("unmarshal_error_wrong_len", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{0, nil})
+		var v Relay.SingleHostAddr
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for wrong array length")
+		}
+	})
+
+	t.Run("unmarshal_error_kind_mismatch", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, nil, nil, nil})
+		var v Relay.SingleHostAddr
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for unexpected kind")
+		}
+	})
+
+	t.Run("unmarshal_error_port_out_of_range", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{0, uint64(70000), nil, nil})
+		var v Relay.SingleHostAddr
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for port out of range")
+		}
+	})
+
+	t.Run("unmarshal_error_port_wrong_type", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{0, "not-a-number", nil, nil})
+		var v Relay.SingleHostAddr
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for port wrong type")
+		}
+	})
+
+	t.Run("unmarshal_error_ipv4_wrong_type", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{0, nil, "not-bytes", nil})
+		var v Relay.SingleHostAddr
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for ipv4 wrong type")
+		}
+	})
+
+	t.Run("unmarshal_error_ipv6_wrong_type", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{0, nil, nil, "not-bytes"})
+		var v Relay.SingleHostAddr
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for ipv6 wrong type")
+		}
+	})
+}
+
+func TestSingleHostName_RoundTripAndErrors(t *testing.T) {
+	success := []Relay.SingleHostName{
+		{DnsName: "example.com"},
+		{Port: u16ptr(0), DnsName: "a"},
+		{Port: u16ptr(65535), DnsName: "x.y.z"},
+		{DnsName: string(make([]byte, 128))},
+	}
+	for i, v := range success {
+		t.Run("roundtrip_success_#"+string(rune('A'+i)), func(t *testing.T) {
+			data, err := v.MarshalCBOR()
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			var got Relay.SingleHostName
+			if err := got.UnmarshalCBOR(data); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if (v.Port == nil) != (got.Port == nil) {
+				t.Fatalf("port nil mismatch")
+			}
+			if v.Port != nil && got.Port != nil && *v.Port != *got.Port {
+				t.Fatalf("port mismatch: want %d got %d", *v.Port, *got.Port)
+			}
+			if v.DnsName != got.DnsName {
+				t.Fatalf("dns mismatch: want %q got %q", v.DnsName, got.DnsName)
+			}
+		})
+	}
+
+	t.Run("marshal_error_dns_too_long", func(t *testing.T) {
+		_, err := (Relay.SingleHostName{DnsName: string(make([]byte, 129))}).MarshalCBOR()
+		if err == nil {
+			t.Fatal("expected error for dns too long")
+		}
+	})
+	t.Run("unmarshal_error_wrong_len", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, nil})
+		var v Relay.SingleHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for wrong array length")
+		}
+	})
+	t.Run("unmarshal_error_kind_mismatch", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{0, nil, "example.com"})
+		var v Relay.SingleHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for unexpected kind")
+		}
+	})
+	t.Run("unmarshal_error_port_wrong_type", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, "bad-port", "example.com"})
+		var v Relay.SingleHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for port wrong type")
+		}
+	})
+	t.Run("unmarshal_error_port_out_of_range", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, uint64(70000), "example.com"})
+		var v Relay.SingleHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for port out of range")
+		}
+	})
+	t.Run("unmarshal_error_dns_wrong_type", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, nil, []byte{1}})
+		var v Relay.SingleHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for dns wrong type")
+		}
+	})
+	t.Run("unmarshal_error_dns_too_long", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, nil, string(make([]byte, 129))})
+		var v Relay.SingleHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for dns too long")
+		}
+	})
+}
+
+func TestMultiHostName_RoundTripAndErrors(t *testing.T) {
+	success := []Relay.MultiHostName{
+		{DnsName: "example.com"},
+		{DnsName: string(make([]byte, 128))},
+	}
+	for i, v := range success {
+		t.Run("roundtrip_success_#"+string(rune('A'+i)), func(t *testing.T) {
+			data, err := v.MarshalCBOR()
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			var got Relay.MultiHostName
+			if err := got.UnmarshalCBOR(data); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if v.DnsName != got.DnsName {
+				t.Fatalf("dns mismatch: want %q got %q", v.DnsName, got.DnsName)
+			}
+		})
+	}
+
+	t.Run("marshal_error_dns_too_long", func(t *testing.T) {
+		_, err := (Relay.MultiHostName{DnsName: string(make([]byte, 129))}).MarshalCBOR()
+		if err == nil {
+			t.Fatal("expected error for dns too long")
+		}
+	})
+	t.Run("unmarshal_error_wrong_len", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{2})
+		var v Relay.MultiHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for wrong array length")
+		}
+	})
+	t.Run("unmarshal_error_kind_mismatch", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{1, "example.com"})
+		var v Relay.MultiHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for unexpected kind")
+		}
+	})
+	t.Run("unmarshal_error_dns_wrong_type", func(t *testing.T) {
+		bad, _ := cbor.Marshal([]any{2, []byte{1}})
+		var v Relay.MultiHostName
+		if err := v.UnmarshalCBOR(bad); err == nil {
+			t.Fatal("expected error for dns wrong type")
+		}
+	})
+}
+
+func TestUnmarshalRelay_Dispatch(t *testing.T) {
+	// single_host_addr
+	aData, _ := cbor.Marshal([]any{0, nil, []byte{1, 2, 3, 4}, nil})
+	a, err := Relay.UnmarshalRelay(aData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := a.(Relay.SingleHostAddr); !ok {
+		t.Fatalf("expected SingleHostAddr, got %T", a)
+	}
+
+	// single_host_name
+	sData, _ := cbor.Marshal([]any{1, nil, "example.com"})
+	s, err := Relay.UnmarshalRelay(sData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := s.(Relay.SingleHostName); !ok {
+		t.Fatalf("expected SingleHostName, got %T", s)
+	}
+
+	// multi_host_name
+	mData, _ := cbor.Marshal([]any{2, "example.com"})
+	m, err := Relay.UnmarshalRelay(mData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := m.(Relay.MultiHostName); !ok {
+		t.Fatalf("expected MultiHostName, got %T", m)
+	}
+
+	// invalid kind
+	badKind, _ := cbor.Marshal([]any{3, nil})
+	if _, err := Relay.UnmarshalRelay(badKind); err == nil {
+		t.Fatal("expected error for unknown relay kind")
+	}
+
+	// invalid array (empty)
+	empty, _ := cbor.Marshal([]any{})
+	if _, err := Relay.UnmarshalRelay(empty); err == nil {
+		t.Fatal("expected error for empty array")
+	}
+
+	// invalid kind type
+	wrongKindType, _ := cbor.Marshal([]any{"not-int", nil})
+	if _, err := Relay.UnmarshalRelay(wrongKindType); err == nil {
+		t.Fatal("expected error for invalid relay kind type")
+	}
+}
+
+func TestRelays_MarshalUnmarshal(t *testing.T) {
+	relays := Relay.Relays{
+		Relay.SingleHostAddr{Ipv4: []byte{1, 2, 3, 4}},
+		Relay.SingleHostName{Port: u16ptr(8080), DnsName: "example.com"},
+		Relay.MultiHostName{DnsName: "pool.example"},
+	}
+	data, err := relays.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var got Relay.Relays
+	if err := got.UnmarshalCBOR(data); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(got) != len(relays) {
+		t.Fatalf("length mismatch: want %d got %d", len(relays), len(got))
+	}
+	// basic sanity of types
+	if _, ok := got[0].(Relay.SingleHostAddr); !ok {
+		t.Fatalf("index 0 type mismatch")
+	}
+	if _, ok := got[1].(Relay.SingleHostName); !ok {
+		t.Fatalf("index 1 type mismatch")
+	}
+	if _, ok := got[2].(Relay.MultiHostName); !ok {
+		t.Fatalf("index 2 type mismatch")
+	}
+
+	// empty slice
+	var empty Relay.Relays
+	data, err = empty.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal empty error: %v", err)
+	}
+	var gotEmpty Relay.Relays
+	if err := gotEmpty.UnmarshalCBOR(data); err != nil {
+		t.Fatalf("unmarshal empty error: %v", err)
+	}
+	if len(gotEmpty) != 0 {
+		t.Fatalf("expected empty relays after roundtrip")
+	}
+}


### PR DESCRIPTION
Updated the `certificate.go` file based on the Conway CDDL spec.

I think it makes sense to use interfaces for union types like `Certificate`, `Relay`, etc., so I implemented almost all of the `Certificate` part using interfaces, except for the `Relay` section inside `PoolParams`. I’d like to finish that part after getting your review.

Also, in your previous version, the function only returned the stake credential, but I think it should return the corresponding credential based on the certificate type.
In other words:

* For stake certificates → return the stake credential
* For DRep certificates → return the DRep credential
* For committee certificates → return the committee credential

My current code does that, except for the committee case, since those certificates have both a cold and a hot credential.

So I’m planning to add three new functions to the `Certificate` interface:

* `DrepCredential()`
* `CommitteeColdCredential()`
* `CommitteeHotCredential()`

And I’ll rename the current `Credential()` function to `StakeCredential()`.
