### PR TITLE
Data Attachment and Staking Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Apollo Documentation
+
+Documentation for the Apollo transaction building library for Cardano.
+
+## Sections
+
+- **[Plutus V3 Support](plutus_v3_support/README.md)** — Plutus V3 scripts, reference inputs, cost models, and data structures.
+- **[Data Attachment](data_attachment/README.md)** — Attaching Plutus datums (hash and inline) and reference scripts to transaction outputs; CLI parity for datum and reference script flags.
+- **[Staking Functionalities](staking_functionalities/README.md)** — Stake key registration and deregistration, pool and vote (DRep) delegation, combined certificates, and reward withdrawals; CLI parity for stake-address and withdrawal flags.
+
+All sections reference **cardano-cli** 10.14.0.0 where applicable. API details and examples are based on the Apollo codebase (see [AGENTS.md](../AGENTS.md) for build and test commands).

--- a/docs/data_attachment/README.md
+++ b/docs/data_attachment/README.md
@@ -1,0 +1,36 @@
+# Data Attachment in Apollo
+
+This section documents how to attach **Plutus datums** (hash or inline) and **reference scripts** to transaction outputs when building transactions with the Apollo library. These features align with the transaction output datum and reference script flags in **cardano-cli** (version 10.14.0.0).
+
+## Table of Contents
+
+- [Pay-to-Contract and Datums](pay_to_contract_and_datums.md) — `PayToContract`, `PayToContractAsHash`, `AddDatum`, `AttachDatum`; datum hash vs inline; examples and caveats
+- [Reference Script Output Attachments](reference_script_output_attachments.md) — `PayToAddressWithV1/V2/V3ReferenceScript`, `PayToContractWithV1/V2/V3ReferenceScript`; examples and caveats
+
+## Terminology
+
+- **Datum hash**: The hash of a Plutus datum is stored in the output; the full datum is in the transaction witness set. CLI: `--tx-out-datum-hash`, `--tx-out-datum-hash-file`, etc.
+- **Inline datum**: The full datum is embedded in the output. CLI: `--tx-out-inline-datum-`*, `--tx-out-datum-embed-*`.
+- **Reference script**: A script attached to an output so that other transactions can reference it without including the script bytes. CLI: `--tx-out-reference-script-file`.
+
+## CLI-to-Apollo Mapping Index
+
+
+| Cardano CLI (10.14.0.0)                              | Apollo method / pattern                                                               | Parity                             |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------- |
+| `--tx-out-datum-hash` / `-file` / `-value`           | `PayToContract(addr, datum, lovelace, false)` (+ manual file/JSON parse if needed)    | Full (manual parse for file/value) |
+| `--tx-out-datum-embed-`* / `--tx-out-inline-datum-*` | `PayToContract(addr, datum, lovelace, true)`                                          | Full (manual parse for file/value) |
+| `--tx-out-reference-script-file` (V1/V2/V3)          | `PayToAddressWithV1/V2/V3ReferenceScript`, `PayToContractWithV1/V2/V3ReferenceScript` | Full                               |
+
+
+Each functionality page above includes method signatures, behavior, side-by-side Apollo + CLI examples, evidence labels, and caveats.
+
+## See also
+
+- [Staking Functionalities](../staking_functionalities/README.md) — Stake certificates and withdrawals
+- [Plutus V3 Support](../plutus_v3_support/README.md) — Plutus V3 scripts and reference inputs
+
+## Reference
+
+- [Cardano CLI repository](https://github.com/IntersectMBO/cardano-cli) — CLI command reference (10.14.0.0)
+

--- a/docs/data_attachment/pay_to_contract_and_datums.md
+++ b/docs/data_attachment/pay_to_contract_and_datums.md
@@ -1,0 +1,154 @@
+# Pay-to-Contract and Datums
+
+This page documents the Apollo APIs for **paying to a contract address** and attaching **Plutus datums** (datum hash or inline): `PayToContract`, `PayToContractAsHash`, `AddDatum`, and `AttachDatum`. Implementation: `[ApolloBuilder.go](../../ApolloBuilder.go)`, `[Models.go](../../Models.go)`; serialization: `[serialization/TransactionOutput/TransactionOutput.go](../../serialization/TransactionOutput/TransactionOutput.go)`, `[serialization/PlutusData/PlutusData.go](../../serialization/PlutusData/PlutusData.go)`.
+
+## Purpose and method signatures
+
+### PayToContract
+
+Creates a payment to a smart contract address with an optional Plutus datum (hash or inline).
+
+```go
+func (b *Apollo) PayToContract(
+    contractAddress Address.Address,
+    pd *PlutusData.PlutusData,
+    lovelace int,
+    isInline bool,
+    units ...Unit,
+) *Apollo
+```
+
+| Parameter         | Description                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| `contractAddress` | Recipient contract address                                                                  |
+| `pd`              | Plutus datum; can be `nil` for output with no datum                                         |
+| `lovelace`        | Amount in lovelace                                                                          |
+| `isInline`        | `true` = inline datum, `false` = datum hash (and datum added to witness set if `pd != nil`) |
+| `units`           | Optional native asset units                                                                 |
+
+### PayToContractAsHash
+
+Creates a contract payment using a **pre-computed** datum hash. The datum is **not** added to the transaction datum list.
+
+```go
+func (b *Apollo) PayToContractAsHash(
+    contractAddress Address.Address,
+    pdHash []byte,
+    lovelace int,
+    isInline bool,
+    units ...Unit,
+) *Apollo
+```
+
+### AddDatum
+
+Appends a datum to the transaction’s datum list. Called automatically by `PayToContract(..., false)` when `pd != nil`; use explicitly when multiple outputs share the same datum.
+
+```go
+func (b *Apollo) AddDatum(pd *PlutusData.PlutusData) *Apollo
+```
+
+### AttachDatum
+
+Same effect as `AddDatum`: appends a datum to the transaction’s datum list (e.g. for redeemers or auxiliary outputs).
+
+```go
+func (b *Apollo) AttachDatum(datum *PlutusData.PlutusData) *Apollo
+```
+
+## Inputs and constraints
+
+- Apollo works with `*PlutusData.PlutusData`. For CLI-style file or JSON value input, you must read and parse/decode in your application, then pass the resulting `PlutusData` into the builder.
+- `PayToContractAsHash`: you supply the hash bytes; the ledger may need the full datum elsewhere (e.g. another output or previous tx) if the contract expects it.
+
+## Behavior details
+
+- **PayToContract**: If `isInline` is `true` and `pd != nil`, the output is post-Alonzo with inline datum (`DatumOptionInline`). If `isInline` is `false` and `pd != nil`, `PlutusDataHash(pd)` is computed, stored in the output, and `AddDatum(pd)` is called. If `pd` is `nil`, no datum is attached.
+- **Post-Alonzo output**: When `isInline` is true (or a reference script is attached), the output is built as post-Alonzo in `Payment.ToTxOut()` (`[Models.go](../../Models.go)`); inline datum is set via `PlutusData.DatumOptionInline(p.Datum)`.
+- **Datum hash**: Computed in `PayToContract` with `PlutusData.PlutusDataHash(pd)`; payload is stored in the payment and then in the transaction output.
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI flag / behavior                                  | Apollo equivalent                                                                                     |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--tx-out-datum-hash HASH`                           | `PayToContract(addr, &datum, amount, false)` or `PayToContractAsHash(addr, hashBytes, amount, false)` |
+| `--tx-out-datum-hash-cbor-file` / `-file` / `-value` | Read/parse to `PlutusData`, then `PayToContract(addr, &datum, amount, false)`                         |
+| `--tx-out-datum-embed-`*/ `--tx-out-inline-datum-`* | Same loading, then `PayToContract(addr, &datum, amount, true)`                                        |
+| Datum in witness set (multiple outputs)              | `AddDatum(pd)` or `AttachDatum(pd)`                                                                   |
+
+**Parity:** Full; file/JSON/CBOR handling is the application’s responsibility.
+
+## Examples
+
+### Datum hash (output stores hash, datum in witness set)
+
+**Apollo:**
+
+```go
+contractAddr, _ := Address.DecodeAddress("addr1qy99jvml0vafzdpy6lm6z52qrczjvs4k362gmr9v4hrrwgqk4xvegxwvtfsu5ck6s83h346nsgf6xu26dwzce9yvd8ysd2seyu")
+datum := PlutusData.PlutusData{
+    TagNr:          0,
+    PlutusDataType: PlutusData.PlutusBytes,
+    Value:          []byte("Hello, World!"),
+}
+apollob = apollob.
+    SetChangeAddress(decodedAddr).
+    AddLoadedUTxOs(utxos...).
+    PayToContract(contractAddr, &datum, 1_000_000, false).
+    Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli transaction build \
+    --tx-out "$CONTRACT_ADDRESS+1000000" \
+    --tx-out-datum-hash "$DATUM_HASH" \
+    ...
+```
+
+### Inline datum
+
+**Apollo:**
+
+```go
+apollob = apollob.PayToContract(contractAddr, &datum, 1_000_000, true)
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli transaction build \
+    --tx-out "$CONTRACT_ADDRESS+1000000" \
+    --tx-out-inline-datum-value "$JSON_DATUM" \
+    ...
+```
+
+### Attach datum to transaction (witness set only)
+
+**Apollo:**
+
+```go
+apollob = apollob.AttachDatum(&datum) // or AddDatum(&datum)
+```
+
+`PayToContract(addr, &datum, amount, false)` already calls `AddDatum` internally.
+
+### Datum from JSON file (application responsibility)
+
+```go
+fileBytes, _ := os.ReadFile("datum.json")
+var datum PlutusData.PlutusData
+// Parse JSON to PlutusData (your or library logic)
+apollob = apollob.PayToContract(contractAddr, &datum, amount, false)
+```
+
+Same idea for inline: parse to `PlutusData`, then `PayToContract(addr, &datum, amount, true)`.
+
+## Evidence
+
+- **Verified by tests:** `PayToContract` (datum hash and inline) in `ApolloBuilder_test.go`, `TransactionOutput_test.go`, `BlockFrostChainContext_test.go` (`TestPayToContract`). `AddDatum` / `AttachDatum` in `ApolloBuilder_test.go` (e.g. `TestRedeemerCollect`, `TestComplexTxBuild`) and `UtxorpcChainContext_test.go` (`TestUTXORPC_TransactionWithDatum`).
+
+## Caveats and validation
+
+- `PayToContractAsHash` does not add the datum to the witness set; ensure the datum is available elsewhere if the contract requires it.

--- a/docs/data_attachment/reference_script_output_attachments.md
+++ b/docs/data_attachment/reference_script_output_attachments.md
@@ -1,0 +1,116 @@
+# Reference Script Output Attachments
+
+This page documents attaching **reference scripts** (Plutus V1, V2, or V3) to transaction outputs: `PayToAddressWithV1/V2/V3ReferenceScript` and `PayToContractWithV1/V2/V3ReferenceScript`. Implementation: `[ApolloBuilder.go](../../ApolloBuilder.go)`; script ref types: `[serialization/PlutusData/PlutusData.go](../../serialization/PlutusData/PlutusData.go)`; outputs: `[serialization/TransactionOutput/TransactionOutput.go](../../serialization/TransactionOutput/TransactionOutput.go)`.
+
+## Purpose and method signatures
+
+### Pay-to-address with reference script
+
+```go
+func (b *Apollo) PayToAddressWithV1ReferenceScript(address Address.Address, lovelace int, script PlutusData.PlutusV1Script, units ...Unit) *Apollo
+func (b *Apollo) PayToAddressWithV2ReferenceScript(address Address.Address, lovelace int, script PlutusData.PlutusV2Script, units ...Unit) *Apollo
+func (b *Apollo) PayToAddressWithV3ReferenceScript(address Address.Address, lovelace int, script PlutusData.PlutusV3Script, units ...Unit) *Apollo
+```
+
+### Pay-to-contract with reference script (and optional datum)
+
+```go
+func (b *Apollo) PayToContractWithV1ReferenceScript(contractAddress Address.Address, pd *PlutusData.PlutusData, lovelace int, isInline bool, script PlutusData.PlutusV1Script, units ...Unit) *Apollo
+func (b *Apollo) PayToContractWithV2ReferenceScript(contractAddress Address.Address, pd *PlutusData.PlutusData, lovelace int, isInline bool, script PlutusData.PlutusV2Script, units ...Unit) *Apollo
+func (b *Apollo) PayToContractWithV3ReferenceScript(contractAddress Address.Address, pd *PlutusData.PlutusData, lovelace int, isInline bool, script PlutusData.PlutusV3Script, units ...Unit) *Apollo
+```
+
+Pay-to-contract methods use the same datum rules as `PayToContract` (inline vs hash; datum added to witness set when not inline). Internally they use `payToContractWithScriptRef`.
+
+## Inputs and constraints
+
+- Script is passed as bytes: `PlutusV1Script(scriptBytes)`, `PlutusV2Script(scriptBytes)`, or `PlutusV3Script(scriptBytes)`. Loading from a file and optional CBOR decode is the application’s responsibility.
+- Outputs with a reference script are always built as post-Alonzo so that `ScriptRef` is present.
+
+## Behavior details
+
+- Reference scripts are stored in the output’s `ScriptRef` field (post-Alonzo). `PlutusData.NewV1ScriptRef`, `NewV2ScriptRef`, `NewV3ScriptRef` wrap script bytes into a `ScriptRef` (CBOR tag 24).
+- Round-trip and `GetScriptRef` are tested in `serialization/TransactionOutput/TransactionOutput_test.go` (`TestScriptRefCborRoundTrip`, `TestTransactionOutputWithScriptRef`, `TestCloneWithScriptRef`).
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI flag                                                                 | Apollo method                                                                                            |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `--tx-out ADDRESS+AMOUNT` and `--tx-out-reference-script-file FILE` (V1) | `PayToAddressWithV1ReferenceScript(addr, lovelace, script)` or `PayToContractWithV1ReferenceScript(...)` |
+| Same for V2                                                              | `PayToAddressWithV2ReferenceScript` / `PayToContractWithV2ReferenceScript`                               |
+| Same for V3                                                              | `PayToAddressWithV3ReferenceScript` / `PayToContractWithV3ReferenceScript`                               |
+
+**Parity:** Full; script file loading is the application’s responsibility.
+
+## Examples
+
+### Pay to address with V2 reference script
+
+**Apollo:**
+
+```go
+SC_CBOR := "5901ec01000032323232323232323232322........855d11"
+decoded_sc_cbor, err := hex.DecodeString(SC_CBOR)
+    if err != nil {
+        t.Error(err)
+    }
+script := PlutusData.PlutusV2Script(decoded_sc_cbor)
+apollob := apollo.New(&cc)
+apollob = apollob.
+    PayToAddressWithV2ReferenceScript(decoded_addr, 5_000_000, script).
+    SetChangeAddress(decoded_addr).
+    AddLoadedUTxOs(utxos...)
+built, err := apollob.Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli transaction build \
+    --tx-out "$ADDRESS+5000000" \
+    --tx-out-reference-script-file plutus_sc.json \
+    ...
+```
+
+### Pay to contract with inline datum and V2 reference script
+
+**Apollo:**
+
+```go
+datum := PlutusData.PlutusData{
+    TagNr:          0,
+    PlutusDataType: PlutusData.PlutusBytes,
+    Value:          []byte("Hello, World!"),
+}
+SC_CBOR := "5901ec01000032323232323232323232322........855d11"
+decoded_sc_cbor, err := hex.DecodeString(SC_CBOR)
+   if err != nil {
+        t.Error(err)
+   }
+script := PlutusData.PlutusV2Script(decoded_sc_cbor)
+apollob = apollob.
+    PayToContractWithV2ReferenceScript(decoded_addr, &datum, 5_000_000, true, script).
+    SetChangeAddress(decoded_addr).
+    AddLoadedUTxOs(utxos...)
+built, err := apollob.Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli transaction build \
+    --tx-out "$CONTRACT_ADDRESS+5000000" \
+    --tx-out-inline-datum-value '{"bytes":"Hello, World!"}' \
+    --tx-out-reference-script-file plutus_sc.json \
+    ...
+```
+
+V1 and V3 follow the same pattern with the corresponding method and script type.
+
+## Evidence
+
+- **Verified by tests:** `TestPayToAddressWithV1ReferenceScript`, `TestPayToAddressWithV2ReferenceScript`, `TestPayToAddressWithV3ReferenceScript`; `TestPayToContractWithV1ReferenceScript`, `TestPayToContractWithV2ReferenceScript`, `TestPayToContractWithV2ReferenceScriptDatumHash`, `TestPayToContractWithV3ReferenceScript` in `ApolloBuilder_test.go`.
+
+## Caveats and validation
+
+- Reference script **file** handling (read from disk, optional CBOR decode) is not part of Apollo; pass in the script as `PlutusV1Script`, `PlutusV2Script`, or `PlutusV3Script` (byte slices).

--- a/docs/plutus_v3_support/README.md
+++ b/docs/plutus_v3_support/README.md
@@ -9,3 +9,8 @@ This documentation provides a comprehensive overview of Plutus V3 support within
 - [Plutus V3 Reference Inputs](reference_inputs.md)
 - [Plutus V3 Cost Models](cost_models.md)
 - [Plutus V3 Data Structures](data_structures.md)
+
+## See also
+
+- [Data Attachment](../data_attachment/README.md) — Datums and reference scripts on outputs (including V1/V2/V3 reference scripts)
+- [Staking Functionalities](../staking_functionalities/README.md) — Stake certificates and withdrawals

--- a/docs/staking_functionalities/README.md
+++ b/docs/staking_functionalities/README.md
@@ -1,0 +1,50 @@
+# Staking Functionalities in Apollo
+
+This section documents how to build **staking-related transactions** with the Apollo library: stake key registration and deregistration, delegation to stake pools, vote (DRep) delegation, combined certificates, and reward withdrawals. The APIs align with **cardano-cli** (10.14.0.0) stake-address and transaction build certificate/withdrawal flags.
+
+## Table of Contents
+
+- [Credential Helpers](credential_helpers.md) — `GetStakeCredentialFromWallet`, `GetStakeCredentialFromAddress`; address/wallet stake key assumptions
+- [Register Methods](register_methods.md) — `RegisterStake*`, `RegisterAndDelegateStake*`, `RegisterAndDelegateVote*`, `RegisterAndDelegateStakeAndVote*`; deposit behavior and examples
+- [Deregister Methods](deregister_methods.md) — `DeregisterStake*`; refund behavior and examples
+- [Delegate Stake Methods](delegate_stake_methods.md) — `DelegateStake*`, `DelegateStakeAndVote*`
+- [Delegate Vote Methods](delegate_vote_methods.md) — `DelegateVote*`; DRep setup
+- [Withdrawal Methods](withdrawal_methods.md) — `AddWithdrawal` including redeemer variant
+
+Each page includes method signatures, behavior, side-by-side Apollo + CLI examples, evidence labels (verified by tests vs implementation-only), and caveats.
+
+## Capability Matrix
+
+| Area | Apollo support | Notes |
+|------|----------------|-------|
+| Stake key derivation | Yes | Via `SetWalletFromMnemonic`; wallet has `StakeVerificationKey` / `StakeSigningKey` |
+| Stake credential from address/wallet | Yes | `GetStakeCredentialFromAddress`, `GetStakeCredentialFromWallet` |
+| Stake registration | Yes | `RegisterStake`, `RegisterStakeFromAddress`, `RegisterStakeFromBech32` |
+| Stake deregistration | Yes | `DeregisterStake`, `DeregisterStakeFromAddress`, `DeregisterStakeFromBech32` |
+| Stake pool delegation | Yes | `DelegateStake`, `DelegateStakeFromAddress`, `DelegateStakeFromBech32` |
+| Register + delegate (combined cert) | Yes | `RegisterAndDelegateStake`, etc. |
+| Vote (DRep) delegation | Yes | `DelegateVote`, `RegisterAndDelegateVote`, etc. |
+| Stake + vote combined | Yes | `DelegateStakeAndVote`, `RegisterAndDelegateStakeAndVote`, etc. |
+| Withdrawals | Yes | `AddWithdrawal(address, amount, redeemerData)` |
+| Deposit handling | Yes | `STAKE_DEPOSIT` (2 ADA) applied/refunded in `Complete()` |
+
+## CLI-to-Apollo Mapping Index
+
+| Cardano CLI (10.14.0.0) | Apollo method / pattern |
+|-------------------------|--------------------------|
+| `stake-address build` | Credential via `GetStakeCredentialFromWallet` / `GetStakeCredentialFromAddress`; build `Address` with staking part |
+| `stake-address registration-certificate` | `RegisterStake` / `RegisterStakeFromAddress` / `RegisterStakeFromBech32` |
+| `stake-address deregistration-certificate` | `DeregisterStake` / `DeregisterStakeFromAddress` / `DeregisterStakeFromBech32` |
+| `stake-address delegation-certificate` | `DelegateStake` / `DelegateStakeFromAddress` / `DelegateStakeFromBech32` |
+| `transaction build --withdrawal` | `AddWithdrawal(address, amount, redeemerData)` |
+
+Combined certificates (register+delegate, vote, stake+vote) are documented in the corresponding method-family pages above.
+
+## See also
+
+- [Data Attachment](../data_attachment/README.md) — Datums and reference scripts on outputs
+- [Plutus V3 Support](../plutus_v3_support/README.md) — Plutus V3 scripts and reference inputs
+
+## Reference
+
+- [Cardano CLI repository](https://github.com/IntersectMBO/cardano-cli) — CLI command reference (10.14.0.0)

--- a/docs/staking_functionalities/credential_helpers.md
+++ b/docs/staking_functionalities/credential_helpers.md
@@ -1,0 +1,71 @@
+# Credential Helpers
+
+This page documents how to obtain **stake credentials** and use **addresses with a staking part** in Apollo: `GetStakeCredentialFromWallet`, `GetStakeCredentialFromAddress`, and related address/wallet assumptions. Implementation: [`ApolloBuilder.go`](../../ApolloBuilder.go), [`serialization/Address`](../../serialization/Address/), [`apollotypes/types.go`](../../apollotypes/types.go).
+
+## Purpose and method signatures
+
+### GetStakeCredentialFromWallet
+
+```go
+func (b *Apollo) GetStakeCredentialFromWallet() (*Certificate.Credential, error)
+```
+
+Returns the stake credential derived from the wallet’s stake verification key. Requires a `GenericWallet` with non-empty `StakeVerificationKey` (e.g. from `SetWalletFromMnemonic`).
+
+### GetStakeCredentialFromAddress
+
+```go
+func GetStakeCredentialFromAddress(address Address.Address) (*Certificate.Credential, error)
+```
+
+Uses `address.StakingPart` (must be 28 bytes). Builds a key-hash credential (Code 0). Returns an error if the address has no staking part or length is not 28.
+
+## Inputs and constraints
+
+- **Stake credential**: `Certificate.Credential` with `Code` (0 = key hash, 1 = script hash) and `Hash` (e.g. 28-byte key hash). Used in certificates and when building stake/reward addresses.
+- **GetStakeCredentialFromWallet**: Only works with a wallet that has stake keys (e.g. `GenericWallet` from mnemonic). Custom wallets may not have stake keys.
+- **GetStakeCredentialFromAddress**: Address must have a valid 28-byte `StakingPart` (base address or stake address). Withdrawal addresses must have this for `AddWithdrawal`.
+
+## Behavior details
+
+- **Address**: Apollo’s `Address` has `PaymentPart`, `StakingPart` (28 bytes for key hash), `HeaderByte`, `Network`, `AddressType`, `Hrp` (e.g. `stake1` / `stake_test1` for stake addresses). Base address = both parts set; stake-only address = staking part and correct header/hrp.
+- **SetWalletFromMnemonic**: Derives payment and staking keys (staking path e.g. `m/1852'/1815'/0'/2/0`). `GenericWallet.StakeVerificationKey` and `StakeSigningKey` are set. `SignTx` signs with the stake key when the transaction uses it (certificates or withdrawals). There is no single `GetStakeAddress()` on the wallet interface; use `GetStakeCredentialFromWallet()` and build an address or pass the credential into certificate methods.
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI | Apollo |
+|-----|--------|
+| `stake-address build` (from verification key) | Build credential with `GetStakeCredentialFromWallet()` or `GetStakeCredentialFromAddress()`; build `Address` with staking part only and correct header/hrp. |
+| `address build --stake-verification-key-file` | Build `Address` with `StakingPart` set to the 28-byte stake key hash. |
+| Staking key from mnemonic | `SetWalletFromMnemonic`; wallet has `StakeVerificationKey` / `StakeSigningKey`. |
+
+## Example
+
+**Apollo (credential from wallet, then use in certificate):**
+
+```go
+cred, err := apollob.GetStakeCredentialFromWallet()
+if err != nil {
+    // wallet has no stake keys
+}
+apollob, err = apollob.RegisterStake(cred)
+```
+
+**Apollo (credential from Bech32 address):**
+
+```go
+addr, _ := Address.DecodeAddress("stake1u...")
+cred, err := GetStakeCredentialFromAddress(addr)
+```
+
+**Cardano CLI:** `cardano-cli stake-address build --stake-verification-key-file stake.vkey` produces a stake address; in Apollo you build the credential and optionally an `Address` with that staking part.
+
+## Evidence
+
+- **Implementation-only** for these builder helpers. Wallet stake key derivation: `serialization/HDWallet/HDWallet_test.go` (e.g. `TestPaymentAddress12Reward`). Address encoding/decoding with staking part: `serialization/Address/Address_test.go`.
+
+## Caveats and validation
+
+- `GetStakeCredentialFromWallet()` only works with a wallet that implements stake keys (e.g. `GenericWallet` from mnemonic).
+- Withdrawal addresses must have a valid 28-byte `StakingPart`; see [withdrawal_methods.md](withdrawal_methods.md).
+- Validate on preprod/mainnet with small amounts when relying on implementation-only paths.

--- a/docs/staking_functionalities/delegate_stake_methods.md
+++ b/docs/staking_functionalities/delegate_stake_methods.md
@@ -1,0 +1,76 @@
+# Delegate Stake Methods
+
+This page documents **stake pool delegation** and **stake+vote delegation**: `DelegateStake`*, `DelegateStakeAndVote*`. Implementation: `[ApolloBuilder.go](../../ApolloBuilder.go)`, `[serialization/Certificate/Certificate.go](../../serialization/Certificate/Certificate.go)`.
+
+## Purpose and method signatures
+
+### DelegateStake / DelegateStakeFromAddress / DelegateStakeFromBech32
+
+```go
+func (b *Apollo) DelegateStake(stakeCredential *Certificate.Credential, poolKeyHash serialization.PubKeyHash) (*Apollo, error)
+func (b *Apollo) DelegateStakeFromAddress(address Address.Address, poolKeyHash serialization.PubKeyHash) (*Apollo, error)
+func (b *Apollo) DelegateStakeFromBech32(address string, poolKeyHash serialization.PubKeyHash) (*Apollo, error)
+```
+
+If `stakeCredential` is `nil`, it is taken from the wallet. `poolKeyHash` is the pool’s cold key hash (28 bytes). Appends a `StakeDelegation` certificate.
+
+### DelegateStakeAndVote / DelegateStakeAndVoteFromAddress / DelegateStakeAndVoteFromBech32
+
+```go
+func (b *Apollo) DelegateStakeAndVote(stakeCredential *Certificate.Credential, poolKeyHash serialization.PubKeyHash, drep *Certificate.Drep) (*Apollo, error)
+// ... FromAddress(address, poolKeyHash, drep), FromBech32(bech32, poolKeyHash, drep)
+```
+
+Appends a `StakeVoteDelegCert` (kind 10): delegates both stake (to pool) and vote (to DRep) in one certificate.
+
+## Inputs and constraints
+
+- `poolKeyHash`: 28-byte cold key hash of the target stake pool.
+- `drep`: `Certificate.Drep` (Code + optional Credential); build it for the target DRep.
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI                                    | Apollo                                               |
+| -------------------------------------- | ---------------------------------------------------- |
+| `stake-address delegation-certificate` | `DelegateStake(cred, poolKeyHash)` etc.              |
+| Stake + vote delegation (one cert)     | `DelegateStakeAndVote(cred, poolKeyHash, drep)` etc. |
+
+## Examples
+
+### Stake pool delegation
+
+**Apollo:**
+
+```go
+var poolKeyHash serialization.PubKeyHash
+apollob, err = apollob.
+    DelegateStake(nil, poolKeyHash).
+    AddInputAddressFromBech32(myAddr).
+    AddLoadedUTxOs(utxos...).
+    PayToAddressBech32(myAddr, 10_000_000).
+    Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli stake-address delegation-certificate --stake-verification-key-file stake.vkey --cold-verification-key-file pool.vkey --out-file deleg.cert
+cardano-cli transaction build --certificate-file deleg.cert ...
+```
+
+### Stake and vote (one cert)
+
+**Apollo:**
+
+```go
+drep := &Certificate.Drep{Code: 0, Credential: &serialization.ConstrainedBytes{Payload: drepKeyHash}}
+apollob, err = apollob.DelegateStakeAndVote(nil, poolKeyHash, drep)
+```
+
+## Evidence
+
+- **Implementation-only**. Certificate round-trips: `TestStakeDelegationRoundTrip`, `TestStakeVoteDelegCertRoundTrip` in `Certificate_test.go`.
+
+## Caveats and validation
+
+- Pool key hash must be the correct cold key hash. DRep must match node expectations. Validate on preprod/mainnet with small amounts.

--- a/docs/staking_functionalities/delegate_vote_methods.md
+++ b/docs/staking_functionalities/delegate_vote_methods.md
@@ -1,0 +1,59 @@
+# Delegate Vote Methods
+
+This page documents **vote (DRep) delegation**: `DelegateVote*`. Certificate types: [`serialization/Certificate/Certificate.go`](../../serialization/Certificate/Certificate.go) (`Drep`, `VoteDelegCert`); builder: [`ApolloBuilder.go`](../../ApolloBuilder.go).
+
+## DRep type
+
+`Certificate.Drep`:
+
+- `Code`: 0 = key hash, 1 = script hash, or special values for “always abstain” / “no confidence.”
+- `Credential`: optional key or script hash (nil for abstain/no-confidence).
+
+Build a `Drep` and pass it into the delegation methods.
+
+## Purpose and method signatures
+
+```go
+func (b *Apollo) DelegateVote(stakeCredential *Certificate.Credential, drep *Certificate.Drep) (*Apollo, error)
+func (b *Apollo) DelegateVoteFromAddress(address Address.Address, drep *Certificate.Drep) (*Apollo, error)
+func (b *Apollo) DelegateVoteFromBech32(address string, drep *Certificate.Drep) (*Apollo, error)
+```
+
+If `stakeCredential` is `nil`, it is taken from the wallet. Appends a `VoteDelegCert` certificate (vote-only; stake key may already be registered).
+
+## Inputs and constraints
+
+- DRep key/script hash and special codes must match what the node expects.
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI | Apollo |
+|-----|--------|
+| Vote delegation cert | `DelegateVote(cred, drep)` / `DelegateVoteFromAddress(addr, drep)` / `DelegateVoteFromBech32(bech32, drep)` |
+
+## Example
+
+**Apollo:**
+
+```go
+drep := &Certificate.Drep{
+    Code:       0,
+    Credential: &serialization.ConstrainedBytes{Payload: drepKeyHash},
+}
+apollob, err = apollob.
+    DelegateVote(nil, drep).
+    AddInputAddressFromBech32(myAddr).
+    AddLoadedUTxOs(utxos...).
+    PayToAddressBech32(myAddr, 10_000_000).
+    Complete()
+```
+
+**Cardano CLI:** Vote delegation certificate in `transaction build`.
+
+## Evidence
+
+- **Implementation-only**. Vote-only cert shape in `Certificate.go`; related round-trips for combined certs in `Certificate_test.go`.
+
+## Caveats and validation
+
+- No ApolloBuilder-level integration tests for vote delegation. Validate on preprod/mainnet with small amounts.

--- a/docs/staking_functionalities/deregister_methods.md
+++ b/docs/staking_functionalities/deregister_methods.md
@@ -1,0 +1,55 @@
+# Deregister Methods
+
+This page documents **stake deregistration**: `DeregisterStake`, `DeregisterStakeFromAddress`, `DeregisterStakeFromBech32`. Deregistering returns the 2 ADA stake key deposit; `Complete()` accounts for the refund. Implementation: `[ApolloBuilder.go](../../ApolloBuilder.go)`, `[serialization/Certificate/Certificate.go](../../serialization/Certificate/Certificate.go)`.
+
+## Purpose and method signatures
+
+```go
+func (b *Apollo) DeregisterStake(stakeCredential *Certificate.Credential) (*Apollo, error)
+func (b *Apollo) DeregisterStakeFromAddress(address Address.Address) (*Apollo, error)
+func (b *Apollo) DeregisterStakeFromBech32(address string) (*Apollo, error)
+```
+
+If `stakeCredential` is `nil` in `DeregisterStake`, the credential is taken from the wallet. Each appends a `StakeDeregistration` certificate.
+
+## Inputs and constraints
+
+- Credential from wallet (nil), from address, or from Bech32 string. Same pattern as registration helpers.
+
+## Behavior details
+
+- The transaction’s requested balance is **reduced** by the deposit refund in `Complete()` when deregistration certificates are present (see `addChangeAndFee` and balance logic in `ApolloBuilder.go`).
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI                                        | Apollo                                                                                             |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `stake-address deregistration-certificate` | `DeregisterStake(cred)` / `DeregisterStakeFromAddress(addr)` / `DeregisterStakeFromBech32(bech32)` |
+
+## Example
+
+**Apollo:**
+
+```go
+apollob, err = apollob.
+    DeregisterStake(nil).
+    AddInputAddressFromBech32(myAddr).
+    AddLoadedUTxOs(utxos...).
+    PayToAddressBech32(myAddr, 10_000_000).
+    Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli stake-address deregistration-certificate --stake-verification-key-file stake.vkey --out-file dereg.cert
+cardano-cli transaction build --certificate-file dereg.cert ...
+```
+
+## Evidence
+
+- **Implementation-only** Certificate: `TestStakeDeregistrationRoundTrip` in `Certificate_test.go`.
+
+## Caveats and validation
+
+- Validate on preprod/mainnet with small amounts. Ensure the stake key is actually registered before deregistering.

--- a/docs/staking_functionalities/register_methods.md
+++ b/docs/staking_functionalities/register_methods.md
@@ -1,0 +1,110 @@
+# Register Methods
+
+This page documents **stake registration** and **register+delegate** certificate methods: `RegisterStake`*, `RegisterAndDelegateStake`*, `RegisterAndDelegateVote*`, `RegisterAndDelegateStakeAndVote*`. Implementation: `[ApolloBuilder.go](../../ApolloBuilder.go)`, `[serialization/Certificate/Certificate.go](../../serialization/Certificate/Certificate.go)`. Certificate CBOR: `[serialization/Certificate/Certificate_test.go](../../serialization/Certificate/Certificate_test.go)`.
+
+## Constants
+
+- **Stake key deposit**: 2 ADA (`2_000_000` lovelace), `STAKE_DEPOSIT` in `ApolloBuilder.go`. `Complete()` adds it to the required balance when registration certificates are present.
+
+## Purpose and method signatures
+
+### RegisterStake / RegisterStakeFromAddress / RegisterStakeFromBech32
+
+```go
+func (b *Apollo) RegisterStake(stakeCredential *Certificate.Credential) (*Apollo, error)
+func (b *Apollo) RegisterStakeFromAddress(address Address.Address) (*Apollo, error)
+func (b *Apollo) RegisterStakeFromBech32(address string) (*Apollo, error)
+```
+
+If `stakeCredential` is `nil` in `RegisterStake`, the credential is taken from the wallet. Each appends a `StakeRegistration` certificate.
+
+### RegisterAndDelegateStake / RegisterAndDelegateStakeFromAddress / RegisterAndDelegateStakeFromBech32
+
+```go
+func (b *Apollo) RegisterAndDelegateStake(stakeCredential *Certificate.Credential, poolKeyHash serialization.PubKeyHash, coin int64) (*Apollo, error)
+// ... FromAddress(address, poolKeyHash, coin), FromBech32(bech32, poolKeyHash, coin)
+```
+
+`coin` is the deposit (typically `STAKE_DEPOSIT`). Appends a `StakeRegDelegCert` certificate.
+
+### RegisterAndDelegateVote / RegisterAndDelegateVoteFromAddress / RegisterAndDelegateVoteFromBech32
+
+```go
+func (b *Apollo) RegisterAndDelegateVote(stakeCredential *Certificate.Credential, drep *Certificate.Drep, coin int64) (*Apollo, error)
+// ... FromAddress(address, drep, coin), FromBech32(bech32, drep, coin)
+```
+
+Appends a `VoteRegDelegCert` (kind 12). Deposit required.
+
+### RegisterAndDelegateStakeAndVote / …FromAddress / …FromBech32
+
+```go
+func (b *Apollo) RegisterAndDelegateStakeAndVote(stakeCredential *Certificate.Credential, poolKeyHash serialization.PubKeyHash, drep *Certificate.Drep, coin int64) (*Apollo, error)
+```
+
+Appends a `StakeVoteRegDelegCert` (kind 13). Deposit required.
+
+## Inputs and constraints
+
+- Ensure inputs cover at least 2 ADA deposit when registering (or register+delegate). `Complete()` adds the deposit automatically.
+- Pool key hash must be the correct 28-byte cold key hash for the target pool. DRep must be built as `Certificate.Drep` (code + credential).
+
+## Behavior details
+
+- Apollo’s staking methods **append** certificates to the builder’s certificate list. The low-level `SetCertificates(c *Certificate.Certificates)` is available to set the full list at once if needed.
+
+## Cardano CLI equivalence (10.14.0.0)
+
+| CLI                                      | Apollo                                                                   |
+| ---------------------------------------- | ------------------------------------------------------------------------ |
+| `stake-address registration-certificate` | `RegisterStake` / `RegisterStakeFromAddress` / `RegisterStakeFromBech32` |
+| Reg + deleg (combined cert)              | `RegisterAndDelegateStake(cred, poolKeyHash, STAKE_DEPOSIT)` etc.        |
+| Reg + vote delegation                    | `RegisterAndDelegateVote(cred, drep, coin)` etc.                         |
+| Reg + stake + vote                       | `RegisterAndDelegateStakeAndVote(cred, poolKeyHash, drep, coin)` etc.    |
+
+## Examples
+
+### Stake registration
+
+**Apollo:**
+
+```go
+apollob, err = apollob.
+    RegisterStake(nil).  // nil => use wallet credential
+    AddInputAddressFromBech32(myAddr).
+    AddLoadedUTxOs(utxos...).
+    PayToAddressBech32(myAddr, 10_000_000).
+    Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli stake-address registration-certificate --stake-verification-key-file stake.vkey --out-file reg.cert
+cardano-cli transaction build --certificate-file reg.cert ...
+```
+
+### Register and delegate in one transaction
+
+**Apollo:**
+
+```go
+cred, _ := apollob.GetStakeCredentialFromWallet()
+apollob, err = apollob.
+    RegisterAndDelegateStake(cred, poolKeyHash, apollo.STAKE_DEPOSIT).
+    AddInputAddressFromBech32(myAddr).
+    AddLoadedUTxOs(utxos...).
+    PayToAddressBech32(myAddr, 12_000_000).
+    Complete()
+```
+
+**Cardano CLI:** Combine registration cert and delegation cert (or use combined reg+deleg where supported).
+
+## Evidence
+
+- **Implementation-only** Certificate round-trips: `TestStakeRegistrationRoundTrip`, `TestStakeRegDelegCertRoundTrip`, `TestStakeVoteRegDelegCertRoundTrip` in `Certificate_test.go`; vote reg cert shapes in `Certificate.go`.
+
+## Caveats and validation
+
+- Ensure enough inputs for the 2 ADA deposit. Pool key hash and DRep must match node expectations.
+- Validate on preprod/mainnet with small amounts before production use.

--- a/docs/staking_functionalities/withdrawal_methods.md
+++ b/docs/staking_functionalities/withdrawal_methods.md
@@ -1,0 +1,83 @@
+# Withdrawal Methods
+
+This page documents **reward withdrawals**: `AddWithdrawal`. Implementation: `[ApolloBuilder.go](../../ApolloBuilder.go)`. Withdrawal and redeemer handling are exercised in backend tests.
+
+## Purpose and method signature
+
+```go
+func (b *Apollo) AddWithdrawal(
+    address Address.Address,
+    amount int,
+    redeemerData PlutusData.PlutusData,
+) *Apollo
+```
+
+- **address**: Must have a valid **staking part** (28 bytes), e.g. stake/reward address or base address. Converted internally to 29-byte form (header + 28-byte staking credential).
+- **amount**: Withdrawal amount in lovelace.
+- **redeemerData**: Optional. If provided (e.g. not empty `PlutusData{}`), a redeemer with `Tag = REWARD` is created and associated with this withdrawal; execution units are filled during evaluation.
+
+## Inputs and constraints
+
+- Address must have 28-byte `StakingPart`. Enterprise addresses are not valid for withdrawals.
+- Redeemer from file/JSON: read and parse to `PlutusData.PlutusData` in your application; Apollo does not accept file paths.
+
+## Behavior details
+
+- Withdrawals are stored in the builder’s withdrawal map and included in the transaction body by `buildTxBody()`. Fee estimation in `Complete()` accounts for withdrawal amounts.
+- If `withdrawals` is nil, it is created on first `AddWithdrawal`. When redeemer data is provided, a `Redeemer` with `Tag = Redeemer.REWARD` and the corresponding index is stored in `stakeRedeemers` and merged into the witness set; execution units are filled when estimation is enabled.
+
+## Cardano CLI equivalence (10.14.0.0)
+
+
+| CLI                                                        | Apollo                                                                                  |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `transaction build --withdrawal STAKE_ADDRESS+AMOUNT`      | `AddWithdrawal(decodedStakeAddress, amount, PlutusData.PlutusData{})`                   |
+| `--withdrawal` + `--withdrawal-reference-tx-in-redeemer-`* | Read/decode redeemer to `PlutusData`, then `AddWithdrawal(addr, amount, redeemerData)`. |
+
+
+**Parity:** Full (manual file/value for redeemer).
+
+## Examples
+
+### Withdrawal (no redeemer)
+
+**Apollo:**
+
+```go
+apollob := apollo.New(cc)
+apollob, err = apollob.
+    AddInputAddressFromBech32(decoded_addr_for_fixtures.String()).
+    AddLoadedUTxOs(utxos...).
+    PayToAddressBech32(decoded_addr_for_fixtures.String(), 10_000_000).
+    AddWithdrawal(decoded_addr_for_fixtures, 1_000_000, PlutusData.PlutusData{}).
+    Complete()
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli transaction build --withdrawal "stake1u...+1000000" ...
+```
+
+### Withdrawal with redeemer
+
+**Apollo:**
+
+```go
+var redeemerData PlutusData.PlutusData
+apollob = apollob.AddWithdrawal(stakeAddr, 1_000_000, redeemerData)
+```
+
+**Cardano CLI:**
+
+```bash
+cardano-cli transaction build --withdrawal "stake1u...+1000000" --withdrawal-reference-tx-in-redeemer-value '...' ...
+```
+
+## Evidence
+
+- **Verified by tests:** `TestUTXORPC_TransactionWithWithdrawals` in `UtxorpcChainContext_test.go`, `TestOGMIOS_TransactionWithWithdrawals` in `OgmiosChainContext_test.go`. Withdrawal with redeemer: implementation (stake redeemers merged and evaluated; file/JSON loading is app responsibility).
+
+## Caveats and validation
+
+- Withdrawals with redeemers require evaluation so execution units can be filled; the builder’s evaluation flow handles this when estimation is enabled.


### PR DESCRIPTION
### Summary

Adds two documentation sections under `docs/`: **Data Attachment** and **Staking Functionalities**. Documentation is organized by **functionality** (one page per feature group) so each page contains behavior, required inputs, side-by-side Apollo + CLI examples, evidence labels, and caveats. Only the folder **README** remains as a cross-cutting index; there are no separate `examples.md`, `cli_mapping.md`, `limitations_and_gaps.md`, or `testing_confidence.md`.

### Changes

**`docs/data_attachment/`**

- **README.md** — Overview, terminology (datum hash, inline datum, reference script), and short CLI-to-Apollo mapping index.
- **pay_to_contract_and_datums.md** — `PayToContract`, `PayToContractAsHash`, `AddDatum`, `AttachDatum`; inline vs datum-hash behavior; side-by-side Apollo + cardano-cli examples; evidence and caveats.
- **reference_script_output_attachments.md** — `PayToAddressWithV1/V2/V3ReferenceScript`, `PayToContractWithV1/V2/V3ReferenceScript`; examples and parity notes.

**`docs/staking_functionalities/`**

- **README.md** — Overview, capability matrix, and CLI-to-Apollo mapping index.
- **credential_helpers.md** — `GetStakeCredentialFromWallet`, `GetStakeCredentialFromAddress`; address/wallet stake key assumptions.
- **register_methods.md** — `RegisterStake*`, `RegisterAndDelegateStake*`, `RegisterAndDelegateVote*`, `RegisterAndDelegateStakeAndVote*`; deposit behavior and examples.
- **deregister_methods.md** — `DeregisterStake*`; refund behavior and examples.
- **delegate_stake_methods.md** — `DelegateStake*`, `DelegateStakeAndVote*`.
- **delegate_vote_methods.md** — `DelegateVote*`; DRep type and usage.
- **withdrawal_methods.md** — `AddWithdrawal` (including redeemer); examples and caveats.