### PR TITLE
Sort redeemers by (Tag, Index) for deterministic ordering

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -2220,6 +2220,15 @@ func (b *Apollo) updateExUnits() (*Apollo, error) {
 		}
 
 	}
+	// Sort redeemers by (Tag, Index) to ensure deterministic ordering.
+	// Without sorting, Go's map iteration produces non-deterministic order,
+	// causing different script_data_hash values on each run.
+	slices.SortFunc(b.redeemers, func(a, b Redeemer.Redeemer) int {
+		if a.Tag != b.Tag {
+			return int(a.Tag) - int(b.Tag)
+		}
+		return a.Index - b.Index
+	})
 	return b, nil
 }
 
@@ -3465,6 +3474,15 @@ func (b *Apollo) updateExUnitsExact(fee int) (*Apollo, error) {
 		}
 
 	}
+	// Sort redeemers by (Tag, Index) to ensure deterministic ordering.
+	// Without sorting, Go's map iteration produces non-deterministic order,
+	// causing different script_data_hash values on each run.
+	slices.SortFunc(b.redeemers, func(a, b Redeemer.Redeemer) int {
+		if a.Tag != b.Tag {
+			return int(a.Tag) - int(b.Tag)
+		}
+		return a.Index - b.Index
+	})
 	return b, nil
 }
 


### PR DESCRIPTION
Redeemers were being collected from Go maps without sorting, resulting in non-deterministic ordering due to Go's map iteration semantics.

This caused different script_data_hash values on each run, making transactions non-reproducible.

The fix adds sorting at the end of updateExUnits() and updateExUnitsExact(), immediately after the redeemer list is constructed. This ensures deterministic ordering before scriptDataHash() is calculated.