### PR TITLE
feat: add Conway reference-script fee to min-fee calculation

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -1592,8 +1592,18 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 		return 0, err
 	}
 
-	// Build a dummy transaction to estimate size
-	body, err := a.buildBody(inputs, outputs, 0)
+	// Build a dummy transaction to estimate size. The fee field (body key 2) is
+	// `omitempty`, so a zero fee is dropped entirely and a non-trivial fee is
+	// encoded as a multi-byte integer. Sizing against a zero fee therefore
+	// undercounts the body by the width of the real fee field (up to ~5 bytes),
+	// producing a fee that is a few hundred lovelace short and a FeeTooSmallUTxO
+	// rejection. Use a placeholder fee whose CBOR width matches (or exceeds) the
+	// final fee so the size — and thus the fee — is not underestimated.
+	placeholderFee, feeErr := a.Context.MaxTxFee()
+	if feeErr != nil || placeholderFee == 0 {
+		placeholderFee = 2_000_000
+	}
+	body, err := a.buildBody(inputs, outputs, placeholderFee)
 	if err != nil {
 		return 0, err
 	}
@@ -1653,15 +1663,111 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 		fee += int64(exUnitFeeFloat)
 	}
 
+	// Add the Conway tiered reference-script fee. Scripts attached (via
+	// script_ref) to the outputs of the transaction's spending inputs AND
+	// reference inputs are priced per byte on a growing tier (native scripts
+	// included, not only Plutus). The ledger counts the union of regular and
+	// reference inputs regardless of whether the transaction executes scripts,
+	// so omitting it produces FeeTooSmallUTxO. The fee is naturally zero when no
+	// referenced UTxO carries a script.
+	refScriptSize, err := a.totalReferenceScriptSize(inputs)
+	if err != nil {
+		return 0, err
+	}
+	if refScriptSize > 0 {
+		// The transaction uses reference scripts, so the ledger charges the
+		// tiered reference-script fee. If the backend did not supply the base
+		// price, charging zero would silently underprice the transaction and
+		// produce a FeeTooSmallUTxO rejection at submission; fail loudly instead.
+		refFeePerByte := pp.RefScriptFeePerByte()
+		if refFeePerByte <= 0 {
+			return 0, fmt.Errorf(
+				"transaction uses %d bytes of reference scripts but the protocol parameters provide no reference-script price (min_fee_ref_script_cost_per_byte); cannot compute a correct minimum fee",
+				refScriptSize,
+			)
+		}
+		fee += backend.TierRefScriptFee(
+			refScriptSize,
+			refFeePerByte,
+			pp.RefScriptSizeIncrement(),
+			pp.RefScriptMultiplier(),
+		)
+	}
+
 	return fee, nil
+}
+
+// totalReferenceScriptSize resolves the combined byte size of all reference
+// scripts that the ledger prices into the reference-script fee. The ledger
+// counts the size of every script attached (via script_ref) to the outputs of
+// the transaction's spending inputs AND its reference inputs, including native
+// scripts (not only Plutus), so any non-nil script is sized. Duplicate input
+// references are de-duplicated (matching the ledger), but distinct outputs that
+// happen to carry identical scripts are each counted.
+//
+// Spending inputs are already resolved by the caller. Reference inputs are
+// resolved against the chain context; an undercounted size silently underprices
+// the fee and gets the tx rejected, so a reference input that fails to resolve
+// is a hard error.
+func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
+	seen := make(map[string]struct{})
+	total := 0
+
+	addScript := func(script common.Script) {
+		if script == nil {
+			return
+		}
+		total += len(script.RawScriptBytes())
+	}
+
+	// Spending inputs already resolved by the caller carry their outputs.
+	for _, utxo := range inputs {
+		ref := utxoRef(utxo)
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		addScript(utxo.Output.ScriptRef())
+	}
+
+	// Reference inputs must be resolved against the chain context.
+	for _, refInput := range a.referenceInputs {
+		ref := hex.EncodeToString(refInput.TxId.Bytes()) + "#" + strconv.Itoa(int(refInput.OutputIndex))
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		utxo, err := a.Context.UtxoByRef(refInput.TxId, refInput.OutputIndex)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"failed to resolve reference input %s for reference-script fee: %w",
+				ref, err,
+			)
+		}
+		if utxo == nil {
+			return 0, fmt.Errorf("reference input %s not found for reference-script fee", ref)
+		}
+		addScript(utxo.Output.ScriptRef())
+	}
+
+	return total, nil
 }
 
 // estimateExecutionUnits builds a preliminary transaction and evaluates it
 // against the chain to get actual execution units for script redeemers.
 // The returned ExUnits include a buffer for safety.
 func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) error {
-	// Build preliminary tx with current (possibly zero) ExUnits
-	body, err := a.buildBody(inputs, outputs, 0)
+	// Build preliminary tx with current (possibly zero) ExUnits. The fee field
+	// is `omitempty`, so a zero fee is dropped from the CBOR and the body has no
+	// fee (key 2). Strict evaluators (Ogmios, and Blockfrost which proxies it)
+	// reject such a body with "field fee with key 2, not decoded". Use a
+	// non-zero placeholder fee so the field is always present; its value does
+	// not affect script evaluation.
+	placeholderFee, feeErr := a.Context.MaxTxFee()
+	if feeErr != nil || placeholderFee == 0 {
+		placeholderFee = 2_000_000
+	}
+	body, err := a.buildBody(inputs, outputs, placeholderFee)
 	if err != nil {
 		return fmt.Errorf("failed to build preliminary tx body: %w", err)
 	}

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -1058,6 +1058,26 @@ func TestCompleteWithReferenceInputs(t *testing.T) {
 	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
 
 	hashHex := "aabb000000000000000000000000000000000000000000000000000000000000"
+	// Register the reference-input UTxOs so they resolve during fee estimation.
+	// They carry no reference script, so they contribute nothing to the
+	// reference-script fee; this only makes them resolvable (an unresolvable
+	// reference input is an invalid transaction on-chain).
+	hashBytes, err := hex.DecodeString(hashHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var refTxHash common.Blake2b256
+	copy(refTxHash[:], hashBytes)
+	for _, idx := range []uint32{0, 1} {
+		cc.AddUtxoByRef(common.Utxo{
+			Id: shelley.ShelleyTransactionInput{TxId: refTxHash, OutputIndex: idx},
+			Output: &babbage.BabbageTransactionOutput{
+				OutputAddress: addr,
+				OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5_000_000},
+			},
+		})
+	}
+
 	w := NewExternalWallet(addr)
 	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
 	if err != nil {
@@ -1088,6 +1108,63 @@ func TestCompleteWithReferenceInputs(t *testing.T) {
 	refInputs := tx.Body.TxReferenceInputs.Items()
 	if len(refInputs) != 2 {
 		t.Errorf("expected 2 reference inputs, got %d", len(refInputs))
+	}
+}
+
+// TestCompleteErrorsOnRefScriptWithoutPrice verifies that a transaction which
+// references a UTxO carrying a reference script fails fast when the protocol
+// parameters provide no reference-script price, rather than silently building
+// an underpriced transaction that the ledger would reject with FeeTooSmallUTxO.
+func TestCompleteErrorsOnRefScriptWithoutPrice(t *testing.T) {
+	// Fixed context whose params deliberately omit the reference-script price.
+	pp := backend.ProtocolParameters{
+		MinFeeConstant:      155381,
+		MinFeeCoefficient:   44,
+		MaxTxSize:           16384,
+		CoinsPerUtxoByte:    "4310",
+		CollateralPercent:   150,
+		MaxCollateralInputs: 3,
+		MaxValSize:          "5000",
+		KeyDeposits:         "2000000",
+		PoolDeposits:        "500000000",
+	}
+	cc := fixed.NewFixedChainContext(pp, backend.GenesisParameters{NetworkMagic: 1}, 0)
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	// Register a reference UTxO carrying a Plutus reference script.
+	hashHex := "ccdd000000000000000000000000000000000000000000000000000000000000"
+	hashBytes, err := hex.DecodeString(hashHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var refTxHash common.Blake2b256
+	copy(refTxHash[:], hashBytes)
+	cc.AddUtxoByRef(common.Utxo{
+		Id: shelley.ShelleyTransactionInput{TxId: refTxHash, OutputIndex: 0},
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: addr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5_000_000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV2,
+				Script: common.PlutusV2Script{0x01, 0x02, 0x03, 0x04},
+			},
+		},
+	})
+
+	w := NewExternalWallet(addr)
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).SetWallet(w).AddPayment(p).SetTtl(50000000)
+	a, err = a.AddReferenceInput(hashHex, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected error when reference script present but no ref-script price in params")
 	}
 }
 

--- a/backend/base.go
+++ b/backend/base.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -74,6 +75,103 @@ type ProtocolParameters struct {
 	MinFeeReferenceScriptsRange      int                `json:"min_fee_reference_scripts_range"`
 	MinFeeReferenceScriptsBase       int                `json:"min_fee_reference_scripts_base"`
 	MinFeeReferenceScriptsMultiplier int                `json:"min_fee_reference_scripts_multiplier"`
+	// MinFeeRefScriptCostPerByte is the BlockFrost/ledger flat name for the
+	// reference-script base price (lovelace per byte for the first tier). Some
+	// providers (e.g. BlockFrost) expose only this field and not the structured
+	// MinFeeReferenceScripts{Base,Range,Multiplier} triple. RefScriptFeePerByte()
+	// reconciles the two representations.
+	MinFeeRefScriptCostPerByte float64 `json:"min_fee_ref_script_cost_per_byte"`
+}
+
+// Conway reference-script fee tier constants. The ledger prices reference
+// scripts on a growing tier: the first SizeIncrement bytes cost the base
+// price per byte, and each subsequent tier of SizeIncrement bytes is priced
+// at the previous tier's price multiplied by Multiplier. These two values are
+// ledger constants (not surfaced by every provider), so they are defaulted
+// when a provider does not supply them.
+const (
+	DefaultRefScriptSizeIncrement = 25600
+	DefaultRefScriptMultiplier    = 1.2
+)
+
+// RefScriptFeePerByte returns the base reference-script price (lovelace per
+// byte for the first tier), preferring the structured MinFeeReferenceScriptsBase
+// when present and falling back to the flat MinFeeRefScriptCostPerByte.
+func (p ProtocolParameters) RefScriptFeePerByte() float64 {
+	if p.MinFeeReferenceScriptsBase > 0 {
+		return float64(p.MinFeeReferenceScriptsBase)
+	}
+	return p.MinFeeRefScriptCostPerByte
+}
+
+// RefScriptSizeIncrement returns the per-tier size increment, defaulting to the
+// Conway ledger constant when a provider does not supply it.
+func (p ProtocolParameters) RefScriptSizeIncrement() int {
+	if p.MinFeeReferenceScriptsRange > 0 {
+		return p.MinFeeReferenceScriptsRange
+	}
+	return DefaultRefScriptSizeIncrement
+}
+
+// RefScriptMultiplier returns the per-tier price multiplier, defaulting to the
+// Conway ledger constant when a provider does not supply it.
+func (p ProtocolParameters) RefScriptMultiplier() float64 {
+	if p.MinFeeReferenceScriptsMultiplier > 0 {
+		return float64(p.MinFeeReferenceScriptsMultiplier)
+	}
+	return DefaultRefScriptMultiplier
+}
+
+// TierRefScriptFee computes the Conway tiered reference-script fee for a total
+// reference-script byte size, matching the ledger's tierRefScriptFee function:
+//
+//	go acc curTierPrice n
+//	  | n < sizeIncrement = floor(acc + n*curTierPrice)
+//	  | otherwise         = go (acc + sizeIncrement*curTierPrice)
+//	                           (curTierPrice*multiplier) (n - sizeIncrement)
+//
+// with the first-tier price = baseFeePerByte. A zero base price yields a zero
+// fee (pre-Conway / provider that does not charge for reference scripts).
+//
+// The accumulation uses exact rational arithmetic and floors once at the end,
+// matching the ledger (which accumulates a Rational and applies floor). Using
+// float64 here would let the repeated multiplier product (1.2 is not exactly
+// representable in binary floating point) drift across an integer boundary on
+// multi-tier reference scripts, producing a fee 1 lovelace below the ledger
+// minimum and a FeeTooSmall rejection.
+func TierRefScriptFee(totalRefScriptSize int, baseFeePerByte float64, sizeIncrement int, multiplier float64) int64 {
+	if totalRefScriptSize <= 0 || baseFeePerByte <= 0 {
+		return 0
+	}
+	if sizeIncrement <= 0 {
+		sizeIncrement = DefaultRefScriptSizeIncrement
+	}
+	if multiplier <= 0 {
+		multiplier = DefaultRefScriptMultiplier
+	}
+	// Exact rationals. baseFeePerByte is an integer lovelace/byte in practice
+	// (15 at current params); the multiplier is the ledger constant 6/5. Recover
+	// it exactly from the float (1.2 -> 1200/1000 -> 6/5) so there is no drift.
+	base := new(big.Rat).SetFloat64(baseFeePerByte)
+	if base == nil { // NaN/Inf guard
+		return 0
+	}
+	m := big.NewRat(int64(math.Round(multiplier*1000)), 1000)
+	acc := new(big.Rat)
+	price := new(big.Rat).Set(base)
+	incr := new(big.Rat).SetInt64(int64(sizeIncrement))
+	n := totalRefScriptSize
+	for n >= sizeIncrement {
+		acc.Add(acc, new(big.Rat).Mul(incr, price))
+		price.Mul(price, m)
+		n -= sizeIncrement
+	}
+	if n > 0 {
+		acc.Add(acc, new(big.Rat).Mul(new(big.Rat).SetInt64(int64(n)), price))
+	}
+	// floor(acc): acc is non-negative, so integer division of num/denom truncates
+	// toward zero, i.e. floors.
+	return new(big.Int).Quo(acc.Num(), acc.Denom()).Int64()
 }
 
 // CoinsPerUtxoByteValue returns the coins per UTxO byte value parsed from the string field.

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -520,6 +520,10 @@ type bfProtocolParams struct {
 	MaxCollateralIn    int64           `json:"max_collateral_inputs"`
 	CoinsPerUtxoSize   string          `json:"coins_per_utxo_size"`
 	CostModels         json.RawMessage `json:"cost_models"`
+	// BlockFrost exposes the Conway reference-script base price under this flat
+	// key (lovelace per byte for the first tier); it does not return the
+	// structured min_fee_reference_scripts_{base,range,multiplier} triple.
+	MinFeeRefScriptCostPerByte float64 `json:"min_fee_ref_script_cost_per_byte"`
 }
 
 func (p *bfProtocolParams) toProtocolParams() (backend.ProtocolParameters, error) {
@@ -544,24 +548,25 @@ func (p *bfProtocolParams) toProtocolParams() (backend.ProtocolParameters, error
 		return backend.ProtocolParameters{}, err
 	}
 	pp := backend.ProtocolParameters{
-		MinFeeConstant:      p.MinFeeB,
-		MinFeeCoefficient:   p.MinFeeA,
-		MaxBlockSize:        maxBlockSize,
-		MaxTxSize:           maxTxSize,
-		MaxBlockHeaderSize:  maxBlockHeaderSize,
-		KeyDeposits:         p.KeyDeposit,
-		PoolDeposits:        p.PoolDeposit,
-		MinPoolCost:         p.MinPoolCost,
-		PriceMem:            p.PriceMem,
-		PriceStep:           p.PriceStep,
-		MaxTxExMem:          p.MaxTxExMem,
-		MaxTxExSteps:        p.MaxTxExSteps,
-		MaxBlockExMem:       p.MaxBlockExMem,
-		MaxBlockExSteps:     p.MaxBlockExSteps,
-		MaxValSize:          p.MaxValSize,
-		CollateralPercent:   collateralPercent,
-		MaxCollateralInputs: maxCollateralInputs,
-		CoinsPerUtxoByte:    p.CoinsPerUtxoSize,
+		MinFeeConstant:             p.MinFeeB,
+		MinFeeCoefficient:          p.MinFeeA,
+		MaxBlockSize:               maxBlockSize,
+		MaxTxSize:                  maxTxSize,
+		MaxBlockHeaderSize:         maxBlockHeaderSize,
+		KeyDeposits:                p.KeyDeposit,
+		PoolDeposits:               p.PoolDeposit,
+		MinPoolCost:                p.MinPoolCost,
+		PriceMem:                   p.PriceMem,
+		PriceStep:                  p.PriceStep,
+		MaxTxExMem:                 p.MaxTxExMem,
+		MaxTxExSteps:               p.MaxTxExSteps,
+		MaxBlockExMem:              p.MaxBlockExMem,
+		MaxBlockExSteps:            p.MaxBlockExSteps,
+		MaxValSize:                 p.MaxValSize,
+		CollateralPercent:          collateralPercent,
+		MaxCollateralInputs:        maxCollateralInputs,
+		CoinsPerUtxoByte:           p.CoinsPerUtxoSize,
+		MinFeeRefScriptCostPerByte: p.MinFeeRefScriptCostPerByte,
 	}
 
 	// Parse cost models from BlockFrost JSON.

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -297,3 +297,34 @@ func TestAddressUTxOToUtxoRejectsOutputIndexOverflow(t *testing.T) {
 		t.Fatal("expected output index overflow error")
 	}
 }
+
+// TestProtocolParamsParsesRefScriptCostPerByte verifies that the BlockFrost
+// min_fee_ref_script_cost_per_byte field is parsed into MinFeeRefScriptCostPerByte
+// and surfaced via RefScriptFeePerByte(), so the Conway reference-script fee is
+// actually charged (not silently zero) when BlockFrost supplies the price.
+func TestProtocolParamsParsesRefScriptCostPerByte(t *testing.T) {
+	const body = `{
+		"min_fee_a": 44,
+		"min_fee_b": 155381,
+		"max_tx_size": 16384,
+		"coins_per_utxo_size": "4310",
+		"collateral_percent": 150,
+		"max_collateral_inputs": 3,
+		"min_fee_ref_script_cost_per_byte": 15
+	}`
+
+	var raw bfProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	pp, err := raw.toProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := pp.MinFeeRefScriptCostPerByte; got != 15 {
+		t.Fatalf("MinFeeRefScriptCostPerByte = %v, want 15", got)
+	}
+	if got := pp.RefScriptFeePerByte(); got != 15 {
+		t.Fatalf("RefScriptFeePerByte() = %v, want 15", got)
+	}
+}

--- a/backend/fixed/fixed.go
+++ b/backend/fixed/fixed.go
@@ -1,7 +1,9 @@
 package fixed
 
 import (
+	"encoding/hex"
 	"errors"
+	"strconv"
 	"sync"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -17,6 +19,7 @@ type FixedChainContext struct {
 	networkId      uint8
 	mu             sync.RWMutex
 	utxos          map[string][]common.Utxo // keyed by address string
+	utxosByRef     map[string]common.Utxo   // keyed by "txid#index"
 }
 
 // NewFixedChainContext creates a new FixedChainContext with the given protocol parameters.
@@ -26,25 +29,28 @@ func NewFixedChainContext(pp backend.ProtocolParameters, gp backend.GenesisParam
 		genesisParams:  gp,
 		networkId:      networkId,
 		utxos:          make(map[string][]common.Utxo),
+		utxosByRef:     make(map[string]common.Utxo),
 	}
 }
 
 // NewEmptyFixedChainContext creates a FixedChainContext with default preprod parameters.
 func NewEmptyFixedChainContext() *FixedChainContext {
 	pp := backend.ProtocolParameters{
-		MinFeeConstant:    155381,
-		MinFeeCoefficient: 44,
-		MaxTxSize:         16384,
-		CoinsPerUtxoByte:  "4310",
-		CollateralPercent: 150,
+		MinFeeConstant:      155381,
+		MinFeeCoefficient:   44,
+		MaxTxSize:           16384,
+		CoinsPerUtxoByte:    "4310",
+		CollateralPercent:   150,
 		MaxCollateralInputs: 3,
-		MaxValSize:        "5000",
-		PriceMem:          0.0577,
-		PriceStep:         0.0000721,
-		MaxTxExMem:        "14000000",
-		MaxTxExSteps:      "10000000000",
-		KeyDeposits:       "2000000",
-		PoolDeposits:      "500000000",
+		MaxValSize:          "5000",
+		PriceMem:            0.0577,
+		PriceStep:           0.0000721,
+		MaxTxExMem:          "14000000",
+		MaxTxExSteps:        "10000000000",
+		KeyDeposits:         "2000000",
+		PoolDeposits:        "500000000",
+		// Conway reference-script base price (lovelace per byte), current value.
+		MinFeeRefScriptCostPerByte: 15,
 	}
 	gp := backend.GenesisParameters{
 		NetworkMagic: 1,
@@ -52,12 +58,28 @@ func NewEmptyFixedChainContext() *FixedChainContext {
 	return NewFixedChainContext(pp, gp, 0)
 }
 
-// AddUtxo adds a UTxO to the fixed context for the given address.
+// AddUtxo adds a UTxO to the fixed context for the given address. It is also
+// registered for resolution by reference (UtxoByRef), so it can be used as a
+// reference input.
 func (f *FixedChainContext) AddUtxo(addr common.Address, utxo common.Utxo) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	key := addr.String()
 	f.utxos[key] = append(f.utxos[key], utxo)
+	f.utxosByRef[utxoRefKey(utxo.Id.Id(), utxo.Id.Index())] = utxo
+}
+
+// AddUtxoByRef registers a UTxO for resolution by reference (UtxoByRef) only,
+// without adding it to any address's spendable UTxO set. Useful for reference
+// inputs, which are read but not spent.
+func (f *FixedChainContext) AddUtxoByRef(utxo common.Utxo) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.utxosByRef[utxoRefKey(utxo.Id.Id(), utxo.Id.Index())] = utxo
+}
+
+func utxoRefKey(txHash common.Blake2b256, index uint32) string {
+	return hex.EncodeToString(txHash.Bytes()) + "#" + strconv.Itoa(int(index))
 }
 
 func (f *FixedChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
@@ -115,8 +137,14 @@ func (f *FixedChainContext) EvaluateTx(_ []byte) (map[common.RedeemerKey]common.
 	return nil, errors.New("cannot evaluate tx with fixed chain context")
 }
 
-func (f *FixedChainContext) UtxoByRef(_ common.Blake2b256, _ uint32) (*common.Utxo, error) {
-	return nil, errors.New("not implemented in fixed chain context")
+func (f *FixedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if utxo, ok := f.utxosByRef[utxoRefKey(txHash, index)]; ok {
+		u := utxo
+		return &u, nil
+	}
+	return nil, errors.New("utxo not found in fixed chain context")
 }
 
 func (f *FixedChainContext) ScriptCbor(_ common.Blake2b224) ([]byte, error) {

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -244,6 +244,15 @@ type ogmiosProtocolParams struct {
 	MaxBlockExUnits    ogmiosExUnits   `json:"maxExecutionUnitsPerBlock"`
 	MinUtxoDeposit     int64           `json:"minUtxoDepositCoefficient"`
 	CostModels         json.RawMessage `json:"plutusCostModels"`
+	// Ogmios v6 exposes Conway reference-script pricing as a structured object
+	// {base, range, multiplier}; base is the lovelace-per-byte first-tier price.
+	MinFeeReferenceScripts *ogmiosRefScripts `json:"minFeeReferenceScripts"`
+}
+
+type ogmiosRefScripts struct {
+	Base       float64 `json:"base"`
+	Range      int     `json:"range"`
+	Multiplier float64 `json:"multiplier"`
 }
 
 type ogmiosLovelace struct {
@@ -293,6 +302,17 @@ func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, e
 		CollateralPercent:   p.CollateralPercent,
 		MaxCollateralInputs: p.MaxCollateral,
 		CoinsPerUtxoByte:    strconv.FormatInt(p.MinUtxoDeposit, 10),
+	}
+
+	if p.MinFeeReferenceScripts != nil {
+		// Only the base price (lovelace per byte) is provider-specific; the
+		// per-tier size increment and multiplier are the Conway ledger constants
+		// (25600 and 6/5). The multiplier is fractional (1.2), so it cannot be
+		// stored in the integer MinFeeReferenceScriptsMultiplier field without
+		// truncating to 1 and undercharging every tier after the first; we
+		// therefore leave it (and the increment) to RefScriptMultiplier() /
+		// RefScriptSizeIncrement() defaults.
+		pp.MinFeeRefScriptCostPerByte = p.MinFeeReferenceScripts.Base
 	}
 
 	// Parse cost models from Ogmios JSON.

--- a/backend/tier_ref_script_fee_test.go
+++ b/backend/tier_ref_script_fee_test.go
@@ -1,0 +1,69 @@
+package backend
+
+import (
+	"math/big"
+	"testing"
+)
+
+// exactTierRefScriptFee is an independent exact-rational implementation of the
+// ledger's tierRefScriptFee (multiplier as the exact rational mulNum/mulDen),
+// used as the oracle for TierRefScriptFee.
+func exactTierRefScriptFee(size int, base float64, incr int, mulNum, mulDen int64) int64 {
+	if size <= 0 || base <= 0 {
+		return 0
+	}
+	b := new(big.Rat).SetFloat64(base)
+	m := big.NewRat(mulNum, mulDen)
+	acc := new(big.Rat)
+	price := new(big.Rat).Set(b)
+	n := size
+	for n >= incr {
+		acc.Add(acc, new(big.Rat).Mul(new(big.Rat).SetInt64(int64(incr)), price))
+		price.Mul(price, m)
+		n -= incr
+	}
+	if n > 0 {
+		acc.Add(acc, new(big.Rat).Mul(new(big.Rat).SetInt64(int64(n)), price))
+	}
+	return new(big.Int).Quo(acc.Num(), acc.Denom()).Int64()
+}
+
+// TierRefScriptFee must equal the exact ledger value (floor of the exact
+// rational accumulation) for all sizes, including multi-tier.
+func TestTierRefScriptFeeIsExact(t *testing.T) {
+	const base = 15.0
+	const incr = DefaultRefScriptSizeIncrement // 25600
+	const mul = DefaultRefScriptMultiplier     // 1.2
+	for _, s := range []int{1, 100, 5000, 25599, 25600, 25601, 51200, 76800, 80000, 128000, 200000, 250880, 333333} {
+		got := TierRefScriptFee(s, base, incr, mul)
+		want := exactTierRefScriptFee(s, base, incr, 6, 5)
+		if got != want {
+			t.Errorf("TierRefScriptFee(%d) = %d, want exact %d", s, got, want)
+		}
+	}
+}
+
+// For a single tier (size < increment) with an integer base price, the fee is
+// exactly size*base.
+func TestTierRefScriptFeeSingleTierLinear(t *testing.T) {
+	const base = 15.0
+	for _, s := range []int{1, 1000, 5000, 25599} {
+		if got, want := TierRefScriptFee(s, base, DefaultRefScriptSizeIncrement, DefaultRefScriptMultiplier), int64(s)*15; got != want {
+			t.Errorf("single-tier TierRefScriptFee(%d) = %d, want %d", s, got, want)
+		}
+	}
+}
+
+// Dense sweep across the multi-tier regime (1..50 tiers): the rational
+// implementation must equal the exact ledger oracle for every size, with no
+// float drift able to push the floor below the ledger minimum.
+func TestTierRefScriptFeeExactAcrossTiers(t *testing.T) {
+	const base = 15.0
+	const incr = DefaultRefScriptSizeIncrement
+	const mul = DefaultRefScriptMultiplier
+	for s := 1; s <= 50*incr; s += 97 {
+		if got, want := TierRefScriptFee(s, base, incr, mul), exactTierRefScriptFee(s, base, incr, 6, 5); got != want {
+			t.Fatalf("TierRefScriptFee(%d) = %d, want exact %d", s, got, want)
+		}
+	}
+}

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -178,6 +178,12 @@ func (u *UtxoRpcChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 		}
 	}
 
+	// Conway reference-script base price (lovelace per byte for the first tier),
+	// exposed as a rational number.
+	if refCost := params.GetMinFeeScriptRefCostPerByte(); refCost != nil && refCost.GetDenominator() != 0 {
+		pp.MinFeeRefScriptCostPerByte = float64(refCost.GetNumerator()) / float64(refCost.GetDenominator())
+	}
+
 	// Parse cost models from UTxO RPC protobuf response.
 	// Keys match ComputeScriptDataHash expectations: "PlutusV1", "PlutusV2", "PlutusV3".
 	if cm := params.GetCostModels(); cm != nil {


### PR DESCRIPTION
## Summary

apollo v2 already carries the Conway reference-script protocol parameters (`MinFeeReferenceScripts{Base,Range,Multiplier}`), but the minimum-fee calculation in `estimateFee` never includes the Conway tiered reference-script fee. As a result, any transaction that uses reference scripts is underpriced and rejected on submission with `FeeTooSmallUTxO`.

This PR adds that fee. It is scoped to fee calculation only.

## What it does

- Adds `TierRefScriptFee` (in `backend`), matching the cardano-ledger `tierRefScriptFee`: the first `range` bytes are priced at the base per-byte price, each subsequent tier is multiplied by the multiplier, accumulation is done in **exact rationals** and floored once at the end. This avoids float drift across an integer boundary (1.2 is not exactly representable in binary floating point) that would otherwise produce a fee 1 lovelace below the ledger minimum on multi-tier scripts. Defaults to the Conway ledger constants (`25600`-byte tiers, `6/5` multiplier) when a provider does not supply them.
- `estimateFee` now sizes the combined byte length of every reference script attached (via `script_ref`) to the outputs of the transaction's spending inputs **and** reference inputs, including native scripts, de-duplicating duplicate input references (matching the ledger). It then adds `TierRefScriptFee(...)`.
- Fails loudly when a transaction uses reference scripts but the protocol parameters provide no per-byte price, instead of silently building an underpriced transaction.
- Wires the per-byte base price from the backends that expose it: BlockFrost (`min_fee_ref_script_cost_per_byte`), Ogmios (`minFeeReferenceScripts.base`), and UTxORPC (`minFeeScriptRefCostPerByte`).

## Placeholder fee fix

`estimateFee` and `estimateExecutionUnits` build their dummy / evaluation transaction body with a non-zero placeholder fee instead of `0`. The body fee field (key 2) is `omitempty`, so a zero fee is dropped from the CBOR entirely: this undersizes the fee estimate by the width of the real fee field, and makes strict evaluators (Ogmios, and Blockfrost which proxies it) reject the evaluation body with `field fee with key 2, not decoded`. The placeholder value does not affect script evaluation.

## Tests

- Exactness/oracle tests for `TierRefScriptFee` against an independent exact-rational implementation, including dense multi-tier sweeps and tier boundaries.
- A parse-path test proving the BlockFrost price is surfaced through `RefScriptFeePerByte()`.
- A regression test for the hard-error path when a reference script is present but no price is configured.

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` are clean and `go test ./...` passes (network-gated backend tests aside).
