### PR TITLE
feat: pass resolved additional UTxOs to EvaluateTx

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -1697,7 +1697,7 @@ func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.
 		return fmt.Errorf("failed to encode preliminary tx: %w", err)
 	}
 
-	evalResult, err := a.Context.EvaluateTx(txBytes)
+	evalResult, err := a.Context.EvaluateTx(txBytes, inputs)
 	if err != nil {
 		return fmt.Errorf("EvaluateTx failed: %w", err)
 	}

--- a/backend/base.go
+++ b/backend/base.go
@@ -21,7 +21,18 @@ type ChainContext interface {
 	Tip() (uint64, error)
 	Utxos(address common.Address) ([]common.Utxo, error)
 	SubmitTx(txCbor []byte) (common.Blake2b256, error)
-	EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error)
+	// EvaluateTx evaluates the scripts in a transaction and returns the
+	// execution units required by each redeemer. additionalUtxos is a set of
+	// resolved UTxOs supplied to the evaluator (e.g. spending inputs that are
+	// not yet confirmed on-chain, such as off-chain or chained inputs), so that
+	// script execution-unit estimation can resolve inputs the backend cannot
+	// see on-chain. Backends that support additionalUtxos (ogmios, blockfrost)
+	// forward them to the evaluator; backends that do not (maestro, utxorpc)
+	// IGNORE additionalUtxos and can only evaluate transactions whose inputs are
+	// already visible on-chain; they do NOT support evaluation of off-chain or
+	// chained inputs. Passing a non-empty additionalUtxos to such a backend is
+	// not an error, but those UTxOs will not be considered.
+	EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
 	UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error)
 	ScriptCbor(scriptHash common.Blake2b224) ([]byte, error)
 }

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -291,7 +291,23 @@ func (b *BlockFrostChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, err
 	return result, nil
 }
 
-func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	// When resolved UTxOs are supplied (e.g. inputs not yet confirmed
+	// on-chain), the bare /utils/txs/evaluate endpoint (cbor body) cannot carry
+	// them. Switch to /utils/txs/evaluate/utxos with a JSON body that includes
+	// the additional UTxO set.
+	if len(additionalUtxos) > 0 {
+		reqBody, err := buildEvalUtxosRequest(txCbor, additionalUtxos)
+		if err != nil {
+			return nil, err
+		}
+		data, err := b.request("POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
+		if err != nil {
+			return nil, err
+		}
+		return parseEvaluateTxResponse(data)
+	}
+
 	// BlockFrost expects the transaction CBOR hex-encoded in the request body
 	// (with Content-Type application/cbor), not the raw CBOR bytes.
 	body := strings.NewReader(hex.EncodeToString(txCbor))
@@ -300,6 +316,141 @@ func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte) (map[common.RedeemerK
 		return nil, err
 	}
 	return parseEvaluateTxResponse(data)
+}
+
+// buildEvalUtxosRequest marshals the JSON body for the
+// /utils/txs/evaluate/utxos endpoint: the hex tx CBOR plus the resolved
+// additional UTxO set as [txIn, txOut] pairs.
+func buildEvalUtxosRequest(txCbor []byte, additionalUtxos []common.Utxo) ([]byte, error) {
+	items := make([]bfAdditionalUtxoItem, 0, len(additionalUtxos))
+	for _, utxo := range additionalUtxos {
+		item, err := bfAdditionalUtxoItemFromUtxo(utxo)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	req := bfEvalRequest{
+		Cbor:              hex.EncodeToString(txCbor),
+		AdditionalUtxoSet: items,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal evaluate request: %w", err)
+	}
+	return body, nil
+}
+
+// bfAdditionalUtxoItemFromUtxo builds a single [txIn, txOut] additional-UTxO
+// entry from a resolved gouroboros UTxO.
+func bfAdditionalUtxoItemFromUtxo(utxo common.Utxo) (bfAdditionalUtxoItem, error) {
+	out := utxo.Output
+
+	txIn := bfTxIn{
+		TxId:  hex.EncodeToString(utxo.Id.Id().Bytes()),
+		Index: int(utxo.Id.Index()),
+	}
+
+	coins, err := bigIntToInt64(out.Amount())
+	if err != nil {
+		return bfAdditionalUtxoItem{}, fmt.Errorf("invalid lovelace amount: %w", err)
+	}
+	val := bfValue{Coins: coins}
+	if assets := out.Assets(); assets != nil {
+		assetMap := make(map[string]int64)
+		for _, policyId := range assets.Policies() {
+			policyHex := hex.EncodeToString(policyId.Bytes())
+			for _, assetName := range assets.Assets(policyId) {
+				// Asset key is policyHex for the empty asset name, otherwise
+				// policyHex + "." + assetNameHex.
+				key := policyHex
+				if len(assetName) > 0 {
+					key = policyHex + "." + hex.EncodeToString(assetName)
+				}
+				qty, err := bigIntToInt64(assets.Asset(policyId, assetName))
+				if err != nil {
+					return bfAdditionalUtxoItem{}, fmt.Errorf("invalid asset quantity for %s: %w", key, err)
+				}
+				assetMap[key] = qty
+			}
+		}
+		if len(assetMap) > 0 {
+			val.Assets = assetMap
+		}
+	}
+
+	txOut := bfTxOut{
+		Address: out.Address().String(),
+		Value:   val,
+	}
+
+	// Inline datum CBOR hex goes in Datum; a bare datum hash goes in DatumHash.
+	if datum := out.Datum(); datum != nil {
+		datumCbor, err := datum.MarshalCBOR()
+		if err != nil {
+			return bfAdditionalUtxoItem{}, fmt.Errorf("failed to encode inline datum: %w", err)
+		}
+		datumHex := hex.EncodeToString(datumCbor)
+		txOut.Datum = &datumHex
+	} else if datumHash := out.DatumHash(); datumHash != nil {
+		datumHashHex := hex.EncodeToString(datumHash.Bytes())
+		txOut.DatumHash = &datumHashHex
+	}
+
+	// Reference script, tagged by Plutus language version.
+	if script := out.ScriptRef(); script != nil {
+		ref, err := bfScriptRefFromScript(script)
+		if err != nil {
+			return bfAdditionalUtxoItem{}, err
+		}
+		txOut.ScriptRef = ref
+	}
+
+	return bfAdditionalUtxoItem{txIn, txOut}, nil
+}
+
+// bfScriptRefFromScript encodes a reference script into the Ogmios-v5 TxOut
+// "script" wire shape used by /utils/txs/evaluate/utxos:
+// {"plutus:v1"|"plutus:v2"|"plutus:v3"|"plutus:v4": "<base16 serialised script>"}.
+// The Plutus language version is detected from the concrete script type, and
+// the value is the on-chain serialised Plutus script (base16), matching the
+// Ogmios encoding consumed by ogmiosScriptToScriptRef on read.
+//
+// Schema source: Ogmios local-tx-submission TxOut schema (scripts labelled
+// "plutus:v1"/"plutus:v2"/"plutus:v3"/"plutus:v4", serialised Plutus scripts as base16),
+// cross-checked against cardano-transaction-lib's encodeScriptRef
+// (Plutonomicon/cardano-transaction-lib@72e4504). Native reference scripts in
+// the additional UTxO set are not supported (their JSON encoding is undefined
+// in that schema), so they are rejected rather than mislabelled.
+func bfScriptRefFromScript(script common.Script) (*bfScriptRef, error) {
+	scriptHex := hex.EncodeToString(script.RawScriptBytes())
+	ref := &bfScriptRef{}
+	switch script.(type) {
+	case common.PlutusV1Script:
+		ref.PlutusV1 = &scriptHex
+	case common.PlutusV2Script:
+		ref.PlutusV2 = &scriptHex
+	case common.PlutusV3Script:
+		ref.PlutusV3 = &scriptHex
+	case common.PlutusV4Script:
+		ref.PlutusV4 = &scriptHex
+	default:
+		return nil, fmt.Errorf("unsupported script type %T in additional UTxO: only Plutus v1/v2/v3/v4 reference scripts can be encoded for /utils/txs/evaluate/utxos", script)
+	}
+	return ref, nil
+}
+
+// bigIntToInt64 converts a big.Int quantity to int64, rejecting values that do
+// not fit rather than silently truncating (the Ogmios-v5 value schema used by
+// /utils/txs/evaluate/utxos encodes coins/assets as JSON integers).
+func bigIntToInt64(v *big.Int) (int64, error) {
+	if v == nil {
+		return 0, nil
+	}
+	if !v.IsInt64() {
+		return 0, fmt.Errorf("quantity %s does not fit in int64", v.String())
+	}
+	return v.Int64(), nil
 }
 
 // jsonValuePresent reports whether a raw JSON field was present and not null.
@@ -495,6 +646,55 @@ func (b *BlockFrostChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byt
 		return nil, fmt.Errorf("invalid script CBOR hex: %w", err)
 	}
 	return scriptCbor, nil
+}
+
+// --- BlockFrost evaluate-with-utxos request types ---
+//
+// /utils/txs/evaluate/utxos proxies Ogmios, so the additionalUtxoSet uses the
+// Ogmios-v5 [txIn, txOut] schema (confirmed by the v5 EvaluationResult
+// response shape this endpoint returns). The value is {coins, assets}; a bare
+// datum hash is "datumHash"; reference scripts are
+// {"plutus:v1"|"plutus:v2"|"plutus:v3": "<base16 script>"}.
+// Schema source: Ogmios local-tx-submission docs/changelog (datumHash key,
+// plutus:vN script labels, base16 script encoding) cross-checked against
+// cardano-transaction-lib (Plutonomicon/cardano-transaction-lib@72e4504) and
+// the production value/coins/assets casing in cardano-connector-go.
+
+type bfEvalRequest struct {
+	Cbor              string                 `json:"cbor"`
+	AdditionalUtxoSet []bfAdditionalUtxoItem `json:"additionalUtxoSet"`
+}
+
+// bfAdditionalUtxoItem is a [txIn, txOut] pair.
+type bfAdditionalUtxoItem [2]any
+
+type bfTxIn struct {
+	TxId  string `json:"txId"`
+	Index int    `json:"index"`
+}
+
+type bfValue struct {
+	Coins int64 `json:"coins"`
+	// Assets key is the policy ID hex for the empty asset name, otherwise
+	// policyHex + "." + assetNameHex.
+	Assets map[string]int64 `json:"assets,omitempty"`
+}
+
+type bfScriptRef struct {
+	PlutusV1 *string `json:"plutus:v1,omitempty"`
+	PlutusV2 *string `json:"plutus:v2,omitempty"`
+	PlutusV3 *string `json:"plutus:v3,omitempty"`
+	PlutusV4 *string `json:"plutus:v4,omitempty"`
+}
+
+type bfTxOut struct {
+	Address string  `json:"address"`
+	Value   bfValue `json:"value"`
+	// DatumHash uses the Ogmios-v5 camelCase key "datumHash" (a bare datum
+	// hash digest); inline datums go under "datum".
+	DatumHash *string      `json:"datumHash,omitempty"`
+	Datum     *string      `json:"datum,omitempty"`
+	ScriptRef *bfScriptRef `json:"script,omitempty"`
 }
 
 // --- BlockFrost response types ---

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -6,13 +6,17 @@ import (
 	"encoding/json"
 	"io"
 	"math"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
 func testAddress(t *testing.T) common.Address {
@@ -101,7 +105,7 @@ func TestEvaluateTxRejectsRedeemerIndexOverflow(t *testing.T) {
 	defer server.Close()
 
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
-	_, err := ctx.EvaluateTx([]byte{0x84})
+	_, err := ctx.EvaluateTx([]byte{0x84}, nil)
 	if err == nil {
 		t.Fatal("expected redeemer index overflow error")
 	}
@@ -129,7 +133,7 @@ func TestEvaluateTxSendsHexEncodedBody(t *testing.T) {
 	defer server.Close()
 
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
-	result, err := ctx.EvaluateTx(txCbor)
+	result, err := ctx.EvaluateTx(txCbor, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,4 +300,355 @@ func TestAddressUTxOToUtxoRejectsOutputIndexOverflow(t *testing.T) {
 	if _, err := raw.toUtxo(addr); err == nil {
 		t.Fatal("expected output index overflow error")
 	}
+}
+
+// sampleCommonUtxo builds a resolved gouroboros UTxO for additional-UTxO
+// request-shaping tests: a known tx ref, address, lovelace coin, one native
+// asset, and a PlutusV2 reference script.
+func sampleCommonUtxo(t *testing.T) common.Utxo {
+	t.Helper()
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x11
+	}
+	input := shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 3}
+
+	var policyId common.Blake2b224
+	for i := range policyId {
+		policyId[i] = 0xAB
+	}
+	assetName := []byte("TOKEN")
+	assetData := map[common.Blake2b224]map[cbor.ByteString]*big.Int{
+		policyId: {cbor.NewByteString(assetName): big.NewInt(42)},
+	}
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](assetData)
+
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount: mary.MaryTransactionOutputValue{
+			Amount: 1_500_000,
+			Assets: &ma,
+		},
+		TxOutScriptRef: &common.ScriptRef{
+			Type:   common.ScriptRefTypePlutusV2,
+			Script: common.PlutusV2Script([]byte{0x49, 0x48, 0x01, 0x00}),
+		},
+	}
+	return common.Utxo{Id: input, Output: &output}
+}
+
+func TestBuildEvalUtxosRequestShape(t *testing.T) {
+	txCbor := []byte{0x84, 0xa3, 0x00}
+	body, err := buildEvalUtxosRequest(txCbor, []common.Utxo{sampleCommonUtxo(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decode generically to assert exact JSON keys and casing.
+	var req map[string]json.RawMessage
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	var cborField string
+	if err := json.Unmarshal(req["cbor"], &cborField); err != nil {
+		t.Fatalf("cbor field: %v", err)
+	}
+	if cborField != hex.EncodeToString(txCbor) {
+		t.Fatalf("cbor = %q, want %q", cborField, hex.EncodeToString(txCbor))
+	}
+
+	var set []json.RawMessage
+	if err := json.Unmarshal(req["additionalUtxoSet"], &set); err != nil {
+		t.Fatalf("additionalUtxoSet field: %v", err)
+	}
+	if len(set) != 1 {
+		t.Fatalf("additionalUtxoSet len = %d, want 1", len(set))
+	}
+
+	// Each item is a [txIn, txOut] pair.
+	var pair []json.RawMessage
+	if err := json.Unmarshal(set[0], &pair); err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	if len(pair) != 2 {
+		t.Fatalf("pair len = %d, want 2", len(pair))
+	}
+
+	var txIn map[string]any
+	if err := json.Unmarshal(pair[0], &txIn); err != nil {
+		t.Fatalf("txIn: %v", err)
+	}
+	if txIn["txId"] != strings.Repeat("11", 32) {
+		t.Fatalf("txIn.txId = %v", txIn["txId"])
+	}
+	if txIn["index"] != float64(3) {
+		t.Fatalf("txIn.index = %v, want 3", txIn["index"])
+	}
+
+	var txOut map[string]json.RawMessage
+	if err := json.Unmarshal(pair[1], &txOut); err != nil {
+		t.Fatalf("txOut: %v", err)
+	}
+	if _, ok := txOut["address"]; !ok {
+		t.Fatal("txOut missing address")
+	}
+	// datumHash / datum must be absent (omitempty) for a script-only output.
+	if _, ok := txOut["datumHash"]; ok {
+		t.Fatal("txOut should not contain datumHash")
+	}
+	if _, ok := txOut["datum_hash"]; ok {
+		t.Fatal("txOut should not contain snake_case datum_hash")
+	}
+	if _, ok := txOut["datum"]; ok {
+		t.Fatal("txOut should not contain datum")
+	}
+
+	var value struct {
+		Coins  int64            `json:"coins"`
+		Assets map[string]int64 `json:"assets"`
+	}
+	if err := json.Unmarshal(txOut["value"], &value); err != nil {
+		t.Fatalf("value: %v", err)
+	}
+	if value.Coins != 1_500_000 {
+		t.Fatalf("coins = %d, want 1500000", value.Coins)
+	}
+	assetKey := strings.Repeat("ab", 28) + "." + hex.EncodeToString([]byte("TOKEN"))
+	if value.Assets[assetKey] != 42 {
+		t.Fatalf("assets[%q] = %d, want 42", assetKey, value.Assets[assetKey])
+	}
+
+	// Script must be tagged under "plutus:v2" with the raw script bytes (base16).
+	var script map[string]string
+	if err := json.Unmarshal(txOut["script"], &script); err != nil {
+		t.Fatalf("script: %v", err)
+	}
+	wantScriptHex := hex.EncodeToString([]byte{0x49, 0x48, 0x01, 0x00})
+	if script["plutus:v2"] != wantScriptHex {
+		t.Fatalf("script[plutus:v2] = %q, want %q", script["plutus:v2"], wantScriptHex)
+	}
+	if _, ok := script["plutus:v1"]; ok {
+		t.Fatal("script should not contain plutus:v1")
+	}
+	if _, ok := script["plutus:v3"]; ok {
+		t.Fatal("script should not contain plutus:v3")
+	}
+}
+
+func TestBuildEvalUtxosRequestHashOnlyDatum(t *testing.T) {
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x22
+	}
+	var datumHash common.Blake2b256
+	for i := range datumHash {
+		datumHash[i] = 0xCD
+	}
+	// Encode a hash-only datum option ([0, hash]).
+	datumCbor, err := cbor.Encode([]any{0, datumHash})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var opt babbage.BabbageTransactionOutputDatumOption
+	if err := opt.UnmarshalCBOR(datumCbor); err != nil {
+		t.Fatal(err)
+	}
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2_000_000},
+		DatumOption:   &opt,
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
+	}
+
+	body, err := buildEvalUtxosRequest([]byte{0x00}, []common.Utxo{utxo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txOut := decodeSingleTxOut(t, body)
+
+	// The hash-only datum must surface under camelCase "datumHash" and there
+	// must be no inline "datum".
+	var datumHashField string
+	if err := json.Unmarshal(txOut["datumHash"], &datumHashField); err != nil {
+		t.Fatalf("datumHash field: %v", err)
+	}
+	if datumHashField != strings.Repeat("cd", 32) {
+		t.Fatalf("datumHash = %q, want %q", datumHashField, strings.Repeat("cd", 32))
+	}
+	if _, ok := txOut["datum"]; ok {
+		t.Fatal("hash-only datum must not emit inline datum")
+	}
+	if _, ok := txOut["datum_hash"]; ok {
+		t.Fatal("must not emit snake_case datum_hash")
+	}
+}
+
+func TestBuildEvalUtxosRequestInlineDatum(t *testing.T) {
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x33
+	}
+	// Inline datum option [1, #6.24(<datum cbor>)]; datum is a simple integer 1.
+	innerDatumCbor := []byte{0x01}
+	optCbor, err := cbor.Encode([]any{1, cbor.Tag{Number: 24, Content: innerDatumCbor}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var opt babbage.BabbageTransactionOutputDatumOption
+	if err := opt.UnmarshalCBOR(optCbor); err != nil {
+		t.Fatal(err)
+	}
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2_000_000},
+		DatumOption:   &opt,
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
+	}
+
+	body, err := buildEvalUtxosRequest([]byte{0x00}, []common.Utxo{utxo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txOut := decodeSingleTxOut(t, body)
+
+	// An inline datum must surface under "datum" as the datum CBOR hex, and not
+	// as "datumHash".
+	var datumField string
+	if err := json.Unmarshal(txOut["datum"], &datumField); err != nil {
+		t.Fatalf("datum field: %v", err)
+	}
+	if datumField != hex.EncodeToString(innerDatumCbor) {
+		t.Fatalf("datum = %q, want %q", datumField, hex.EncodeToString(innerDatumCbor))
+	}
+	if _, ok := txOut["datumHash"]; ok {
+		t.Fatal("inline datum must not emit datumHash")
+	}
+}
+
+func TestBfScriptRefFromScriptRejectsNativeScript(t *testing.T) {
+	if _, err := bfScriptRefFromScript(common.NativeScript{}); err == nil {
+		t.Fatal("expected unsupported native script error")
+	}
+}
+
+func TestBfScriptRefFromScriptLanguageDetection(t *testing.T) {
+	raw := []byte{0x49, 0x48, 0x01, 0x00}
+	wantHex := hex.EncodeToString(raw)
+
+	v1, err := bfScriptRefFromScript(common.PlutusV1Script(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v1.PlutusV1 == nil || *v1.PlutusV1 != wantHex || v1.PlutusV2 != nil || v1.PlutusV3 != nil {
+		t.Fatalf("v1 mis-tagged: %+v", v1)
+	}
+	v3, err := bfScriptRefFromScript(common.PlutusV3Script(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v3.PlutusV3 == nil || *v3.PlutusV3 != wantHex || v3.PlutusV1 != nil || v3.PlutusV2 != nil || v3.PlutusV4 != nil {
+		t.Fatalf("v3 mis-tagged: %+v", v3)
+	}
+	v4, err := bfScriptRefFromScript(common.PlutusV4Script(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v4.PlutusV4 == nil || *v4.PlutusV4 != wantHex || v4.PlutusV1 != nil || v4.PlutusV2 != nil || v4.PlutusV3 != nil {
+		t.Fatalf("v4 mis-tagged: %+v", v4)
+	}
+}
+
+func TestBuildEvalUtxosRequestRejectsOverflowQuantity(t *testing.T) {
+	var txId common.Blake2b256
+	var policyId common.Blake2b224
+	for i := range policyId {
+		policyId[i] = 0x01
+	}
+	overflow := new(big.Int).Add(new(big.Int).SetUint64(math.MaxInt64), big.NewInt(1))
+	assetData := map[common.Blake2b224]map[cbor.ByteString]*big.Int{
+		policyId: {cbor.NewByteString(nil): overflow},
+	}
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](assetData)
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1, Assets: &ma},
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
+	}
+	if _, err := buildEvalUtxosRequest([]byte{0x00}, []common.Utxo{utxo}); err == nil {
+		t.Fatal("expected overflow asset quantity to be rejected")
+	}
+}
+
+func TestEvaluateTxWithAdditionalUtxosTargetsUtxosEndpoint(t *testing.T) {
+	var gotPath, gotContentType, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		_, _ = w.Write([]byte(`{"result":{"EvaluationResult":{"spend:0":{"memory":1700,"steps":476468}}}}`))
+	}))
+	defer server.Close()
+
+	ctx := NewBlockFrostChainContext(server.URL, 0, "")
+	result, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{sampleCommonUtxo(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/api/v0/utils/txs/evaluate/utxos" {
+		t.Fatalf("path = %q, want /api/v0/utils/txs/evaluate/utxos", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", gotContentType)
+	}
+	// Body must be valid JSON carrying the cbor + additionalUtxoSet keys.
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(gotBody), &parsed); err != nil {
+		t.Fatalf("request body is not JSON: %v", err)
+	}
+	if _, ok := parsed["additionalUtxoSet"]; !ok {
+		t.Fatal("request body missing additionalUtxoSet")
+	}
+	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
+		t.Fatalf("unexpected ExUnits %+v", eu)
+	}
+}
+
+// decodeSingleTxOut decodes an eval request body and returns the txOut of its
+// single additional-UTxO item.
+func decodeSingleTxOut(t *testing.T, body []byte) map[string]json.RawMessage {
+	t.Helper()
+	var req map[string]json.RawMessage
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	var set []json.RawMessage
+	if err := json.Unmarshal(req["additionalUtxoSet"], &set); err != nil {
+		t.Fatalf("additionalUtxoSet: %v", err)
+	}
+	if len(set) != 1 {
+		t.Fatalf("additionalUtxoSet len = %d, want 1", len(set))
+	}
+	var pair []json.RawMessage
+	if err := json.Unmarshal(set[0], &pair); err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	if len(pair) != 2 {
+		t.Fatalf("pair len = %d, want 2", len(pair))
+	}
+	var txOut map[string]json.RawMessage
+	if err := json.Unmarshal(pair[1], &txOut); err != nil {
+		t.Fatalf("txOut: %v", err)
+	}
+	return txOut
 }

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -119,8 +119,8 @@ func (c *CachedChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) 
 	return c.inner.SubmitTx(txCbor)
 }
 
-func (c *CachedChainContext) EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
-	return c.inner.EvaluateTx(txCbor)
+func (c *CachedChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	return c.inner.EvaluateTx(txCbor, additionalUtxos)
 }
 
 func (c *CachedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {

--- a/backend/fixed/fixed.go
+++ b/backend/fixed/fixed.go
@@ -111,7 +111,7 @@ func (f *FixedChainContext) SubmitTx(_ []byte) (common.Blake2b256, error) {
 	return common.Blake2b256{}, errors.New("cannot submit tx with fixed chain context")
 }
 
-func (f *FixedChainContext) EvaluateTx(_ []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+func (f *FixedChainContext) EvaluateTx(_ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	return nil, errors.New("cannot evaluate tx with fixed chain context")
 }
 

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -1,11 +1,15 @@
 package maestro
 
 import (
+	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -25,6 +29,11 @@ import (
 type MaestroChainContext struct {
 	client    *maestroClient.Client
 	networkId uint8
+	// apiKey is retained alongside the SDK client because the SDK keeps its
+	// own copy unexported. EvaluateTx with additional UTxOs issues a raw POST
+	// (the SDK's additional_utxos field is []string and cannot carry the
+	// object-shaped entries Maestro requires) and needs the key for auth.
+	apiKey string
 }
 
 // NewMaestroChainContext creates a new Maestro chain context.
@@ -34,6 +43,7 @@ func NewMaestroChainContext(networkId uint8, projectId string) (*MaestroChainCon
 	return &MaestroChainContext{
 		client:    client,
 		networkId: networkId,
+		apiKey:    projectId,
 	}, nil
 }
 
@@ -69,6 +79,7 @@ func NewMaestroChainContextWithNetwork(networkId uint8, projectId string, networ
 	return &MaestroChainContext{
 		client:    client,
 		networkId: networkId,
+		apiKey:    projectId,
 	}, nil
 }
 
@@ -261,25 +272,127 @@ func (m *MaestroChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 	return result, nil
 }
 
+// EvaluateTx evaluates the script execution budgets for a transaction. When
+// additionalUtxos is empty it uses the Maestro SDK's EvaluateTx, which posts the
+// bare tx CBOR. When resolved UTxOs are supplied (e.g. off-chain or chained
+// inputs not yet visible to Maestro) it issues a raw POST to
+// /transactions/evaluate with the documented object-shaped additional_utxos
+// field. The SDK's own additional_utxos type is []string and cannot represent
+// the required {tx_hash, index, txout_cbor} entries, so the request is built
+// here against the SDK client's base URL and API key.
 func (m *MaestroChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	txHex := hex.EncodeToString(txCbor)
-	// The Maestro SDK exposes additional UTxOs as a variadic []string
-	// (models.EvaluateTx.AdditionalUtxos), but Maestro's REST
-	// /transactions/evaluate additional_utxos field actually expects an array of
-	// objects (tx ref + resolved output CBOR), which the []string SDK type
-	// cannot represent. Rather than ship a guessed wire format, the resolved
-	// UTxOs are IGNORED: this backend can only evaluate transactions whose
-	// inputs are already visible on-chain to Maestro and does NOT support
-	// evaluating off-chain or chained inputs. This is not an error (the caller
-	// always passes the spending inputs), but additionalUtxos has no effect.
-	// TODO: Maestro additional_utxos string encoding not yet wired (SDK type
-	// mismatch); wire it once the SDK accepts the documented object shape.
-	_ = additionalUtxos
-	evalResp, err := m.client.EvaluateTx(txHex)
+
+	if len(additionalUtxos) == 0 {
+		evalResp, err := m.client.EvaluateTx(txHex)
+		if err != nil {
+			return nil, err
+		}
+		return evaluationsToExUnits(evalResp)
+	}
+
+	reqBody, err := buildEvaluateRequest(txHex, additionalUtxos)
+	if err != nil {
+		return nil, err
+	}
+	evalResp, err := m.postEvaluate(reqBody)
 	if err != nil {
 		return nil, err
 	}
 	return evaluationsToExUnits(evalResp)
+}
+
+// maestroAdditionalUtxo is a single additional_utxos entry: a transaction
+// reference plus the hex-encoded CBOR of the resolved output.
+type maestroAdditionalUtxo struct {
+	TxHash    string `json:"tx_hash"`
+	Index     int    `json:"index"`
+	TxoutCbor string `json:"txout_cbor"`
+}
+
+// maestroEvaluateRequest is the JSON body for POST /transactions/evaluate.
+type maestroEvaluateRequest struct {
+	Cbor            string                  `json:"cbor"`
+	AdditionalUtxos []maestroAdditionalUtxo `json:"additional_utxos"`
+}
+
+// buildEvaluateRequest marshals the evaluate request body, encoding each
+// resolved UTxO into its {tx_hash, index, txout_cbor} entry.
+func buildEvaluateRequest(txHex string, additionalUtxos []common.Utxo) ([]byte, error) {
+	items := make([]maestroAdditionalUtxo, 0, len(additionalUtxos))
+	for _, utxo := range additionalUtxos {
+		item, err := maestroAdditionalUtxoFromUtxo(utxo)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	req := maestroEvaluateRequest{
+		Cbor:            txHex,
+		AdditionalUtxos: items,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal evaluate request: %w", err)
+	}
+	return body, nil
+}
+
+// maestroAdditionalUtxoFromUtxo builds an additional_utxos entry from a resolved
+// gouroboros UTxO. txout_cbor is the CBOR encoding of the resolved output; it is
+// produced via cbor.Encode (the output's MarshalCBOR) rather than the cached
+// Cbor() bytes so outputs built in memory are encoded correctly.
+func maestroAdditionalUtxoFromUtxo(utxo common.Utxo) (maestroAdditionalUtxo, error) {
+	if utxo.Output == nil {
+		return maestroAdditionalUtxo{}, errors.New("additional UTxO is missing its resolved output")
+	}
+	if utxo.Id == nil {
+		return maestroAdditionalUtxo{}, errors.New("additional UTxO is missing its input reference")
+	}
+	txoutCbor, err := cbor.Encode(utxo.Output)
+	if err != nil {
+		return maestroAdditionalUtxo{}, fmt.Errorf("failed to encode resolved output CBOR: %w", err)
+	}
+	return maestroAdditionalUtxo{
+		TxHash:    hex.EncodeToString(utxo.Id.Id().Bytes()),
+		Index:     int(utxo.Id.Index()),
+		TxoutCbor: hex.EncodeToString(txoutCbor),
+	}, nil
+}
+
+// postEvaluate issues a raw POST to /transactions/evaluate, reusing the SDK
+// client's base URL, API key and HTTP client, and decodes the response with the
+// same shape the SDK uses.
+func (m *MaestroChainContext) postEvaluate(body []byte) (models.EvaluateTxResponse, error) {
+	url := m.client.BaseUrl + "/transactions/evaluate"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("api-key", m.apiKey)
+
+	httpClient := m.client.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("maestro evaluate failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+
+	var evalResp models.EvaluateTxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&evalResp); err != nil {
+		return nil, fmt.Errorf("failed to decode evaluate response: %w", err)
+	}
+	return evalResp, nil
 }
 
 // evaluationsToExUnits converts a Maestro evaluate response into a redeemer

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -261,8 +261,20 @@ func (m *MaestroChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 	return result, nil
 }
 
-func (m *MaestroChainContext) EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+func (m *MaestroChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	txHex := hex.EncodeToString(txCbor)
+	// The Maestro SDK exposes additional UTxOs as a variadic []string
+	// (models.EvaluateTx.AdditionalUtxos), but Maestro's REST
+	// /transactions/evaluate additional_utxos field actually expects an array of
+	// objects (tx ref + resolved output CBOR), which the []string SDK type
+	// cannot represent. Rather than ship a guessed wire format, the resolved
+	// UTxOs are IGNORED: this backend can only evaluate transactions whose
+	// inputs are already visible on-chain to Maestro and does NOT support
+	// evaluating off-chain or chained inputs. This is not an error (the caller
+	// always passes the spending inputs), but additionalUtxos has no effect.
+	// TODO: Maestro additional_utxos string encoding not yet wired (SDK type
+	// mismatch); wire it once the SDK accepts the documented object shape.
+	_ = additionalUtxos
 	evalResp, err := m.client.EvaluateTx(txHex)
 	if err != nil {
 		return nil, err

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -3,13 +3,18 @@ package maestro
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/maestro-org/go-sdk/models"
 )
 
@@ -225,6 +230,233 @@ func TestSubmitTxPostsCborToTxManager(t *testing.T) {
 	}
 	if !bytes.Equal(txHash.Bytes(), wantHash) {
 		t.Fatalf("tx hash = %x, want %x", txHash.Bytes(), wantHash)
+	}
+}
+
+func TestBuildEvaluateRequest(t *testing.T) {
+	var txId common.Blake2b256
+	idBytes, err := hex.DecodeString(testTxHashHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	copy(txId[:], idBytes)
+
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000000},
+	}
+	utxo := common.Utxo{
+		Id: shelley.ShelleyTransactionInput{
+			TxId:        txId,
+			OutputIndex: 3,
+		},
+		Output: &output,
+	}
+
+	txHex := hex.EncodeToString([]byte{0x84, 0xa3, 0x00})
+	body, err := buildEvaluateRequest(txHex, []common.Utxo{utxo})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req maestroEvaluateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("request body is not valid JSON: %v", err)
+	}
+	if req.Cbor != txHex {
+		t.Fatalf("cbor = %q, want %q", req.Cbor, txHex)
+	}
+	if len(req.AdditionalUtxos) != 1 {
+		t.Fatalf("expected 1 additional UTxO, got %d", len(req.AdditionalUtxos))
+	}
+	got := req.AdditionalUtxos[0]
+	if got.TxHash != testTxHashHex {
+		t.Fatalf("tx_hash = %q, want %q", got.TxHash, testTxHashHex)
+	}
+	if got.Index != 3 {
+		t.Fatalf("index = %d, want 3", got.Index)
+	}
+
+	wantCbor, err := cbor.Encode(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TxoutCbor != hex.EncodeToString(wantCbor) {
+		t.Fatalf("txout_cbor = %q, want %q", got.TxoutCbor, hex.EncodeToString(wantCbor))
+	}
+	// The encoded output CBOR must round-trip back to a valid Babbage output.
+	rawCbor, err := hex.DecodeString(got.TxoutCbor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded babbage.BabbageTransactionOutput
+	if _, err := cbor.Decode(rawCbor, &decoded); err != nil {
+		t.Fatalf("txout_cbor does not decode as a Babbage output: %v", err)
+	}
+	if decoded.Amount().Uint64() != 1000000 {
+		t.Fatalf("decoded amount = %d, want 1000000", decoded.Amount().Uint64())
+	}
+}
+
+func TestBuildEvaluateRequestRejectsMissingOutput(t *testing.T) {
+	var txId common.Blake2b256
+	utxo := common.Utxo{
+		Id: shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+	}
+	if _, err := buildEvaluateRequest("00", []common.Utxo{utxo}); err == nil {
+		t.Fatal("expected error for UTxO missing its resolved output")
+	}
+}
+
+func TestEvaluateTxWithAdditionalUtxosPostsObjectShape(t *testing.T) {
+	var txId common.Blake2b256
+	idBytes, _ := hex.DecodeString(testTxHashHex)
+	copy(txId[:], idBytes)
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2000000},
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 1},
+		Output: &output,
+	}
+
+	var gotPath, gotContentType, gotApiKey string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotApiKey = r.Header.Get("api-key")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		gotBody = body
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"ex_units":{"mem":1700,"steps":476468},"redeemer_index":0,"redeemer_tag":"spend"}]`))
+	}))
+	defer server.Close()
+
+	ctx, err := NewMaestroChainContextWithNetwork(0, "project-id", "preprod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx.client.BaseUrl = server.URL
+
+	result, err := ctx.EvaluateTx([]byte{0x84, 0xa3, 0x00}, []common.Utxo{utxo})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotPath != "/transactions/evaluate" {
+		t.Fatalf("path = %q, want /transactions/evaluate", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotApiKey != "project-id" {
+		t.Fatalf("api-key = %q, want project-id", gotApiKey)
+	}
+	var req maestroEvaluateRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("posted body is not valid JSON: %v", err)
+	}
+	if len(req.AdditionalUtxos) != 1 || req.AdditionalUtxos[0].TxHash != testTxHashHex {
+		t.Fatalf("unexpected additional_utxos in posted body: %+v", req.AdditionalUtxos)
+	}
+	spendKey := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	if eu := result[spendKey]; eu.Memory != 1700 || eu.Steps != 476468 {
+		t.Fatalf("unexpected spend budget %+v", eu)
+	}
+}
+
+func TestEvaluateTxEmptyAdditionalUtxosUsesSdkPath(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		utxos []common.Utxo
+	}{
+		{"nil", nil},
+		{"empty", []common.Utxo{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+				}
+				gotBody = body
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[{"ex_units":{"mem":10,"steps":20},"redeemer_index":0,"redeemer_tag":"spend"}]`))
+			}))
+			defer server.Close()
+
+			ctx, err := NewMaestroChainContextWithNetwork(0, "project-id", "preprod")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx.client.BaseUrl = server.URL
+
+			result, err := ctx.EvaluateTx([]byte{0x84}, tc.utxos)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The SDK EvaluateTx posts to /transactions/evaluate as well, so the
+			// path alone does not distinguish the two code paths. The SDK body
+			// serializes additional_utxos from a nil []string, which encodes as
+			// JSON null; the raw object-shaped path would instead emit an array.
+			// Asserting null proves the empty/nil slice took the SDK fallback.
+			if gotPath != "/transactions/evaluate" {
+				t.Fatalf("path = %q, want /transactions/evaluate", gotPath)
+			}
+			var sdkBody struct {
+				Cbor            string          `json:"cbor"`
+				AdditionalUtxos json.RawMessage `json:"additional_utxos"`
+			}
+			if err := json.Unmarshal(gotBody, &sdkBody); err != nil {
+				t.Fatalf("posted body is not valid JSON: %v", err)
+			}
+			if sdkBody.Cbor != "84" {
+				t.Fatalf("cbor = %q, want 84", sdkBody.Cbor)
+			}
+			if string(sdkBody.AdditionalUtxos) != "null" {
+				t.Fatalf("additional_utxos = %s, want null (SDK fallback path)", sdkBody.AdditionalUtxos)
+			}
+			spendKey := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+			if eu := result[spendKey]; eu.Memory != 10 || eu.Steps != 20 {
+				t.Fatalf("unexpected spend budget %+v", eu)
+			}
+		})
+	}
+}
+
+func TestEvaluateTxWithAdditionalUtxosPropagatesHTTPError(t *testing.T) {
+	var txId common.Blake2b256
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000000},
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"bad request"}`))
+	}))
+	defer server.Close()
+
+	ctx, err := NewMaestroChainContextWithNetwork(0, "project-id", "preprod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx.client.BaseUrl = server.URL
+
+	if _, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{utxo}); err == nil {
+		t.Fatal("expected error for non-200 evaluate response")
 	}
 }
 

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -13,6 +13,7 @@ import (
 	"github.com/SundaeSwap-finance/kugo"
 	ogmigo "github.com/SundaeSwap-finance/ogmigo/v6"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -142,14 +143,144 @@ func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) 
 	return result, nil
 }
 
-func (o *OgmiosChainContext) EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+func (o *OgmiosChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	ctx := context.Background()
 	txHex := hex.EncodeToString(txCbor)
-	resp, err := o.ogmios.EvaluateTx(ctx, txHex)
+	var resp *ogmigo.EvaluateTxResponse
+	var err error
+	if len(additionalUtxos) > 0 {
+		// Ogmios natively accepts a set of resolved UTxOs so it can evaluate
+		// inputs that are not yet visible on-chain.
+		sharedUtxos, convErr := commonUtxosToShared(additionalUtxos)
+		if convErr != nil {
+			return nil, convErr
+		}
+		resp, err = o.ogmios.EvaluateTxWithAdditionalUtxos(ctx, txHex, sharedUtxos)
+	} else {
+		resp, err = o.ogmios.EvaluateTx(ctx, txHex)
+	}
 	if err != nil {
 		return nil, err
 	}
 	return evaluateResponseToExUnits(resp)
+}
+
+// commonUtxosToShared converts resolved gouroboros UTxOs into the ogmigo
+// shared.Utxo wire form expected by EvaluateTxWithAdditionalUtxos.
+func commonUtxosToShared(utxos []common.Utxo) ([]shared.Utxo, error) {
+	result := make([]shared.Utxo, 0, len(utxos))
+	for _, utxo := range utxos {
+		su, err := commonUtxoToShared(utxo)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, su)
+	}
+	return result, nil
+}
+
+// commonUtxoToShared converts a single resolved gouroboros UTxO into an
+// ogmigo shared.Utxo. The value is encoded as Ogmios expects: the outer key is
+// "ada" (with inner key "lovelace") for the coin, and the policy ID hex (with
+// inner asset-name hex) for native assets.
+func commonUtxoToShared(utxo common.Utxo) (shared.Utxo, error) {
+	out := utxo.Output
+
+	coin, err := bigIntToNum(out.Amount())
+	if err != nil {
+		return shared.Utxo{}, fmt.Errorf("invalid lovelace amount: %w", err)
+	}
+	value := shared.Value{
+		shared.AdaPolicy: {
+			shared.AdaAsset: coin,
+		},
+	}
+	if assets := out.Assets(); assets != nil {
+		for _, policyId := range assets.Policies() {
+			policyHex := hex.EncodeToString(policyId.Bytes())
+			for _, assetName := range assets.Assets(policyId) {
+				qty, err := bigIntToNum(assets.Asset(policyId, assetName))
+				if err != nil {
+					return shared.Utxo{}, fmt.Errorf("invalid asset quantity for policy %s: %w", policyHex, err)
+				}
+				if value[policyHex] == nil {
+					value[policyHex] = map[string]num.Int{}
+				}
+				value[policyHex][hex.EncodeToString(assetName)] = qty
+			}
+		}
+	}
+
+	su := shared.Utxo{
+		Transaction: shared.UtxoTxID{ID: hex.EncodeToString(utxo.Id.Id().Bytes())},
+		Index:       utxo.Id.Index(),
+		Address:     out.Address().String(),
+		Value:       value,
+	}
+
+	// Datum: inline datum CBOR hex goes in Datum, a bare datum hash in DatumHash.
+	if datum := out.Datum(); datum != nil {
+		datumCbor, err := datum.MarshalCBOR()
+		if err != nil {
+			return shared.Utxo{}, fmt.Errorf("failed to encode inline datum: %w", err)
+		}
+		su.Datum = hex.EncodeToString(datumCbor)
+	} else if datumHash := out.DatumHash(); datumHash != nil {
+		su.DatumHash = hex.EncodeToString(datumHash.Bytes())
+	}
+
+	// Reference script: Ogmios expects {"language": ..., "cbor": ...}.
+	if script := out.ScriptRef(); script != nil {
+		scriptJSON, err := ogmiosScriptRefJSON(script)
+		if err != nil {
+			return shared.Utxo{}, err
+		}
+		su.Script = scriptJSON
+	}
+
+	return su, nil
+}
+
+// bigIntToNum converts a big.Int quantity into the ogmigo num.Int used by
+// shared.Value, preserving the full magnitude (no int64 truncation).
+func bigIntToNum(v *big.Int) (num.Int, error) {
+	if v == nil {
+		return num.Int64(0), nil
+	}
+	n, ok := num.New(v.String())
+	if !ok {
+		return num.Int{}, fmt.Errorf("cannot represent quantity %s", v.String())
+	}
+	return n, nil
+}
+
+// ogmiosScriptRefJSON encodes a reference script as the Ogmios script JSON
+// object ({"language": "plutus:vN"|"native", "cbor": "<hex>"}) matching the
+// shape consumed by ogmiosScriptToScriptRef.
+func ogmiosScriptRefJSON(script common.Script) (json.RawMessage, error) {
+	var language string
+	switch script.(type) {
+	case common.PlutusV1Script:
+		language = "plutus:v1"
+	case common.PlutusV2Script:
+		language = "plutus:v2"
+	case common.PlutusV3Script:
+		language = "plutus:v3"
+	case common.PlutusV4Script:
+		language = "plutus:v4"
+	case common.NativeScript:
+		language = "native"
+	default:
+		return nil, fmt.Errorf("unsupported reference script type %T", script)
+	}
+	payload := struct {
+		Language string `json:"language"`
+		Cbor     string `json:"cbor"`
+	}{
+		Language: language,
+		Cbor:     hex.EncodeToString(script.RawScriptBytes()),
+	}
+	return json.Marshal(payload)
 }
 
 // evaluateResponseToExUnits converts an ogmigo EvaluateTxResponse into a

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -4,16 +4,21 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SundaeSwap-finance/kugo"
 	ogmigo "github.com/SundaeSwap-finance/ogmigo/v6"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
 func testAddress(t *testing.T) common.Address {
@@ -214,5 +219,206 @@ func TestEvaluateResponseToExUnitsConvertsResults(t *testing.T) {
 	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
 	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
 		t.Fatalf("unexpected budget %+v", eu)
+	}
+}
+
+// sampleCommonUtxo builds a resolved gouroboros UTxO for additional-UTxO
+// conversion tests: a known tx ref, address, lovelace coin, one native asset,
+// and a PlutusV2 reference script.
+func sampleCommonUtxo(t *testing.T) common.Utxo {
+	t.Helper()
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x11
+	}
+	input := shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 3}
+
+	var policyId common.Blake2b224
+	for i := range policyId {
+		policyId[i] = 0xAB
+	}
+	assetName := []byte("TOKEN")
+	assetData := map[common.Blake2b224]map[cbor.ByteString]*big.Int{
+		policyId: {cbor.NewByteString(assetName): big.NewInt(42)},
+	}
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](assetData)
+
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount: mary.MaryTransactionOutputValue{
+			Amount: 1_500_000,
+			Assets: &ma,
+		},
+		TxOutScriptRef: &common.ScriptRef{
+			Type:   common.ScriptRefTypePlutusV2,
+			Script: common.PlutusV2Script([]byte{0x49, 0x48, 0x01, 0x00}),
+		},
+	}
+	return common.Utxo{Id: input, Output: &output}
+}
+
+func TestCommonUtxoToShared(t *testing.T) {
+	su, err := commonUtxoToShared(sampleCommonUtxo(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantTxID := strings.Repeat("11", 32)
+	if su.Transaction.ID != wantTxID {
+		t.Fatalf("transaction id = %q, want %q", su.Transaction.ID, wantTxID)
+	}
+	if su.Index != 3 {
+		t.Fatalf("index = %d, want 3", su.Index)
+	}
+	if su.Address != testAddress(t).String() {
+		t.Fatalf("address = %q, want %q", su.Address, testAddress(t).String())
+	}
+
+	// ADA must nest under "ada" -> "lovelace".
+	ada, ok := su.Value[shared.AdaPolicy]
+	if !ok {
+		t.Fatalf("value missing %q key: %+v", shared.AdaPolicy, su.Value)
+	}
+	if got := ada[shared.AdaAsset].String(); got != "1500000" {
+		t.Fatalf("lovelace = %s, want 1500000", got)
+	}
+
+	// Native asset must nest under policyHex -> assetNameHex.
+	policyHex := strings.Repeat("ab", 28)
+	assetNameHex := hex.EncodeToString([]byte("TOKEN"))
+	assets, ok := su.Value[policyHex]
+	if !ok {
+		t.Fatalf("value missing policy key %q: %+v", policyHex, su.Value)
+	}
+	if got := assets[assetNameHex].String(); got != "42" {
+		t.Fatalf("asset qty = %s, want 42", got)
+	}
+
+	// Reference script must serialize as {"language":"plutus:v2","cbor":...}.
+	if len(su.Script) == 0 {
+		t.Fatal("expected script to be set")
+	}
+	var script struct {
+		Language string `json:"language"`
+		Cbor     string `json:"cbor"`
+	}
+	if err := json.Unmarshal(su.Script, &script); err != nil {
+		t.Fatalf("script JSON unmarshal: %v", err)
+	}
+	if script.Language != "plutus:v2" {
+		t.Fatalf("script language = %q, want plutus:v2", script.Language)
+	}
+	if script.Cbor != hex.EncodeToString([]byte{0x49, 0x48, 0x01, 0x00}) {
+		t.Fatalf("script cbor = %q", script.Cbor)
+	}
+	if su.Datum != "" || su.DatumHash != "" {
+		t.Fatalf("unexpected datum fields: datum=%q datumHash=%q", su.Datum, su.DatumHash)
+	}
+}
+
+func TestCommonUtxoToSharedInlineDatum(t *testing.T) {
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x44
+	}
+	innerDatumCbor := []byte{0x01}
+	optCbor, err := cbor.Encode([]any{1, cbor.Tag{Number: 24, Content: innerDatumCbor}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var opt babbage.BabbageTransactionOutputDatumOption
+	if err := opt.UnmarshalCBOR(optCbor); err != nil {
+		t.Fatal(err)
+	}
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2_000_000},
+		DatumOption:   &opt,
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
+	}
+
+	su, err := commonUtxoToShared(utxo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if su.Datum != hex.EncodeToString(innerDatumCbor) {
+		t.Fatalf("datum = %q, want %q", su.Datum, hex.EncodeToString(innerDatumCbor))
+	}
+	if su.DatumHash != "" {
+		t.Fatalf("inline datum must not set DatumHash, got %q", su.DatumHash)
+	}
+	if len(su.Script) != 0 {
+		t.Fatalf("unexpected script: %s", su.Script)
+	}
+}
+
+func TestCommonUtxoToSharedHashOnlyDatum(t *testing.T) {
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x55
+	}
+	var datumHash common.Blake2b256
+	for i := range datumHash {
+		datumHash[i] = 0xEF
+	}
+	optCbor, err := cbor.Encode([]any{0, datumHash})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var opt babbage.BabbageTransactionOutputDatumOption
+	if err := opt.UnmarshalCBOR(optCbor); err != nil {
+		t.Fatal(err)
+	}
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2_000_000},
+		DatumOption:   &opt,
+	}
+	utxo := common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
+	}
+
+	su, err := commonUtxoToShared(utxo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if su.DatumHash != strings.Repeat("ef", 32) {
+		t.Fatalf("datumHash = %q, want %q", su.DatumHash, strings.Repeat("ef", 32))
+	}
+	if su.Datum != "" {
+		t.Fatalf("hash-only datum must not set Datum, got %q", su.Datum)
+	}
+}
+
+func TestOgmiosScriptRefJSONLanguageDetection(t *testing.T) {
+	raw := []byte{0x49, 0x48, 0x01, 0x00}
+	for _, tc := range []struct {
+		script   common.Script
+		language string
+	}{
+		{common.PlutusV1Script(raw), "plutus:v1"},
+		{common.PlutusV2Script(raw), "plutus:v2"},
+		{common.PlutusV3Script(raw), "plutus:v3"},
+		{common.PlutusV4Script(raw), "plutus:v4"},
+		{common.NativeScript{}, "native"},
+	} {
+		out, err := ogmiosScriptRefJSON(tc.script)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.language, err)
+		}
+		var parsed struct {
+			Language string `json:"language"`
+			Cbor     string `json:"cbor"`
+		}
+		if err := json.Unmarshal(out, &parsed); err != nil {
+			t.Fatalf("%s: unmarshal: %v", tc.language, err)
+		}
+		if parsed.Language != tc.language {
+			t.Fatalf("language = %q, want %q", parsed.Language, tc.language)
+		}
 	}
 }

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -289,7 +289,14 @@ func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 	return result, nil
 }
 
-func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+// EvaluateTx evaluates the scripts in a transaction. The additionalUtxos
+// argument is IGNORED: the utxorpc EvalTx schema (submit.EvalTxRequest) carries
+// only the raw transaction CBOR and has no field for additional/resolved
+// UTxOs. This backend can therefore only evaluate transactions whose inputs
+// are already visible on-chain to the provider and does NOT support evaluating
+// off-chain or chained inputs. Passing a non-empty additionalUtxos is not an
+// error, but those UTxOs have no effect.
+func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	req := connect.NewRequest(&submit.EvalTxRequest{
 		Tx: &submit.AnyChainTx{
 			Type: &submit.AnyChainTx_Raw{Raw: txCbor},

--- a/security_hardening_test.go
+++ b/security_hardening_test.go
@@ -288,7 +288,7 @@ type fakeEvalContext struct {
 	result map[common.RedeemerKey]common.ExUnits
 }
 
-func (f *fakeEvalContext) EvaluateTx(_ []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+func (f *fakeEvalContext) EvaluateTx(_ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	return f.result, nil
 }
 


### PR DESCRIPTION
## Summary

Adds support for supplying a resolved additional UTxO set to transaction
evaluation. `ChainContext.EvaluateTx` now takes `additionalUtxos []common.Utxo`,
letting script execution-unit evaluation resolve inputs the backend cannot see
on-chain (for example transaction chaining). The single call site in
`estimateExecutionUnits` passes the already canonical-sorted inputs.

## Per-backend behavior

- **ogmios**: forwards the additional UTxOs via ogmigo `EvaluateTxWithAdditionalUtxos`.
- **blockfrost**: switches to `POST /utils/txs/evaluate/utxos` with a JSON
  `{cbor, additionalUtxoSet}` body when extras are present (bare cbor endpoint
  otherwise). Scripts are encoded as raw bytes under `plutus:v1/v2/v3/v4`, datum
  hashes under `datumHash`; native scripts and out-of-range quantities are rejected.
- **maestro, utxorpc**: accept the parameter but ignore it (no support in the
  client / proto), documented as such.
- **fixed, cache**: signature and forwarding only.

## Tests

Offline request-shape tests for the blockfrost additional-UTxO JSON (endpoint,
content-type, script language detection, datum hash vs inline datum, overflow
rejection) and the ogmios `shared.Utxo` conversion. `go test ./...` and
`make test` (including `-race`) pass.
