### PR TITLE
fix: harden pass

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -355,7 +355,13 @@ func (b *Apollo) AddInputAddress(address Address.Address) *Apollo {
 		*Apollo: A pointer to the modified Apollo instance.
 */
 func (b *Apollo) AddInputAddressFromBech32(address string) *Apollo {
-	decoded_addr, _ := Address.DecodeAddress(address)
+	decoded_addr, err := Address.DecodeAddress(address)
+	if err != nil {
+		if b.err == nil {
+			b.err = fmt.Errorf("AddInputAddressFromBech32: %w", err)
+		}
+		return b
+	}
 	b.inputAddresses = append(b.inputAddresses, decoded_addr)
 	return b
 }
@@ -800,8 +806,22 @@ func (b *Apollo) AddRequiredSignerFromBech32(
 	address string,
 	addPaymentPart, addStakingPart bool,
 ) *Apollo {
-	decoded_addr, _ := Address.DecodeAddress(address)
+	decoded_addr, err := Address.DecodeAddress(address)
+	if err != nil {
+		if b.err == nil {
+			b.err = fmt.Errorf("AddRequiredSignerFromBech32: %w", err)
+		}
+		return b
+	}
 	if addPaymentPart {
+		if len(decoded_addr.PaymentPart) != serialization.VERIFICATION_KEY_HASH_SIZE {
+			if b.err == nil {
+				b.err = errors.New(
+					"AddRequiredSignerFromBech32: invalid payment part length",
+				)
+			}
+			return b
+		}
 		b.requiredSigners = append(
 			b.requiredSigners,
 			serialization.PubKeyHash(decoded_addr.PaymentPart[0:28]),
@@ -809,6 +829,14 @@ func (b *Apollo) AddRequiredSignerFromBech32(
 
 	}
 	if addStakingPart {
+		if len(decoded_addr.StakingPart) != serialization.VERIFICATION_KEY_HASH_SIZE {
+			if b.err == nil {
+				b.err = errors.New(
+					"AddRequiredSignerFromBech32: invalid staking part length",
+				)
+			}
+			return b
+		}
 		b.requiredSigners = append(
 			b.requiredSigners,
 			serialization.PubKeyHash(decoded_addr.StakingPart[0:28]),
@@ -864,12 +892,28 @@ func (b *Apollo) AddRequiredSignerFromAddress(
 	addPaymentPart, addStakingPart bool,
 ) *Apollo {
 	if addPaymentPart {
+		if len(address.PaymentPart) != serialization.VERIFICATION_KEY_HASH_SIZE {
+			if b.err == nil {
+				b.err = errors.New(
+					"AddRequiredSignerFromAddress: invalid payment part length",
+				)
+			}
+			return b
+		}
 		pkh := serialization.PubKeyHash(address.PaymentPart)
 
 		b.requiredSigners = append(b.requiredSigners, pkh)
 
 	}
 	if addStakingPart {
+		if len(address.StakingPart) != serialization.VERIFICATION_KEY_HASH_SIZE {
+			if b.err == nil {
+				b.err = errors.New(
+					"AddRequiredSignerFromAddress: invalid staking part length",
+				)
+			}
+			return b
+		}
 		pkh := serialization.PubKeyHash(address.StakingPart)
 
 		b.requiredSigners = append(b.requiredSigners, pkh)
@@ -3764,11 +3808,35 @@ func (a *Apollo) SetWalletFromKeypair(
 ) *Apollo {
 	verificationKey_bytes, err := hex.DecodeString(vkey)
 	if err != nil {
-		fmt.Println("SetWalletFromKeypair: Failed to decode vkey")
+		if a.err == nil {
+			a.err = fmt.Errorf("SetWalletFromKeypair: decode vkey: %w", err)
+		}
+		return a
+	}
+	if len(verificationKey_bytes) != ed25519.PublicKeySize {
+		if a.err == nil {
+			a.err = fmt.Errorf(
+				"SetWalletFromKeypair: invalid vkey length %d",
+				len(verificationKey_bytes),
+			)
+		}
+		return a
 	}
 	signingKey_bytes, err := hex.DecodeString(skey)
 	if err != nil {
-		fmt.Println("SetWalletFromKeypair: Failed to decode skey")
+		if a.err == nil {
+			a.err = fmt.Errorf("SetWalletFromKeypair: decode skey: %w", err)
+		}
+		return a
+	}
+	if len(signingKey_bytes) != ed25519.SeedSize {
+		if a.err == nil {
+			a.err = fmt.Errorf(
+				"SetWalletFromKeypair: invalid skey seed length %d",
+				len(signingKey_bytes),
+			)
+		}
+		return a
 	}
 	// There are two slightly different interpretations of ed25519,
 	// depending on which thing you call the "private key".
@@ -3778,7 +3846,13 @@ func (a *Apollo) SetWalletFromKeypair(
 		Payload: ed25519.NewKeyFromSeed(signingKey_bytes),
 	}
 	verificationKey := Key.VerificationKey{Payload: verificationKey_bytes}
-	vkh, _ := verificationKey.Hash()
+	vkh, err := verificationKey.Hash()
+	if err != nil {
+		if a.err == nil {
+			a.err = fmt.Errorf("SetWalletFromKeypair: hash vkey: %w", err)
+		}
+		return a
+	}
 
 	var addr Address.Address
 	if network == constants.MAINNET {

--- a/ApolloBuilder_security_test.go
+++ b/ApolloBuilder_security_test.go
@@ -1,0 +1,20 @@
+package apollo
+
+import (
+	"testing"
+
+	"github.com/Salvionied/apollo/constants"
+)
+
+func TestSetWalletFromKeypairRejectsInvalidInput(t *testing.T) {
+	builder := New(nil)
+
+	builder.SetWalletFromKeypair("not hex", "00", constants.TESTNET)
+
+	if builder.err == nil {
+		t.Fatal("expected keypair validation error")
+	}
+	if builder.wallet != nil {
+		t.Fatal("wallet should not be set for invalid key material")
+	}
+}

--- a/plutusencoder/customtypes.go
+++ b/plutusencoder/customtypes.go
@@ -2,6 +2,8 @@ package plutusencoder
 
 import (
 	"errors"
+	"fmt"
+	"math"
 
 	"github.com/Salvionied/apollo/serialization"
 	"github.com/Salvionied/apollo/serialization/Address"
@@ -43,27 +45,43 @@ func GetAssetPlutusData(assets Asset) PlutusData.PlutusData {
 
 // / ADDRESS SUPPORT
 func DecodePlutusAsset(pd PlutusData.PlutusData) Asset {
+	asset, _ := DecodePlutusAssetE(pd)
+	return asset
+}
+
+func DecodePlutusAssetE(pd PlutusData.PlutusData) (Asset, error) {
+	type plutusDataMap = map[serialization.CustomBytes]PlutusData.PlutusData
+
 	assets := Asset{}
-	val, _ := pd.Value.(map[serialization.CustomBytes]PlutusData.PlutusData)
+	val, ok := pd.Value.(plutusDataMap)
+	if !ok {
+		return nil, errors.New("asset value is not a Plutus map")
+	}
 	for key, asset := range val {
-		innerval, _ := asset.Value.(map[serialization.CustomBytes]PlutusData.PlutusData)
+		innerval, ok := asset.Value.(plutusDataMap)
+		if !ok {
+			return nil, errors.New("asset policy value is not a Plutus map")
+		}
 		inner := map[serialization.CustomBytes]int64{}
 		for k, v := range innerval {
-			x, ok := v.Value.(int64)
-			if !ok {
-				y, ok := v.Value.(uint64)
-
-				if !ok {
-					panic("error: Int Data field is not int64")
+			var x int64
+			switch y := v.Value.(type) {
+			case int64:
+				x = y
+			case uint64:
+				if y > math.MaxInt64 {
+					return nil, fmt.Errorf("asset quantity overflows int64: %d", y)
 				}
 				x = int64(y)
+			default:
+				return nil, fmt.Errorf("asset quantity has invalid type %T", v.Value)
 			}
 
 			inner[k] = x
 		}
 		assets[key] = inner
 	}
-	return assets
+	return assets, nil
 }
 
 func GetAddressPlutusData(

--- a/plutusencoder/customtypes_test.go
+++ b/plutusencoder/customtypes_test.go
@@ -1,0 +1,38 @@
+package plutusencoder
+
+import (
+	"testing"
+
+	"github.com/Salvionied/apollo/serialization"
+	"github.com/Salvionied/apollo/serialization/PlutusData"
+)
+
+func TestDecodePlutusAssetERejectsInvalidQuantity(t *testing.T) {
+	pd := PlutusData.PlutusData{
+		PlutusDataType: PlutusData.PlutusMap,
+		Value: map[serialization.CustomBytes]PlutusData.PlutusData{
+			serialization.NewCustomBytes("policy"): {
+				PlutusDataType: PlutusData.PlutusMap,
+				Value: map[serialization.CustomBytes]PlutusData.PlutusData{
+					serialization.NewCustomBytes("asset"): {
+						PlutusDataType: PlutusData.PlutusBytes,
+						Value:          []byte("not an int"),
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := DecodePlutusAssetE(pd); err == nil {
+		t.Fatal("expected invalid asset quantity error")
+	}
+}
+
+func TestDecodePlutusAssetCompatibilityWrapperDoesNotPanic(t *testing.T) {
+	pd := PlutusData.PlutusData{
+		PlutusDataType: PlutusData.PlutusBytes,
+		Value:          []byte("not a map"),
+	}
+
+	_ = DecodePlutusAsset(pd)
+}

--- a/plutusencoder/plutus.go
+++ b/plutusencoder/plutus.go
@@ -554,7 +554,10 @@ func unmarshalPlutus(
 						continue
 					}
 					if tps.Field(idx+1).Type.String() == "plutusencoder.Asset" {
-						asset := DecodePlutusAsset(pAEl)
+						asset, err := DecodePlutusAssetE(pAEl)
+						if err != nil {
+							return fmt.Errorf("error: %w", err)
+						}
 						reflect.ValueOf(v).
 							Elem().
 							Field(idx + 1).
@@ -734,7 +737,10 @@ func unmarshalPlutus(
 						continue
 					}
 					if tps.Field(idx+1).Type.String() == "plutusencoder.Asset" {
-						asset := DecodePlutusAsset(pAEl)
+						asset, err := DecodePlutusAssetE(pAEl)
+						if err != nil {
+							return fmt.Errorf("error: %w", err)
+						}
 						reflect.ValueOf(v).
 							Elem().
 							Field(idx + 1).
@@ -916,7 +922,10 @@ func unmarshalPlutus(
 				}
 				switch field.Type.String() {
 				case "Asset":
-					asset := DecodePlutusAsset(pAEl)
+					asset, err := DecodePlutusAssetE(pAEl)
+					if err != nil {
+						return fmt.Errorf("error: %w", err)
+					}
 					reflect.ValueOf(v).
 						Elem().
 						FieldByName(idx).

--- a/serialization/Address/Address.go
+++ b/serialization/Address/Address.go
@@ -180,16 +180,15 @@ func (addr *Address) MarshalCBOR() ([]byte, error) {
 */
 func (addr *Address) UnmarshalCBOR(value []byte) error {
 	res := make([]byte, 0)
-	err := cbor.Unmarshal(value, &res)
-	header := res[0]
-	payload := res[1:]
-	addr.PaymentPart = payload[:serialization.VERIFICATION_KEY_HASH_SIZE]
-	addr.StakingPart = payload[serialization.VERIFICATION_KEY_HASH_SIZE:]
-	addr.Network = (header & 0x0F)
-	addr.AddressType = (header & 0xF0) >> 4
-	addr.HeaderByte = header
-	addr.Hrp = ComputeHrp(addr.AddressType, addr.Network)
-	return err
+	if err := cbor.Unmarshal(value, &res); err != nil {
+		return err
+	}
+	decoded, err := addressFromDecodedBytes(res)
+	if err != nil {
+		return err
+	}
+	*addr = decoded
+	return nil
 }
 
 /*
@@ -283,88 +282,80 @@ func DecodeAddress(value string) (Address, error) {
 		return Address{}, err
 	}
 
-	decoded_value, _ := bech32.ConvertBits(data, 5, 8, false)
+	decodedValue, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return Address{}, err
+	}
 
-	header := decoded_value[0]
-	payload := decoded_value[1:]
-	network := (header & 0x0F)
-	addr_type := (header & 0xF0) >> 4
+	return addressFromDecodedBytes(decodedValue)
+}
+
+func addressFromDecodedBytes(decodedValue []byte) (Address, error) {
+	if len(decodedValue) == 0 {
+		return Address{}, errors.New("address payload is empty")
+	}
+
+	header := decodedValue[0]
+	payload := decodedValue[1:]
+	network := header & 0x0F
+	addrType := (header & 0xF0) >> 4
+
 	if network != 0b0000 && network != 0b0001 {
 		return Address{}, errors.New("invalid network tag")
 	}
-	switch addr_type {
-	case KEY_KEY:
+
+	const hashSize = serialization.VERIFICATION_KEY_HASH_SIZE
+	switch addrType {
+	case KEY_KEY, SCRIPT_KEY, KEY_SCRIPT, SCRIPT_SCRIPT:
+		if len(payload) != 2*hashSize {
+			return Address{}, fmt.Errorf(
+				"invalid address payload length %d for type %d",
+				len(payload),
+				addrType,
+			)
+		}
 		return Address{
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			payload[serialization.VERIFICATION_KEY_HASH_SIZE:],
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
+			PaymentPart: payload[:hashSize],
+			StakingPart: payload[hashSize:],
+			Network:     network,
+			AddressType: addrType,
+			HeaderByte:  header,
+			Hrp:         ComputeHrp(addrType, network),
 		}, nil
-	case SCRIPT_KEY:
+	case KEY_NONE, SCRIPT_NONE:
+		if len(payload) != hashSize {
+			return Address{}, fmt.Errorf(
+				"invalid address payload length %d for type %d",
+				len(payload),
+				addrType,
+			)
+		}
 		return Address{
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			payload[serialization.VERIFICATION_KEY_HASH_SIZE:],
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
+			PaymentPart: payload[:hashSize],
+			StakingPart: make([]byte, 0),
+			Network:     network,
+			AddressType: addrType,
+			HeaderByte:  header,
+			Hrp:         ComputeHrp(addrType, network),
 		}, nil
-	case KEY_SCRIPT:
+	case NONE_KEY, NONE_SCRIPT:
+		if len(payload) != hashSize {
+			return Address{}, fmt.Errorf(
+				"invalid address payload length %d for type %d",
+				len(payload),
+				addrType,
+			)
+		}
 		return Address{
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			payload[serialization.VERIFICATION_KEY_HASH_SIZE:],
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
-		}, nil
-	case KEY_NONE:
-		return Address{
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			make([]byte, 0),
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
-		}, nil
-	case SCRIPT_SCRIPT:
-		return Address{
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			payload[serialization.VERIFICATION_KEY_HASH_SIZE:],
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
-		}, nil
-	case SCRIPT_NONE:
-		return Address{
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			make([]byte, 0),
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
-		}, nil
-	case NONE_KEY:
-		return Address{
-			make([]byte, 0),
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
+			PaymentPart: make([]byte, 0),
+			StakingPart: payload[:hashSize],
+			Network:     network,
+			AddressType: addrType,
+			HeaderByte:  header,
+			Hrp:         ComputeHrp(addrType, network),
 		}, nil
 	default:
-		return Address{
-			make([]byte, 0),
-			payload[:serialization.VERIFICATION_KEY_HASH_SIZE],
-			network,
-			addr_type,
-			header,
-			ComputeHrp(addr_type, network),
-		}, nil
+		return Address{}, fmt.Errorf("unsupported address type %d", addrType)
 	}
 }
 

--- a/serialization/Address/Address_test.go
+++ b/serialization/Address/Address_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Salvionied/apollo/crypto/bech32"
 	"github.com/Salvionied/apollo/serialization/Address"
 )
 
@@ -2189,6 +2190,43 @@ func TestAddressFromBytesScriptTypes(t *testing.T) {
 			"expected NONE_SCRIPT, got %v",
 			addr.AddressType,
 		)
+	}
+}
+
+func TestDecodeAddressRejectsShortPayload(t *testing.T) {
+	emptyPayload, err := bech32.Encode("addr", nil)
+	if err != nil {
+		t.Fatalf("encode empty payload: %v", err)
+	}
+	headerOnlyData, err := bech32.ConvertBits([]byte{0x01}, 8, 5, true)
+	if err != nil {
+		t.Fatalf("convert header payload: %v", err)
+	}
+	headerOnly, err := bech32.Encode("addr", headerOnlyData)
+	if err != nil {
+		t.Fatalf("encode header payload: %v", err)
+	}
+
+	for _, input := range []string{emptyPayload, headerOnly} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := Address.DecodeAddress(input); err == nil {
+				t.Fatal("expected invalid address payload error")
+			}
+		})
+	}
+}
+
+func TestAddressUnmarshalCBORRejectsShortPayload(t *testing.T) {
+	for _, input := range [][]byte{
+		{0x40},       // empty byte string
+		{0x41, 0x01}, // header without credential payload
+	} {
+		t.Run(hex.EncodeToString(input), func(t *testing.T) {
+			var addr Address.Address
+			if err := addr.UnmarshalCBOR(input); err == nil {
+				t.Fatal("expected invalid address payload error")
+			}
+		})
 	}
 }
 

--- a/serialization/AssetName/AssetName.go
+++ b/serialization/AssetName/AssetName.go
@@ -47,7 +47,10 @@ func (an *AssetName) MarshalCBOR() ([]byte, error) {
 		return nil, errors.New("invalid asset name length")
 	}
 
-	byteSlice, _ := hex.DecodeString(an.value)
+	byteSlice, err := hex.DecodeString(an.value)
+	if err != nil {
+		return nil, err
+	}
 
 	return cbor.Marshal(byteSlice)
 }

--- a/serialization/Policy/Policy.go
+++ b/serialization/Policy/Policy.go
@@ -27,6 +27,9 @@ func New(value string) (*PolicyId, error) {
 	if len(value) != 56 {
 		return nil, errors.New("invalid length of a policy id")
 	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return nil, err
+	}
 	return &PolicyId{
 		Value: value,
 	}, nil
@@ -116,6 +119,9 @@ func (policyId *PolicyId) UnmarshalCBOR(value []byte) error {
 		hexString := res
 		if len(hexString) != 56 {
 			return errors.New("invalid length of a policy id")
+		}
+		if _, err := hex.DecodeString(hexString); err != nil {
+			return err
 		}
 		policyId.Value = hexString
 	default:

--- a/txBuilding/Backend/Base/Base.go
+++ b/txBuilding/Backend/Base/Base.go
@@ -114,6 +114,30 @@ type Output struct {
 	ReferenceScriptHash string          `json:"reference_script_hash"`
 }
 
+func ParseAssetUnit(unit string) (Policy.PolicyId, AssetName.AssetName, error) {
+	if len(unit) < 56 {
+		return Policy.PolicyId{}, AssetName.AssetName{}, fmt.Errorf(
+			"asset unit is too short: %q",
+			unit,
+		)
+	}
+	policyID, err := Policy.New(unit[:56])
+	if err != nil {
+		return Policy.PolicyId{}, AssetName.AssetName{}, fmt.Errorf(
+			"invalid policy id: %w",
+			err,
+		)
+	}
+	assetName := AssetName.NewAssetNameFromHexString(unit[56:])
+	if assetName == nil {
+		return Policy.PolicyId{}, AssetName.AssetName{}, fmt.Errorf(
+			"invalid asset name: %q",
+			unit[56:],
+		)
+	}
+	return *policyID, *assetName, nil
+}
+
 func (o Output) ToUTxO(txHash string) (*UTxO.UTxO, error) {
 	txOut, err := o.ToTransactionOutput()
 	if err != nil {
@@ -136,7 +160,11 @@ func (o Output) ToUTxO(txHash string) (*UTxO.UTxO, error) {
 func (o Output) ToTransactionOutput() (TransactionOutput.TransactionOutput, error) {
 	address, err := Address.DecodeAddress(o.Address)
 	if err != nil {
-		return TransactionOutput.TransactionOutput{}, fmt.Errorf("ToTransactionOutput: invalid address %q: %w", o.Address, err)
+		return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+			"ToTransactionOutput: invalid address %q: %w",
+			o.Address,
+			err,
+		)
 	}
 	amount := o.Amount
 	lovelace_amount := 0
@@ -145,21 +173,35 @@ func (o Output) ToTransactionOutput() (TransactionOutput.TransactionOutput, erro
 		if item.Unit == "lovelace" {
 			amt, err := strconv.Atoi(item.Quantity)
 			if err != nil {
-				return TransactionOutput.TransactionOutput{}, fmt.Errorf("ToTransactionOutput: invalid lovelace quantity %q: %w", item.Quantity, err)
+				return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+					"ToTransactionOutput: invalid lovelace quantity %q: %w",
+					item.Quantity,
+					err,
+				)
 			}
 			lovelace_amount += amt
 		} else {
 			asset_quantity, err := strconv.ParseInt(item.Quantity, 10, 64)
 			if err != nil {
-				return TransactionOutput.TransactionOutput{}, fmt.Errorf("ToTransactionOutput: invalid asset quantity %q: %w", item.Quantity, err)
+				return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+					"ToTransactionOutput: invalid asset quantity %q: %w",
+					item.Quantity,
+					err,
+				)
 			}
-			policy_id := Policy.PolicyId{Value: item.Unit[:56]}
-			asset_name := *AssetName.NewAssetNameFromHexString(item.Unit[56:])
-			_, ok := multi_assets[policy_id]
+			policyID, assetName, err := ParseAssetUnit(item.Unit)
+			if err != nil {
+				return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+					"ToTransactionOutput: invalid asset unit %q: %w",
+					item.Unit,
+					err,
+				)
+			}
+			_, ok := multi_assets[policyID]
 			if !ok {
-				multi_assets[policy_id] = Asset.Asset[int64]{}
+				multi_assets[policyID] = Asset.Asset[int64]{}
 			}
-			multi_assets[policy_id][asset_name] = int64(asset_quantity)
+			multi_assets[policyID][assetName] = int64(asset_quantity)
 		}
 	}
 	var final_amount Value.Value
@@ -178,18 +220,28 @@ func (o Output) ToTransactionOutput() (TransactionOutput.TransactionOutput, erro
 	if o.DataHash != "" && o.InlineDatum == "" {
 		decoded_hash, err := hex.DecodeString(o.DataHash)
 		if err != nil {
-			return TransactionOutput.TransactionOutput{}, fmt.Errorf("ToTransactionOutput: invalid data hash %q: %w", o.DataHash, err)
+			return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+				"ToTransactionOutput: invalid data hash %q: %w",
+				o.DataHash,
+				err,
+			)
 		}
 		datum_hash = serialization.DatumHash{Payload: decoded_hash}
 	}
 	if o.InlineDatum != "" {
 		decoded, err := hex.DecodeString(o.InlineDatum)
 		if err != nil {
-			return TransactionOutput.TransactionOutput{}, fmt.Errorf("ToTransactionOutput: invalid inline datum hex: %w", err)
+			return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+				"ToTransactionOutput: invalid inline datum hex: %w",
+				err,
+			)
 		}
 		var datum PlutusData.PlutusData
 		if err := cbor.Unmarshal(decoded, &datum); err != nil {
-			return TransactionOutput.TransactionOutput{}, fmt.Errorf("ToTransactionOutput: invalid inline datum CBOR: %w", err)
+			return TransactionOutput.TransactionOutput{}, fmt.Errorf(
+				"ToTransactionOutput: invalid inline datum CBOR: %w",
+				err,
+			)
 		}
 		tx_out := TransactionOutput.TransactionOutput{
 			PostAlonzo: TransactionOutput.TransactionOutputAlonzo{

--- a/txBuilding/Backend/Base/Base_test.go
+++ b/txBuilding/Backend/Base/Base_test.go
@@ -1,0 +1,31 @@
+package Base
+
+import "testing"
+
+const testAddress = "addr_test1vz5g0tr9z6tqflpsk4dguqce75zx0efmayflw0kl8xj" +
+	"qu7c5n5xg7"
+
+func TestParseAssetUnitRejectsInvalidInput(t *testing.T) {
+	cases := []AddressAmount{
+		{Unit: "abcd", Quantity: "1"},
+		{
+			Unit:     "00000000000000000000000000000000000000000000000000000000zz",
+			Quantity: "1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Unit, func(t *testing.T) {
+			output := Output{
+				Address: testAddress,
+				Amount: []AddressAmount{
+					{Unit: "lovelace", Quantity: "1000000"},
+					tc,
+				},
+			}
+			if _, err := output.ToTransactionOutput(); err == nil {
+				t.Fatal("expected invalid asset unit error")
+			}
+		})
+	}
+}

--- a/txBuilding/Backend/BlockFrostChainContext/BlockFrostChainContext.go
+++ b/txBuilding/Backend/BlockFrostChainContext/BlockFrostChainContext.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -19,10 +18,8 @@ import (
 	"github.com/Salvionied/apollo/serialization/Address"
 	"github.com/Salvionied/apollo/serialization/Amount"
 	"github.com/Salvionied/apollo/serialization/Asset"
-	"github.com/Salvionied/apollo/serialization/AssetName"
 	"github.com/Salvionied/apollo/serialization/MultiAsset"
 	"github.com/Salvionied/apollo/serialization/PlutusData"
-	"github.com/Salvionied/apollo/serialization/Policy"
 	"github.com/Salvionied/apollo/serialization/Redeemer"
 	"github.com/Salvionied/apollo/serialization/Transaction"
 	"github.com/Salvionied/apollo/serialization/TransactionInput"
@@ -33,6 +30,11 @@ import (
 	"github.com/Salvionied/apollo/txBuilding/Backend/Cache"
 
 	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	defaultHTTPTimeout         = 30 * time.Second
+	maxBlockfrostResponseBytes = 16 << 20
 )
 
 type BlockFrostChainContext struct {
@@ -54,13 +56,6 @@ func NewBlockfrostChainContext(
 	projectId ...string,
 ) (BlockFrostChainContext, error) {
 	ctx := context.Background()
-	file, err := os.ReadFile("config.ini")
-	var cse []string
-	if err == nil {
-		cse = strings.Split(string(file), "\n")
-	} else {
-		cse = []string{}
-	}
 
 	var _projectId string
 	if len(projectId) > 0 {
@@ -75,19 +70,83 @@ func NewBlockfrostChainContext(
 	}
 
 	bfc := BlockFrostChainContext{
-		client:                    &http.Client{},
+		client:                    &http.Client{Timeout: defaultHTTPTimeout},
 		_Network:                  network,
 		_baseUrl:                  _baseUrl,
 		_projectId:                _projectId,
 		ctx:                       ctx,
-		CustomSubmissionEndpoints: cse,
+		CustomSubmissionEndpoints: nil,
 	}
-	err = bfc.Init()
+	err := bfc.Init()
 	if err != nil {
 		return bfc, err
 	}
 	return bfc, nil
 }
+
+func (bfc *BlockFrostChainContext) newRequest(
+	method string,
+	url string,
+	body io.Reader,
+	includeProjectID bool,
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(bfc.ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"create %s request for %q: %w",
+			method,
+			url,
+			err,
+		)
+	}
+	if includeProjectID && bfc._projectId != "" {
+		req.Header.Set("project_id", bfc._projectId)
+	}
+	return req, nil
+}
+
+func responseSnippet(body []byte) string {
+	const maxSnippet = 512
+	if len(body) <= maxSnippet {
+		return string(body)
+	}
+	return string(body[:maxSnippet]) + "...(truncated)"
+}
+
+func (bfc *BlockFrostChainContext) doRequest(
+	req *http.Request,
+) ([]byte, error) {
+	res, err := bfc.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(
+		io.LimitReader(res.Body, maxBlockfrostResponseBytes+1),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxBlockfrostResponseBytes {
+		return nil, fmt.Errorf(
+			"response body exceeds %d bytes",
+			maxBlockfrostResponseBytes,
+		)
+	}
+	if res.StatusCode < http.StatusOK ||
+		res.StatusCode >= http.StatusMultipleChoices {
+		return body, fmt.Errorf(
+			"%s %s returned %s: %s",
+			req.Method,
+			req.URL.String(),
+			res.Status,
+			responseSnippet(body),
+		)
+	}
+	return body, nil
+}
+
 func (bfc *BlockFrostChainContext) Init() error {
 	latest_epochs, err := bfc.LatestEpoch()
 	if err != nil {
@@ -132,21 +191,16 @@ func (bfc *BlockFrostChainContext) GetUtxoFromRef(
 func (bfc *BlockFrostChainContext) TxOuts(
 	txHash string,
 ) ([]Base.Output, error) {
-	req, _ := http.NewRequestWithContext(
-		bfc.ctx,
+	req, err := bfc.newRequest(
 		"GET",
 		fmt.Sprintf("%s/txs/%s/utxos", bfc._baseUrl, txHash),
 		nil,
+		true,
 	)
-	if bfc._projectId != "" {
-		req.Header.Set("project_id", bfc._projectId)
-	}
-	res, err := bfc.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
+	body, err := bfc.doRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -161,21 +215,16 @@ func (bfc *BlockFrostChainContext) TxOuts(
 
 func (bfc *BlockFrostChainContext) LatestBlock() (Base.Block, error) {
 	bb := Base.Block{}
-	req, _ := http.NewRequestWithContext(
-		bfc.ctx,
+	req, err := bfc.newRequest(
 		"GET",
 		bfc._baseUrl+"/blocks/latest",
 		nil,
+		true,
 	)
-	if bfc._projectId != "" {
-		req.Header.Set("project_id", bfc._projectId)
-	}
-	res, err := bfc.client.Do(req)
 	if err != nil {
 		return bb, err
 	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
+	body, err := bfc.doRequest(req)
 	if err != nil {
 		return bb, err
 	}
@@ -193,21 +242,16 @@ func (bfc *BlockFrostChainContext) LatestEpoch() (Base.Epoch, error) {
 	timest := time.Time{}
 	foundTime := Cache.Get[time.Time]("latest_epoch_time", &timest)
 	if !found || !foundTime || time.Since(timest) > 5*time.Minute {
-		req, _ := http.NewRequestWithContext(
-			bfc.ctx,
+		req, err := bfc.newRequest(
 			"GET",
 			bfc._baseUrl+"/epochs/latest",
 			nil,
+			true,
 		)
-		if bfc._projectId != "" {
-			req.Header.Set("project_id", bfc._projectId)
-		}
-		res, err := bfc.client.Do(req)
 		if err != nil {
 			return resultingEpoch, err
 		}
-		defer res.Body.Close()
-		body, err := io.ReadAll(res.Body)
+		body, err := bfc.doRequest(req)
 		if err != nil {
 			return resultingEpoch, err
 		}
@@ -233,8 +277,7 @@ func (bfc *BlockFrostChainContext) AddressUtxos(
 		var i = 1
 		result := make([]Base.AddressUTXO, 0)
 		for {
-			req, _ := http.NewRequestWithContext(
-				bfc.ctx,
+			req, err := bfc.newRequest(
 				"GET",
 				fmt.Sprintf(
 					"%s/addresses/%s/utxos?page=%s",
@@ -243,16 +286,12 @@ func (bfc *BlockFrostChainContext) AddressUtxos(
 					strconv.Itoa(i),
 				),
 				nil,
+				true,
 			)
-			if bfc._projectId != "" {
-				req.Header.Set("project_id", bfc._projectId)
-			}
-			res, err := bfc.client.Do(req)
 			if err != nil {
 				return nil, err
 			}
-			defer res.Body.Close()
-			body, err := io.ReadAll(res.Body)
+			body, err := bfc.doRequest(req)
 			if err != nil {
 				return nil, err
 			}
@@ -269,16 +308,16 @@ func (bfc *BlockFrostChainContext) AddressUtxos(
 		}
 		return result, nil
 	} else {
-		req, _ := http.NewRequestWithContext(bfc.ctx, "GET", fmt.Sprintf("%s/addresses/%s/utxos", bfc._baseUrl, address), nil)
-		if bfc._projectId != "" {
-			req.Header.Set("project_id", bfc._projectId)
-		}
-		res, err := bfc.client.Do(req)
+		req, err := bfc.newRequest(
+			"GET",
+			fmt.Sprintf("%s/addresses/%s/utxos", bfc._baseUrl, address),
+			nil,
+			true,
+		)
 		if err != nil {
 			return nil, err
 		}
-		defer res.Body.Close()
-		body, err := io.ReadAll(res.Body)
+		body, err := bfc.doRequest(req)
 		if err != nil {
 			return nil, err
 		}
@@ -297,21 +336,16 @@ func (bfc *BlockFrostChainContext) LatestEpochParams() (Base.ProtocolParameters,
 	timest := time.Time{}
 	foundTime := Cache.Get[time.Time]("latest_epoch_params_time", &timest)
 	if !found || !foundTime || time.Since(timest) > 5*time.Minute {
-		req, _ := http.NewRequestWithContext(
-			bfc.ctx,
+		req, err := bfc.newRequest(
 			"GET",
 			bfc._baseUrl+"/epochs/latest/parameters",
 			nil,
+			true,
 		)
-		if bfc._projectId != "" {
-			req.Header.Set("project_id", bfc._projectId)
-		}
-		res, err := bfc.client.Do(req)
 		if err != nil {
 			return pm, err
 		}
-		defer res.Body.Close()
-		body, err := io.ReadAll(res.Body)
+		body, err := bfc.doRequest(req)
 		if err != nil {
 			return pm, err
 		}
@@ -339,21 +373,16 @@ func (bfc *BlockFrostChainContext) GenesisParams() (Base.GenesisParameters, erro
 		timest, _ = time.Parse(time.RFC3339, timestamp)
 	}
 	if !found || !foundTime || time.Since(timest) > 5*time.Minute {
-		req, _ := http.NewRequestWithContext(
-			bfc.ctx,
+		req, err := bfc.newRequest(
 			"GET",
-			bfc._baseUrl+"/Genesis",
+			bfc._baseUrl+"/genesis",
 			nil,
+			true,
 		)
-		if bfc._projectId != "" {
-			req.Header.Set("project_id", bfc._projectId)
-		}
-		res, err := bfc.client.Do(req)
 		if err != nil {
 			return gp, err
 		}
-		defer res.Body.Close()
-		body, err := io.ReadAll(res.Body)
+		body, err := bfc.doRequest(req)
 		if err != nil {
 			return gp, err
 		}
@@ -480,13 +509,19 @@ func (bfc *BlockFrostChainContext) Utxos(
 				if err != nil {
 					return nil, fmt.Errorf("Utxos: invalid asset quantity %q: %w", item.Quantity, err)
 				}
-				policy_id := Policy.PolicyId{Value: item.Unit[:56]}
-				asset_name := *AssetName.NewAssetNameFromHexString(item.Unit[56:])
-				_, ok := multi_assets[policy_id]
-				if !ok {
-					multi_assets[policy_id] = Asset.Asset[int64]{}
+				policyID, assetName, err := Base.ParseAssetUnit(item.Unit)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"Utxos: invalid asset unit %q: %w",
+						item.Unit,
+						err,
+					)
 				}
-				multi_assets[policy_id][asset_name] = int64(asset_quantity)
+				_, ok := multi_assets[policyID]
+				if !ok {
+					multi_assets[policyID] = Asset.Asset[int64]{}
+				}
+				multi_assets[policyID][assetName] = int64(asset_quantity)
 			}
 		}
 		var final_amount Value.Value
@@ -547,26 +582,21 @@ func (bfc *BlockFrostChainContext) SpecialSubmitTx(
 	if err != nil {
 		return resId, fmt.Errorf("SpecialSubmitTx: failed to marshal transaction: %w", err)
 	}
-	if bfc.CustomSubmissionEndpoints != nil {
+	if len(bfc.CustomSubmissionEndpoints) > 0 {
 		logger <- ("Custom Submission Endpoints Found, submitting...")
 		for _, endpoint := range bfc.CustomSubmissionEndpoints {
 			logger <- fmt.Sprint("TRYING WITH:", endpoint)
-			req, _ := http.NewRequestWithContext(
-				bfc.ctx,
+			req, err := bfc.newRequest(
 				"POST",
 				endpoint,
 				bytes.NewBuffer(txBytes),
+				false,
 			)
-			if bfc._projectId != "" {
-				req.Header.Set("project_id", bfc._projectId)
-			}
-			req.Header.Set("Content-Type", "application/cbor")
-			res, err := bfc.client.Do(req)
 			if err != nil {
 				return resId, err
 			}
-			defer res.Body.Close()
-			body, err := io.ReadAll(res.Body)
+			req.Header.Set("Content-Type", "application/cbor")
+			body, err := bfc.doRequest(req)
 			if err != nil {
 				return resId, err
 			}
@@ -578,22 +608,17 @@ func (bfc *BlockFrostChainContext) SpecialSubmitTx(
 			logger <- fmt.Sprint("RESPONSE:", response)
 		}
 	}
-	req, _ := http.NewRequestWithContext(
-		bfc.ctx,
+	req, err := bfc.newRequest(
 		"POST",
 		bfc._baseUrl+"/tx/submit",
 		bytes.NewBuffer(txBytes),
+		true,
 	)
-	if bfc._projectId != "" {
-		req.Header.Set("project_id", bfc._projectId)
-	}
-	req.Header.Set("Content-Type", "application/cbor")
-	res, err := bfc.client.Do(req)
 	if err != nil {
 		return resId, err
 	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
+	req.Header.Set("Content-Type", "application/cbor")
+	body, err := bfc.doRequest(req)
 	if err != nil {
 		return resId, err
 	}
@@ -610,25 +635,23 @@ func (bfc *BlockFrostChainContext) SubmitTx(
 	tx Transaction.Transaction,
 ) (serialization.TransactionId, error) {
 	resId := serialization.TransactionId{}
-	txBytes, _ := cbor.Marshal(tx)
-	if bfc.CustomSubmissionEndpoints != nil {
+	txBytes, err := cbor.Marshal(tx)
+	if err != nil {
+		return resId, fmt.Errorf("SubmitTx: failed to marshal transaction: %w", err)
+	}
+	if len(bfc.CustomSubmissionEndpoints) > 0 {
 		for _, endpoint := range bfc.CustomSubmissionEndpoints {
-			req, _ := http.NewRequestWithContext(
-				bfc.ctx,
+			req, err := bfc.newRequest(
 				"POST",
 				endpoint,
 				bytes.NewBuffer(txBytes),
+				false,
 			)
-			if bfc._projectId != "" {
-				req.Header.Set("project_id", bfc._projectId)
-			}
-			req.Header.Set("Content-Type", "application/cbor")
-			res, err := bfc.client.Do(req)
 			if err != nil {
 				return resId, err
 			}
-			defer res.Body.Close()
-			body, err := io.ReadAll(res.Body)
+			req.Header.Set("Content-Type", "application/cbor")
+			body, err := bfc.doRequest(req)
 			if err != nil {
 				return resId, err
 			}
@@ -639,35 +662,24 @@ func (bfc *BlockFrostChainContext) SubmitTx(
 			}
 		}
 	}
-	req, _ := http.NewRequestWithContext(
-		bfc.ctx,
+	req, err := bfc.newRequest(
 		"POST",
 		bfc._baseUrl+"/tx/submit",
 		bytes.NewBuffer(txBytes),
+		true,
 	)
-	if bfc._projectId != "" {
-		req.Header.Set("project_id", bfc._projectId)
+	if err != nil {
+		return serialization.TransactionId{}, err
 	}
 	req.Header.Set("Content-Type", "application/cbor")
-	res, err := bfc.client.Do(req)
+	body, err := bfc.doRequest(req)
 	if err != nil {
-		return serialization.TransactionId{}, err
-	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return serialization.TransactionId{}, err
+		return serialization.TransactionId{}, fmt.Errorf("error submitting tx: %w", err)
 	}
 	var response any
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return serialization.TransactionId{}, err
-	}
-	if res.Status != "200 OK" {
-		return serialization.TransactionId{}, fmt.Errorf(
-			"error submitting tx: %v",
-			response,
-		)
 	}
 	hash, err := tx.TransactionBody.Hash()
 	if err != nil {
@@ -688,22 +700,17 @@ func (bfc *BlockFrostChainContext) EvaluateTx(
 	tx []byte,
 ) (map[string]Redeemer.ExecutionUnits, error) {
 	encoded := hex.EncodeToString(tx)
-	req, _ := http.NewRequestWithContext(
-		bfc.ctx,
+	req, err := bfc.newRequest(
 		"POST",
 		bfc._baseUrl+"/utils/txs/evaluate",
 		strings.NewReader(encoded),
+		true,
 	)
-	if bfc._projectId != "" {
-		req.Header.Set("project_id", bfc._projectId)
-	}
-	req.Header.Set("Content-Type", "application/cbor")
-	res, err := bfc.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
+	req.Header.Set("Content-Type", "application/cbor")
+	body, err := bfc.doRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -734,21 +741,16 @@ type BlockfrostContractCbor struct {
 func (bfc *BlockFrostChainContext) GetContractCbor(
 	scriptHash string,
 ) (string, error) {
-	req, _ := http.NewRequestWithContext(
-		bfc.ctx,
+	req, err := bfc.newRequest(
 		"GET",
 		fmt.Sprintf("%s/scripts/%s/cbor", bfc._baseUrl, scriptHash),
 		nil,
+		true,
 	)
-	if bfc._projectId != "" {
-		req.Header.Set("project_id", bfc._projectId)
-	}
-	res, err := bfc.client.Do(req)
 	if err != nil {
 		return "", err
 	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
+	body, err := bfc.doRequest(req)
 	if err != nil {
 		return "", err
 	}

--- a/txBuilding/Backend/Cache/Cache.go
+++ b/txBuilding/Backend/Cache/Cache.go
@@ -2,9 +2,11 @@ package Cache
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -14,18 +16,54 @@ var (
 	cacheDirOnce sync.Once
 )
 
-// getCacheDir returns the cache directory, creating it if necessary.
-// Uses os.TempDir() for a consistent, system-appropriate location.
+// getCacheDir returns the cache directory path. Directory creation and
+// permission checks are handled by ensureCacheDir.
 func getCacheDir() string {
 	cacheDirOnce.Do(func() {
-		cacheDir = filepath.Join(os.TempDir(), "apollo-cache")
-		// Best effort directory creation - errors handled in Get/Set
-		_ = os.MkdirAll(cacheDir, 0755)
+		if cacheDir != "" {
+			return
+		}
+		userCacheDir, err := os.UserCacheDir()
+		if err == nil && userCacheDir != "" {
+			cacheDir = filepath.Join(userCacheDir, "apollo")
+			return
+		}
+		cacheDir = filepath.Join(
+			os.TempDir(),
+			"apollo-cache-"+strconv.Itoa(os.Getuid()),
+		)
 	})
 	return cacheDir
 }
 
-// sanitizeKey removes path traversal attempts and invalid characters from cache keys.
+func ensureCacheDir() error {
+	dir := getCacheDir()
+	info, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return fmt.Errorf("create cache directory: %w", err)
+		}
+		info, err = os.Lstat(dir)
+	}
+	if err != nil {
+		return fmt.Errorf("stat cache directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("cache directory %q must not be a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("cache path %q is not a directory", dir)
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		if err := os.Chmod(dir, 0700); err != nil {
+			return fmt.Errorf("secure cache directory permissions: %w", err)
+		}
+	}
+	return nil
+}
+
+// sanitizeKey removes path traversal attempts and invalid characters
+// from cache keys.
 // Returns a safe filename that cannot escape the cache directory.
 func sanitizeKey(key string) string {
 	// Remove any path separators and parent directory references
@@ -44,6 +82,9 @@ func sanitizeKey(key string) string {
 // Get retrieves a cached value by key. Returns true if the value was found
 // and successfully unmarshaled, false otherwise.
 func Get[T any](key string, val *T) bool {
+	if err := ensureCacheDir(); err != nil {
+		return false
+	}
 	key = sanitizeKey(key)
 	path := filepath.Join(getCacheDir(), key+".json")
 	dat, err := os.ReadFile(path)
@@ -57,6 +98,9 @@ func Get[T any](key string, val *T) bool {
 // Set stores a value in the cache with the given key.
 // Returns an error if marshaling or writing fails.
 func Set[T any](key string, value T) error {
+	if err := ensureCacheDir(); err != nil {
+		return fmt.Errorf("cache set: %w", err)
+	}
 	key = sanitizeKey(key)
 	val, err := json.Marshal(value)
 	if err != nil {

--- a/txBuilding/Backend/Cache/Cache_test.go
+++ b/txBuilding/Backend/Cache/Cache_test.go
@@ -3,9 +3,20 @@ package Cache
 import (
 	"os"
 	"path/filepath"
-	"strings"
+	"sync"
 	"testing"
 )
+
+func useTempCacheDir(t *testing.T) {
+	t.Helper()
+
+	cacheDir = filepath.Join(t.TempDir(), "apollo-cache")
+	cacheDirOnce = sync.Once{}
+	t.Cleanup(func() {
+		cacheDir = ""
+		cacheDirOnce = sync.Once{}
+	})
+}
 
 func TestSanitizeKey(t *testing.T) {
 	tests := []struct {
@@ -34,6 +45,8 @@ func TestSanitizeKey(t *testing.T) {
 }
 
 func TestGetSet(t *testing.T) {
+	useTempCacheDir(t)
+
 	// Test basic get/set functionality
 	type TestData struct {
 		Name  string `json:"name"`
@@ -64,6 +77,8 @@ func TestGetSet(t *testing.T) {
 }
 
 func TestGetMissingKey(t *testing.T) {
+	useTempCacheDir(t)
+
 	var data string
 	found := Get("nonexistent_key_12345", &data)
 	if found {
@@ -72,6 +87,8 @@ func TestGetMissingKey(t *testing.T) {
 }
 
 func TestPathTraversalPrevention(t *testing.T) {
+	useTempCacheDir(t)
+
 	// Attempt to write to a path outside the cache directory
 	maliciousKey := "../../../tmp/malicious"
 
@@ -97,16 +114,25 @@ func TestPathTraversalPrevention(t *testing.T) {
 	}
 }
 
-func TestCacheUsesSystemTempDir(t *testing.T) {
-	dir := getCacheDir()
-	tempDir := os.TempDir()
+func TestCacheUsesPrivateDir(t *testing.T) {
+	useTempCacheDir(t)
 
-	// Check that cache dir starts with temp dir
-	if !strings.HasPrefix(dir, tempDir) {
-		t.Errorf("Cache directory %q is not under system temp dir %q", dir, tempDir)
+	dir := getCacheDir()
+	if err := ensureCacheDir(); err != nil {
+		t.Fatalf("ensureCacheDir failed: %v", err)
 	}
 
 	if filepath.Base(dir) != "apollo-cache" {
-		t.Errorf("Cache directory should be named 'apollo-cache', got %q", filepath.Base(dir))
+		t.Errorf(
+			"Cache directory should be named 'apollo-cache', got %q",
+			filepath.Base(dir),
+		)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat cache dir: %v", err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("cache directory permissions = %o, want 0700", info.Mode().Perm())
 	}
 }

--- a/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
+++ b/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
@@ -94,34 +94,40 @@ func (occ *OgmiosChainContext) Init() error {
 
 func multiAsset_OgmigoToApollo(
 	m map[string]map[string]num.Int,
-) MultiAsset.MultiAsset[int64] {
+) (MultiAsset.MultiAsset[int64], error) {
 	if len(m) == 0 {
-		return nil
+		return nil, nil
 	}
 	assetMap := make(map[Policy.PolicyId]Asset.Asset[int64])
 	for policy, tokens := range m {
 		tokensMap := make(map[AssetName.AssetName]int64)
 		for token, amt := range tokens {
-			tok := *AssetName.NewAssetNameFromHexString(token)
-			tokensMap[tok] = amt.Int64()
+			assetName := AssetName.NewAssetNameFromHexString(token)
+			if assetName == nil {
+				return nil, fmt.Errorf("invalid asset name %q", token)
+			}
+			tokensMap[*assetName] = amt.Int64()
 		}
-		pol := Policy.PolicyId{
-			Value: policy,
+		pol, err := Policy.New(policy)
+		if err != nil {
+			return nil, fmt.Errorf("invalid policy id %q: %w", policy, err)
 		}
-		assetMap[pol] = make(map[AssetName.AssetName]int64)
-		assetMap[pol] = tokensMap
+		assetMap[*pol] = tokensMap
 	}
-	return assetMap
+	return assetMap, nil
 }
 
-func value_OgmigoToApollo(v shared.Value) Value.AlonzoValue {
-	ass := multiAsset_OgmigoToApollo(v.AssetsExceptAda())
+func value_OgmigoToApollo(v shared.Value) (Value.AlonzoValue, error) {
+	ass, err := multiAsset_OgmigoToApollo(v.AssetsExceptAda())
+	if err != nil {
+		return Value.AlonzoValue{}, err
+	}
 	if ass == nil {
 		return Value.AlonzoValue{
 			Am:        Amount.AlonzoAmount{},
 			Coin:      v.AdaLovelace().Int64(),
 			HasAssets: false,
-		}
+		}, nil
 	}
 	return Value.AlonzoValue{
 		Am: Amount.AlonzoAmount{
@@ -130,7 +136,7 @@ func value_OgmigoToApollo(v shared.Value) Value.AlonzoValue {
 		},
 		Coin:      0,
 		HasAssets: true,
-	}
+	}, nil
 }
 
 func datum_OgmigoToApollo(
@@ -215,7 +221,13 @@ func Utxo_OgmigoToApollo(u shared.Utxo) (UTxO.UTxO, error) {
 	if err != nil {
 		return UTxO.UTxO{}, err
 	}
-	v := value_OgmigoToApollo(u.Value)
+	v, err := value_OgmigoToApollo(u.Value)
+	if err != nil {
+		return UTxO.UTxO{}, fmt.Errorf(
+			"OgmiosChainContext: failed to convert value: %w",
+			err,
+		)
+	}
 	scriptRef, err := scriptRef_OgmigoToApollo(u.Script)
 	if err != nil {
 		return UTxO.UTxO{}, fmt.Errorf(
@@ -878,13 +890,19 @@ func (occ *OgmiosChainContext) Utxos(
 						err,
 					)
 				}
-				policy_id := Policy.PolicyId{Value: item.Unit[:56]}
-				asset_name := *AssetName.NewAssetNameFromHexString(item.Unit[56:])
-				_, ok := multi_assets[policy_id]
-				if !ok {
-					multi_assets[policy_id] = Asset.Asset[int64]{}
+				policyID, assetName, err := Base.ParseAssetUnit(item.Unit)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"OgmiosChainContext: Utxos: invalid asset unit %q: %w",
+						item.Unit,
+						err,
+					)
 				}
-				multi_assets[policy_id][asset_name] = int64(asset_quantity)
+				_, ok := multi_assets[policyID]
+				if !ok {
+					multi_assets[policyID] = Asset.Asset[int64]{}
+				}
+				multi_assets[policyID][assetName] = int64(asset_quantity)
 			}
 		}
 		var final_amount Value.Value


### PR DESCRIPTION
Cleanups

- Hardens address decoding/CBOR unmarshalling with payload length/type validation.
- Adds validation for keypair wallet setup, required signer hash lengths, policy IDs, asset names, and asset units.
- Changes Plutus asset decoding to return errors instead of panicking.
- Centralizes BlockFrost HTTP handling with timeouts, response size limits, body closing, and non-2xx errors.
- Secures cache storage by using a private cache directory, 0700 permissions, and symlink checks.
- Adds focused tests for the new validation/error paths.
