### PR TITLE
fix: burn value discarded in Complete() causes ValueNotConservedUTxO

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -3018,7 +3018,7 @@ func (b *Apollo) Complete() (
 	mintedValue := b.getPositiveMints()
 	selectedAmount = selectedAmount.Add(mintedValue)
 	requestedAmount := Value.Value{}
-	requestedAmount.Add(burnedValue)
+	requestedAmount = requestedAmount.Add(burnedValue)
 	for _, payment := range b.payments {
 		payment.EnsureMinUTXO(b.Context)
 		requestedAmount = requestedAmount.Add(payment.ToValue())

--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -3110,6 +3110,10 @@ func (b *Apollo) Complete() (
 			//BALANCE WITH ASSETS
 			for pol, assets := range unfulfilledAmount.GetAssets() {
 				for asset, amt := range assets {
+					if selectedAmount.GetAssets().
+						GetByPolicyAndId(pol, asset) >= amt {
+						continue
+					}
 					found := false
 					selectedSoFar := int64(0)
 					usedIdxs := make([]int, 0)

--- a/ApolloBuilder_test.go
+++ b/ApolloBuilder_test.go
@@ -1652,3 +1652,62 @@ func TestPayToContractWithV3ReferenceScript(t *testing.T) {
 		t.Fatal("Expected inline datum to be set on output")
 	}
 }
+
+func TestPureBurnOnlyTransactionComplete(t *testing.T) {
+	cc := FixedChainContext.InitFixedChainContext()
+	utxos := testutils.InitUtxos()
+
+	const (
+		policyHex = "00000000000000000000000000000000000000000000000000000000"
+		assetName = "token0"
+	)
+	const burnQty = -100
+
+	built, _, err := apollo.New(&cc).
+		AddInputAddressFromBech32(testutils.TESTADDRESS).
+		AddLoadedUTxOs(utxos...).
+		MintAssets(apollo.NewUnit(policyHex, assetName, burnQty)).
+		Complete()
+	if err != nil {
+		t.Fatalf(
+			"Complete() returned error for pure-burn tx: %v", err,
+		)
+	}
+
+	tx := built.GetTx()
+	if tx == nil {
+		t.Fatal("GetTx() returned nil after successful Complete()")
+	}
+
+	utxoByKey := make(map[string]UTxO.UTxO, len(utxos))
+	for _, u := range utxos {
+		utxoByKey[u.GetKey()] = u
+	}
+
+	inputVal := Value.SimpleValue(0, MultiAsset.MultiAsset[int64]{})
+	for _, inp := range tx.TransactionBody.Inputs {
+		key := fmt.Sprintf(
+			"%s:%d",
+			hex.EncodeToString(inp.TransactionId),
+			inp.Index,
+		)
+		if u, ok := utxoByKey[key]; ok {
+			inputVal = inputVal.Add(u.Output.GetAmount())
+		}
+	}
+
+	outputVal := Value.SimpleValue(0, MultiAsset.MultiAsset[int64]{})
+	for _, out := range tx.TransactionBody.Outputs {
+		outputVal = outputVal.Add(out.GetAmount())
+	}
+	outputVal.AddLovelace(built.Fee)
+	outputVal = outputVal.Add(built.GetBurns())
+
+	if !inputVal.Equal(outputVal) {
+		t.Errorf(
+			"tx not balanced: inputs=%v  outputs+fee+burns=%v",
+			inputVal,
+			outputVal,
+		)
+	}
+}


### PR DESCRIPTION
### Bug

`Complete()` silently discards the burned token value when computing how
much the transaction needs to consume, causing an on-chain
`ValueNotConservedUTxO` validation error for every pure-burn transaction.

**File:** `ApolloBuilder.go`  
**Line:** 3021

```go
// before — Add returns a new Value; the result is never assigned
requestedAmount.Add(burnedValue)

// after
requestedAmount = requestedAmount.Add(burnedValue)