### PR TITLE
feat: allow a wallet UTxO to be both spending input and collateral

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -1205,6 +1205,12 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	if err != nil {
 		if a.releaseCollateralForOverlap() {
 			selectedUtxos, err = a.selectCoins(selectionTarget, totalInput)
+			if err != nil {
+				// The overlap retry also failed. Restore the collateral
+				// reservation and clear the overlap flag so a subsequent
+				// Complete() on this builder starts from consistent state.
+				a.restoreCollateralReservation()
+			}
 		}
 		if err != nil {
 			return a, fmt.Errorf("coin selection failed: %w", err)
@@ -1379,6 +1385,13 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		if a.Fee > 0 {
 			converged = true
 			break
+		}
+		// Size the collateral against the current fee BEFORE re-estimating, so
+		// the fee accounts for the final collateral total/return footprint in
+		// the body. A collateral_return that only materializes after sizing
+		// would otherwise grow the tx past the frozen estimate.
+		if err := a.finalizeCollateral(fee); err != nil {
+			return a, err
 		}
 		newFee, err := a.estimateFee(allInputUtxos, outputs)
 		if err != nil {
@@ -2420,15 +2433,29 @@ func (a *Apollo) setCollateral() error {
 		}
 	}
 
-	// First pass: prefer a pure-lovelace UTxO (no assets).
-	for _, utxo := range candidates {
+	// First pass: prefer a pure-lovelace UTxO (no assets). Among eligible
+	// candidates, choose the SMALLEST: reserving the smallest dedicated
+	// collateral leaves the larger UTxOs available to coin selection, which
+	// minimizes the chance the reservation starves spending and forces an
+	// overlap. (On starvation Complete() still falls back to overlap.)
+	var bestIdx = -1
+	var bestLovelace int64
+	for i, utxo := range candidates {
 		if a.isUsed(utxoRef(utxo)) {
 			continue
 		}
-		if collateralEligible(utxo, true) {
-			selectCollateral(utxo)
-			return nil
+		if !collateralEligible(utxo, true) {
+			continue
 		}
+		lovelace := utxo.Output.Amount().Int64()
+		if bestIdx == -1 || lovelace < bestLovelace {
+			bestIdx = i
+			bestLovelace = lovelace
+		}
+	}
+	if bestIdx != -1 {
+		selectCollateral(candidates[bestIdx])
+		return nil
 	}
 	// Second pass: a UTxO that may carry assets.
 	for _, utxo := range candidates {
@@ -2461,6 +2488,19 @@ func (a *Apollo) releaseCollateralForOverlap() bool {
 	return true
 }
 
+// restoreCollateralReservation reverses releaseCollateralForOverlap: it re-marks
+// the released collateral UTxO as used and clears the overlap flag. It is called
+// when the overlap retry still fails, so the builder is left in the same state
+// it had before the release and a subsequent Complete() is not skewed by a
+// half-applied overlap.
+func (a *Apollo) restoreCollateralReservation() {
+	if a.collateralOverlapRef == "" {
+		return
+	}
+	a.markUsed(a.collateralOverlapRef)
+	a.collateralOverlapRef = ""
+}
+
 // finalizeCollateral recomputes the total collateral and the collateral-return
 // output from the final transaction fee. The ledger requires
 //
@@ -2480,7 +2520,7 @@ func (a *Apollo) releaseCollateralForOverlap() bool {
 // inputs (AddCollateral) or an explicit amount (SetCollateralAmount), the
 // sizing is intentional and left untouched.
 func (a *Apollo) finalizeCollateral(fee int64) error {
-	if len(a.collaterals) == 0 || !a.collateralAutoSelected || a.collateralAmount > 0 {
+	if len(a.collaterals) == 0 {
 		return nil
 	}
 	pp, err := a.Context.ProtocolParams()
@@ -2496,6 +2536,21 @@ func (a *Apollo) finalizeCollateral(fee int64) error {
 	// Ceil division: ceil(fee * percent / 100).
 	required := (fee*int64(pp.CollateralPercent) + 99) / 100
 	if required <= 0 {
+		return nil
+	}
+
+	// Caller-pinned sizing (explicit SetCollateralAmount, or a fully manual
+	// AddCollateral with an explicit total_collateral) is not rewritten - the
+	// caller asked for a specific value. But it is still ledger-validated: an
+	// explicit total below the required minimum would build an invalid tx, so
+	// surface that as a clear error instead of silently shipping it.
+	if !a.collateralAutoSelected || a.collateralAmount > 0 {
+		if a.totalCollateral > 0 && a.totalCollateral < required {
+			return fmt.Errorf(
+				"insufficient collateral: total_collateral %d is below the required %d (ceil(fee %d * %d%%))",
+				a.totalCollateral, required, fee, pp.CollateralPercent,
+			)
+		}
 		return nil
 	}
 
@@ -2609,6 +2664,16 @@ func (a *Apollo) validateCollateral() error {
 			return fmt.Errorf("duplicate collateral input %s", ref)
 		}
 		seen[ref] = struct{}{}
+		// Collateral must be vkey-locked: the ledger rejects collateral at a
+		// script address. Auto-selection already filters on this, but
+		// caller-pinned collateral (AddCollateral) is validated here so a
+		// script-address UTxO never reaches the body.
+		if out := collateral.Output; out != nil {
+			if addr := out.Address(); addr.Type() != common.AddressTypeKeyKey &&
+				addr.Type() != common.AddressTypeKeyNone {
+				return fmt.Errorf("collateral input %s is not vkey-locked (script-address collateral is rejected by the ledger)", ref)
+			}
+		}
 	}
 	// Enforce the protocol max on collateral inputs when known.
 	if pp, err := a.Context.ProtocolParams(); err == nil && pp.MaxCollateralInputs > 0 &&

--- a/apollo.go
+++ b/apollo.go
@@ -1428,32 +1428,6 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, err
 	}
 
-	// Guard the non-converged escape: if the loop exhausted its iterations the
-	// fee was frozen before collateral was finalized against it, so the final
-	// collateral footprint could nudge the real min fee above the frozen value.
-	// Re-estimate once against the finalized body; if it is higher, raise the
-	// fee, rebuild outputs and re-finalize collateral so the body is consistent.
-	if !a.forceFee && a.Fee == 0 {
-		checkFee, err := a.estimateFee(allInputUtxos, outputs)
-		if err != nil {
-			return a, fmt.Errorf("final fee verification failed: %w", err)
-		}
-		checkFee += a.FeePadding
-		if checkFee < 0 {
-			checkFee = 0
-		}
-		if checkFee > fee {
-			fee = checkFee
-			outputs, err = buildOutputsWithChange(fee)
-			if err != nil {
-				return a, err
-			}
-			if err := a.finalizeCollateral(fee); err != nil {
-				return a, err
-			}
-		}
-	}
-
 	// Build transaction body
 	body, err := a.buildBody(allInputUtxos, outputs, uint64(fee))
 	if err != nil {
@@ -2675,7 +2649,17 @@ func (a *Apollo) finalizeCollateral(fee int64) error {
 			a.collateralReturn = &ret
 			return nil
 		}
-		// Dust remainder: absorb into total_collateral, no return.
+		// Dust remainder below min-ADA. For an explicitly requested amount we may
+		// not silently raise total_collateral (that would forfeit the dust on
+		// failure and exceed what the caller asked for); reject instead. Only the
+		// auto-sized path is free to absorb the dust into total_collateral.
+		if a.collateralAmount > 0 {
+			return fmt.Errorf(
+				"requested collateral amount %d leaves a %d lovelace return below the %d min-ADA; choose an amount that leaves no return or at least min-ADA",
+				required, remainder, minReturn,
+			)
+		}
+		// Auto-sized dust remainder: absorb into total_collateral, no return.
 		a.totalCollateral = totalLovelace
 		a.collateralReturn = nil
 		return nil

--- a/apollo.go
+++ b/apollo.go
@@ -1428,6 +1428,32 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, err
 	}
 
+	// Guard the non-converged escape: if the loop exhausted its iterations the
+	// fee was frozen before collateral was finalized against it, so the final
+	// collateral footprint could nudge the real min fee above the frozen value.
+	// Re-estimate once against the finalized body; if it is higher, raise the
+	// fee, rebuild outputs and re-finalize collateral so the body is consistent.
+	if !a.forceFee && a.Fee == 0 {
+		checkFee, err := a.estimateFee(allInputUtxos, outputs)
+		if err != nil {
+			return a, fmt.Errorf("final fee verification failed: %w", err)
+		}
+		checkFee += a.FeePadding
+		if checkFee < 0 {
+			checkFee = 0
+		}
+		if checkFee > fee {
+			fee = checkFee
+			outputs, err = buildOutputsWithChange(fee)
+			if err != nil {
+				return a, err
+			}
+			if err := a.finalizeCollateral(fee); err != nil {
+				return a, err
+			}
+		}
+	}
+
 	// Build transaction body
 	body, err := a.buildBody(allInputUtxos, outputs, uint64(fee))
 	if err != nil {
@@ -2433,29 +2459,18 @@ func (a *Apollo) setCollateral() error {
 		}
 	}
 
-	// First pass: prefer a pure-lovelace UTxO (no assets). Among eligible
-	// candidates, choose the SMALLEST: reserving the smallest dedicated
-	// collateral leaves the larger UTxOs available to coin selection, which
-	// minimizes the chance the reservation starves spending and forces an
-	// overlap. (On starvation Complete() still falls back to overlap.)
-	var bestIdx = -1
-	var bestLovelace int64
-	for i, utxo := range candidates {
+	// First pass: prefer a pure-lovelace UTxO (no assets). Selection keeps the
+	// first-eligible candidate so a multi-UTxO wallet produces the same tx shape
+	// as before this change; the overlap fallback in Complete() handles the case
+	// where reserving a dedicated collateral starves coin selection.
+	for _, utxo := range candidates {
 		if a.isUsed(utxoRef(utxo)) {
 			continue
 		}
-		if !collateralEligible(utxo, true) {
-			continue
+		if collateralEligible(utxo, true) {
+			selectCollateral(utxo)
+			return nil
 		}
-		lovelace := utxo.Output.Amount().Int64()
-		if bestIdx == -1 || lovelace < bestLovelace {
-			bestIdx = i
-			bestLovelace = lovelace
-		}
-	}
-	if bestIdx != -1 {
-		selectCollateral(candidates[bestIdx])
-		return nil
 	}
 	// Second pass: a UTxO that may carry assets.
 	for _, utxo := range candidates {
@@ -2501,24 +2516,32 @@ func (a *Apollo) restoreCollateralReservation() {
 	a.collateralOverlapRef = ""
 }
 
-// finalizeCollateral recomputes the total collateral and the collateral-return
-// output from the final transaction fee. The ledger requires
+// finalizeCollateral sizes and validates the total collateral and the
+// collateral-return output against the final transaction fee. The ledger
+// requires
 //
 //	totalCollateral >= ceil(fee * collateralPercent / 100)
 //
 // computed against the ACTUAL fee. setCollateral() only had a preliminary
 // (max-by-size) fee available, so its sizing is stale once coin selection and
-// fee estimation have run. We keep the collateral UTxO(s) it selected and only
-// resize the total and the return here.
+// fee estimation have run.
 //
 // The computation uses the collateral inputs' value ALONE: on phase-2 script
 // failure only the collateral is consumed, so collateral_return = (collateral
 // input ADA - total_collateral) plus all native assets on the collateral. This
 // never touches the success-path input/output/fee balance.
 //
-// Only auto-selected collateral is resized. If the caller pinned the collateral
-// inputs (AddCollateral) or an explicit amount (SetCollateralAmount), the
-// sizing is intentional and left untouched.
+// Three modes:
+//   - auto-selected, no explicit amount: total/return are (re)computed from the
+//     final fee.
+//   - explicit SetCollateralAmount: total_collateral is pinned to the requested
+//     amount (raised to the ledger minimum if the caller asked for too little is
+//     rejected rather than silently bumped), and the return is recomputed so the
+//     requested amount is actually emitted in the body.
+//   - fully manual AddCollateral with no amount: the sizing is left to the
+//     ledger's implicit "all collateral inputs" rule, but it is still validated
+//     so an under-funded or asset-stranding collateral set is rejected locally
+//     rather than built into an invalid tx.
 func (a *Apollo) finalizeCollateral(fee int64) error {
 	if len(a.collaterals) == 0 {
 		return nil
@@ -2539,23 +2562,8 @@ func (a *Apollo) finalizeCollateral(fee int64) error {
 		return nil
 	}
 
-	// Caller-pinned sizing (explicit SetCollateralAmount, or a fully manual
-	// AddCollateral with an explicit total_collateral) is not rewritten - the
-	// caller asked for a specific value. But it is still ledger-validated: an
-	// explicit total below the required minimum would build an invalid tx, so
-	// surface that as a clear error instead of silently shipping it.
-	if !a.collateralAutoSelected || a.collateralAmount > 0 {
-		if a.totalCollateral > 0 && a.totalCollateral < required {
-			return fmt.Errorf(
-				"insufficient collateral: total_collateral %d is below the required %d (ceil(fee %d * %d%%))",
-				a.totalCollateral, required, fee, pp.CollateralPercent,
-			)
-		}
-		return nil
-	}
-
-	// Sum the lovelace and assets across the selected collateral inputs so the
-	// collateral return can carry the remainder (and any tokens) forward.
+	// Sum the lovelace and assets across the collateral inputs so the collateral
+	// return can carry the remainder (and any tokens) forward.
 	var totalLovelace int64
 	var collateralAssets *common.MultiAsset[common.MultiAssetTypeOutput]
 	hasAssets := false
@@ -2581,9 +2589,44 @@ func (a *Apollo) finalizeCollateral(fee int64) error {
 
 	if required > totalLovelace {
 		return fmt.Errorf(
-			"insufficient collateral: need %d lovelace (ceil(fee %d * %d%%)), selected collateral holds %d",
+			"insufficient collateral: need %d lovelace (ceil(fee %d * %d%%)), collateral inputs hold %d",
 			required, fee, pp.CollateralPercent, totalLovelace,
 		)
+	}
+
+	// Fully manual collateral with no explicit amount: the caller pinned the
+	// inputs and did not ask for a specific total_collateral, so leave the body
+	// untouched (the ledger consumes the whole collateral set on failure). Still
+	// validate: the implicit collateral cannot carry assets forward without a
+	// collateral return, so asset-bearing manual collateral must be rejected.
+	if !a.collateralAutoSelected && a.collateralAmount == 0 {
+		if hasAssets {
+			return errors.New(
+				"manual collateral carries native assets but no collateral return is set; " +
+					"set a collateral amount/return or use ADA-only collateral",
+			)
+		}
+		return nil
+	}
+
+	// Explicit SetCollateralAmount: honor the requested total_collateral (it must
+	// still meet the ledger minimum and fit within the collateral inputs). This
+	// raises the effective total above `required` when the caller wants a larger
+	// margin; a request below the minimum is rejected rather than silently bumped.
+	if a.collateralAmount > 0 {
+		if a.collateralAmount < required {
+			return fmt.Errorf(
+				"insufficient collateral: requested amount %d is below the required %d (ceil(fee %d * %d%%))",
+				a.collateralAmount, required, fee, pp.CollateralPercent,
+			)
+		}
+		if a.collateralAmount > totalLovelace {
+			return fmt.Errorf(
+				"requested collateral amount %d exceeds collateral inputs %d",
+				a.collateralAmount, totalLovelace,
+			)
+		}
+		required = a.collateralAmount
 	}
 
 	remainder := totalLovelace - required

--- a/apollo.go
+++ b/apollo.go
@@ -54,6 +54,20 @@ type Apollo struct {
 	totalCollateral    int64
 	referenceInputs    []shelley.ShelleyTransactionInput
 	collateralReturn   *babbage.BabbageTransactionOutput
+	// collateralOverlapRef holds the ref of an auto-selected collateral UTxO
+	// that is also allowed to serve as a regular spending input. It is set only
+	// when no dedicated (separate) collateral UTxO was available, so wallets
+	// with a single UTxO can still build script transactions. The Cardano ledger
+	// permits this overlap because collateral is consumed only on phase-2 script
+	// failure and regular inputs only on success - the two paths are mutually
+	// exclusive. When empty, collateral is reserved out of the coin-selection
+	// pool as usual.
+	collateralOverlapRef string
+	// collateralAutoSelected is true when setCollateral() chose the collateral
+	// inputs itself (rather than the caller pinning them via AddCollateral).
+	// Only auto-selected collateral is resized by finalizeCollateral(), so
+	// caller-pinned collateral is never silently rewritten.
+	collateralAutoSelected bool
 	nativescripts      []common.NativeScript
 	usedUtxos          map[string]bool
 	wallet             Wallet
@@ -934,9 +948,11 @@ func (a *Apollo) Clone() *Apollo {
 		forceFee:           a.forceFee,
 		Ttl:                a.Ttl,
 		ValidityStart:      a.ValidityStart,
-		totalCollateral:    a.totalCollateral,
-		collateralAmount:   a.collateralAmount,
-		currentTreasury:    a.currentTreasury,
+		totalCollateral:      a.totalCollateral,
+		collateralAmount:       a.collateralAmount,
+		collateralOverlapRef:   a.collateralOverlapRef,
+		collateralAutoSelected: a.collateralAutoSelected,
+		currentTreasury:        a.currentTreasury,
 		treasuryDonation:   a.treasuryDonation,
 		estimateExUnits:    a.estimateExUnits,
 		wallet:             a.wallet,
@@ -1180,10 +1196,19 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		}
 	}
 
-	// Coin selection
+	// Coin selection. setCollateral() reserves an auto-selected collateral UTxO
+	// out of the pool so multi-UTxO wallets keep a separate collateral and an
+	// unchanged tx shape. If that reservation starves selection (e.g. a wallet
+	// with a single UTxO), release the collateral for overlap - the ledger lets
+	// one UTxO be both a spending input and collateral - and retry once.
 	selectedUtxos, err := a.selectCoins(selectionTarget, totalInput)
 	if err != nil {
-		return a, fmt.Errorf("coin selection failed: %w", err)
+		if a.releaseCollateralForOverlap() {
+			selectedUtxos, err = a.selectCoins(selectionTarget, totalInput)
+		}
+		if err != nil {
+			return a, fmt.Errorf("coin selection failed: %w", err)
+		}
 	}
 
 	// Build inputs (explicit allocation to avoid slice aliasing)
@@ -1191,7 +1216,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	allInputUtxos = append(allInputUtxos, a.preselectedUtxos...)
 	allInputUtxos = append(allInputUtxos, selectedUtxos...)
 	allInputUtxos = SortInputs(allInputUtxos)
-	if err := a.validateCollateralDistinctFromInputs(allInputUtxos); err != nil {
+	if err := a.validateCollateral(); err != nil {
 		return a, err
 	}
 
@@ -1378,6 +1403,16 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		if err != nil {
 			return a, err
 		}
+	}
+
+	// Recompute total collateral and the collateral return from the FINAL fee.
+	// setCollateral() runs before coin selection and fee estimation, so it can
+	// only size collateral from a preliminary (max-by-size) fee. The ledger
+	// requires total collateral >= ceil(fee * collateralPercent / 100) against
+	// the ACTUAL fee, so a stale preliminary value triggers
+	// InsufficientCollateral. Resize here now that the fee is final.
+	if err := a.finalizeCollateral(fee); err != nil {
+		return a, err
 	}
 
 	// Build transaction body
@@ -2249,7 +2284,14 @@ func (a *Apollo) isUsed(ref string) bool {
 		}
 	}
 	for _, utxo := range a.collaterals {
-		if utxoRef(utxo) == ref {
+		// A collateral UTxO flagged for overlap is intentionally left available
+		// to coin selection so it can ALSO be picked as a regular spending input
+		// (see collateralOverlapRef). Treat it as not-used here.
+		cref := utxoRef(utxo)
+		if cref == a.collateralOverlapRef {
+			continue
+		}
+		if cref == ref {
 			return true
 		}
 	}
@@ -2284,6 +2326,19 @@ func (a *Apollo) hasScripts() bool {
 }
 
 // setCollateral auto-selects collateral from UTxOs if needed.
+//
+// Selection prefers a SEPARATE eligible vkey UTxO that is reserved out of the
+// coin-selection pool (the common multi-UTxO case, where the tx shape is
+// unchanged). When no dedicated UTxO is free, it falls back to a UTxO that may
+// ALSO be used as a regular spending input: the candidate is recorded in
+// collateralOverlapRef and is NOT reserved, so coin selection can still pick
+// it. This lets a wallet with a single UTxO build a script transaction. The
+// ledger permits the overlap because collateral is consumed only on phase-2
+// script failure and regular inputs only on success.
+//
+// totalCollateral and collateralReturn are sized here from a preliminary
+// (max-by-size) fee; finalizeCollateral() resizes them once the final fee is
+// known.
 func (a *Apollo) setCollateral() error {
 	if len(a.collaterals) > 0 || !a.hasScripts() {
 		return nil
@@ -2312,80 +2367,238 @@ func (a *Apollo) setCollateral() error {
 		candidates = loaded
 	}
 
-	// First pass: prefer pure-lovelace UTxOs (no assets)
-	for _, utxo := range candidates {
-		ref := utxoRef(utxo)
-		if a.isUsed(ref) {
-			continue
-		}
-		if utxo.Output.Assets() != nil {
-			continue
+	// collateralEligible reports whether a UTxO can back collateral: it must be
+	// vkey-locked (never a script address), hold a representable lovelace amount
+	// of at least minCollateral, and -- if it carries native assets -- leave a
+	// positive ADA remainder so the assets can be returned via collateral_return.
+	collateralEligible := func(utxo common.Utxo, requirePureLovelace bool) bool {
+		assets := utxo.Output.Assets()
+		if requirePureLovelace && assets != nil {
+			return false
 		}
 		addr := utxo.Output.Address()
 		if addr.Type() != common.AddressTypeKeyKey && addr.Type() != common.AddressTypeKeyNone {
-			continue
+			return false
 		}
 		amt := utxo.Output.Amount()
 		if amt == nil || !amt.IsInt64() {
-			continue
+			return false
 		}
 		lovelace := amt.Int64()
 		if lovelace < minCollateral {
-			continue
+			return false
 		}
+		// An asset-bearing UTxO needs a positive remainder to carry the assets
+		// forward in the collateral return.
+		if assets != nil && lovelace-minCollateral == 0 {
+			return false
+		}
+		return true
+	}
+
+	// selectCollateral records the chosen UTxO as collateral, reserves it out of
+	// the coin-selection pool (markUsed), and sizes the preliminary total and
+	// return. The reservation is provisional: if coin selection cannot then meet
+	// its target (a wallet with no other UTxO to spare), Complete() releases it
+	// for overlap via releaseCollateralForOverlap().
+	selectCollateral := func(utxo common.Utxo) {
+		ref := utxoRef(utxo)
 		a.collaterals = append(a.collaterals, utxo)
+		a.collateralAutoSelected = true
 		a.markUsed(ref)
 		a.totalCollateral = minCollateral
-		remainder := lovelace - minCollateral
-		if remainder > 0 {
-			returnVal := Value{Coin: uint64(remainder)}
-			ret := NewBabbageOutput(a.getChangeAddress(), returnVal, nil, nil)
-			a.collateralReturn = &ret
-		}
-		return nil
-	}
-	// Fallback: allow UTxOs with some assets
-	for _, utxo := range candidates {
-		ref := utxoRef(utxo)
-		if a.isUsed(ref) {
-			continue
-		}
-		addr := utxo.Output.Address()
-		if addr.Type() != common.AddressTypeKeyKey && addr.Type() != common.AddressTypeKeyNone {
-			continue
-		}
-		amt := utxo.Output.Amount()
-		if amt == nil || !amt.IsInt64() {
-			continue
-		}
-		lovelace := amt.Int64()
-		if lovelace < minCollateral {
-			continue
-		}
+		lovelace := utxo.Output.Amount().Int64()
 		remainder := lovelace - minCollateral
 		assets := utxo.Output.Assets()
-		if remainder == 0 && assets != nil {
-			// We can't select an asset-bearing collateral UTxO unless we can
-			// produce a collateral return that carries those assets forward.
-			continue
-		}
-		a.collaterals = append(a.collaterals, utxo)
-		a.markUsed(ref)
-		a.totalCollateral = minCollateral
-		if remainder > 0 {
-			returnVal := Value{Coin: uint64(remainder)}
+		if remainder > 0 || assets != nil {
+			returnVal := Value{Coin: uint64(remainder)} //nolint:gosec // remainder >= 0 (eligibility checked)
 			if assets != nil {
 				returnVal.Assets = CloneMultiAsset(assets)
 			}
 			ret := NewBabbageOutput(a.getChangeAddress(), returnVal, nil, nil)
 			a.collateralReturn = &ret
 		}
-		return nil
+	}
+
+	// First pass: prefer a pure-lovelace UTxO (no assets).
+	for _, utxo := range candidates {
+		if a.isUsed(utxoRef(utxo)) {
+			continue
+		}
+		if collateralEligible(utxo, true) {
+			selectCollateral(utxo)
+			return nil
+		}
+	}
+	// Second pass: a UTxO that may carry assets.
+	for _, utxo := range candidates {
+		if a.isUsed(utxoRef(utxo)) {
+			continue
+		}
+		if collateralEligible(utxo, false) {
+			selectCollateral(utxo)
+			return nil
+		}
 	}
 	return errors.New("script transaction requires collateral, but no eligible collateral UTxO was found")
 }
 
-func (a *Apollo) validateCollateralDistinctFromInputs(inputs []common.Utxo) error {
+// releaseCollateralForOverlap un-reserves an auto-selected collateral UTxO so
+// coin selection can also pick it as a regular spending input. The ledger
+// permits a UTxO to be both a spending input and collateral because the two are
+// consumed on mutually exclusive paths (success vs phase-2 script failure).
+//
+// It only acts on a single auto-selected collateral input that has not already
+// been flagged for overlap, and reports whether anything was released so the
+// caller knows a retry is worthwhile. Caller-pinned collateral is never touched.
+func (a *Apollo) releaseCollateralForOverlap() bool {
+	if !a.collateralAutoSelected || a.collateralOverlapRef != "" || len(a.collaterals) != 1 {
+		return false
+	}
+	ref := utxoRef(a.collaterals[0])
+	delete(a.usedUtxos, ref)
+	a.collateralOverlapRef = ref
+	return true
+}
+
+// finalizeCollateral recomputes the total collateral and the collateral-return
+// output from the final transaction fee. The ledger requires
+//
+//	totalCollateral >= ceil(fee * collateralPercent / 100)
+//
+// computed against the ACTUAL fee. setCollateral() only had a preliminary
+// (max-by-size) fee available, so its sizing is stale once coin selection and
+// fee estimation have run. We keep the collateral UTxO(s) it selected and only
+// resize the total and the return here.
+//
+// The computation uses the collateral inputs' value ALONE: on phase-2 script
+// failure only the collateral is consumed, so collateral_return = (collateral
+// input ADA - total_collateral) plus all native assets on the collateral. This
+// never touches the success-path input/output/fee balance.
+//
+// Only auto-selected collateral is resized. If the caller pinned the collateral
+// inputs (AddCollateral) or an explicit amount (SetCollateralAmount), the
+// sizing is intentional and left untouched.
+func (a *Apollo) finalizeCollateral(fee int64) error {
+	if len(a.collaterals) == 0 || !a.collateralAutoSelected || a.collateralAmount > 0 {
+		return nil
+	}
+	pp, err := a.Context.ProtocolParams()
+	if err != nil {
+		return fmt.Errorf("failed to get protocol params for collateral sizing: %w", err)
+	}
+	if pp.CollateralPercent <= 0 || fee <= 0 {
+		return nil
+	}
+	if fee > (math.MaxInt64-99)/int64(pp.CollateralPercent) {
+		return fmt.Errorf("collateral sizing overflows: fee=%d collateralPercent=%d", fee, pp.CollateralPercent)
+	}
+	// Ceil division: ceil(fee * percent / 100).
+	required := (fee*int64(pp.CollateralPercent) + 99) / 100
+	if required <= 0 {
+		return nil
+	}
+
+	// Sum the lovelace and assets across the selected collateral inputs so the
+	// collateral return can carry the remainder (and any tokens) forward.
+	var totalLovelace int64
+	var collateralAssets *common.MultiAsset[common.MultiAssetTypeOutput]
+	hasAssets := false
+	for _, utxo := range a.collaterals {
+		amt := utxo.Output.Amount()
+		if amt == nil || !amt.IsInt64() {
+			return fmt.Errorf("collateral UTxO %s has an invalid lovelace amount", utxoRef(utxo))
+		}
+		sum := totalLovelace + amt.Int64()
+		if sum < totalLovelace {
+			return errors.New("collateral lovelace total overflows int64")
+		}
+		totalLovelace = sum
+		if assets := utxo.Output.Assets(); assets != nil {
+			hasAssets = true
+			if collateralAssets == nil {
+				collateralAssets = CloneMultiAsset(assets)
+			} else {
+				collateralAssets.Add(assets)
+			}
+		}
+	}
+
+	if required > totalLovelace {
+		return fmt.Errorf(
+			"insufficient collateral: need %d lovelace (ceil(fee %d * %d%%)), selected collateral holds %d",
+			required, fee, pp.CollateralPercent, totalLovelace,
+		)
+	}
+
+	remainder := totalLovelace - required
+
+	// Asset-bearing collateral mandates a collateral_return to carry the tokens
+	// forward, and that return must meet min-ADA. If the ADA remainder cannot
+	// cover min-ADA, lowering total_collateral to free more ADA could break the
+	// >= required invariant, so report a clear error rather than build an
+	// invalid transaction.
+	if hasAssets {
+		returnVal := Value{Coin: uint64(remainder), Assets: collateralAssets} //nolint:gosec // remainder >= 0
+		ret := NewBabbageOutput(a.getChangeAddress(), returnVal, nil, nil)
+		minReturn, mErr := MinLovelacePostAlonzo(&ret, pp.CoinsPerUtxoByteValue())
+		if mErr != nil {
+			return fmt.Errorf("failed to compute min UTxO for collateral return: %w", mErr)
+		}
+		if minReturn < 0 {
+			return fmt.Errorf("invalid min UTxO for collateral return: %d", minReturn)
+		}
+		if remainder < minReturn {
+			return fmt.Errorf(
+				"collateral return for native assets needs %d lovelace but only %d is available after total collateral %d; supply a larger or additional collateral UTxO",
+				minReturn, remainder, required,
+			)
+		}
+		a.totalCollateral = required
+		a.collateralReturn = &ret
+		return nil
+	}
+
+	// ADA-only collateral. If the remainder is too small to form a valid return
+	// output (below min-ADA), absorb it into total_collateral and omit the
+	// return rather than emit a sub-min-ADA output.
+	if remainder > 0 {
+		returnVal := Value{Coin: uint64(remainder)} //nolint:gosec // remainder > 0
+		ret := NewBabbageOutput(a.getChangeAddress(), returnVal, nil, nil)
+		minReturn, mErr := MinLovelacePostAlonzo(&ret, pp.CoinsPerUtxoByteValue())
+		if mErr != nil {
+			return fmt.Errorf("failed to compute min UTxO for collateral return: %w", mErr)
+		}
+		if minReturn < 0 {
+			return fmt.Errorf("invalid min UTxO for collateral return: %d", minReturn)
+		}
+		if remainder >= minReturn {
+			a.totalCollateral = required
+			a.collateralReturn = &ret
+			return nil
+		}
+		// Dust remainder: absorb into total_collateral, no return.
+		a.totalCollateral = totalLovelace
+		a.collateralReturn = nil
+		return nil
+	}
+
+	// Exact match: total collateral consumes the whole input, no return.
+	a.totalCollateral = required
+	a.collateralReturn = nil
+	return nil
+}
+
+// validateCollateral checks the collateral input set against the ledger rules
+// that apollo can enforce locally: no duplicate collateral inputs and no more
+// than MaxCollateralInputs of them.
+//
+// It deliberately does NOT reject a UTxO that is also a regular spending input.
+// The Cardano ledger permits that overlap because collateral is consumed only
+// on phase-2 script failure and regular inputs only on success; the two paths
+// are mutually exclusive. This matches mesh, lucid, and lucid-evolution and
+// lets a single-UTxO wallet build a script transaction.
+func (a *Apollo) validateCollateral() error {
 	if len(a.collaterals) == 0 {
 		return nil
 	}
@@ -2397,11 +2610,13 @@ func (a *Apollo) validateCollateralDistinctFromInputs(inputs []common.Utxo) erro
 		}
 		seen[ref] = struct{}{}
 	}
-	for _, input := range inputs {
-		ref := utxoRef(input)
-		if _, ok := seen[ref]; ok {
-			return fmt.Errorf("utxo %s cannot be used as both input and collateral", ref)
-		}
+	// Enforce the protocol max on collateral inputs when known.
+	if pp, err := a.Context.ProtocolParams(); err == nil && pp.MaxCollateralInputs > 0 &&
+		len(a.collaterals) > pp.MaxCollateralInputs {
+		return fmt.Errorf(
+			"too many collateral inputs: %d exceeds protocol maximum of %d",
+			len(a.collaterals), pp.MaxCollateralInputs,
+		)
 	}
 	return nil
 }

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -1234,22 +1234,10 @@ func TestCompleteDoesNotReuseCollateralAsInput(t *testing.T) {
 func TestCompleteFailsWhenScriptTxHasNoEligibleCollateral(t *testing.T) {
 	cc := setupFixedContext()
 	addr := testAddress(t)
-	var txHash common.Blake2b256
-	txHash[0] = 0x01
-	output := babbage.BabbageTransactionOutput{
-		OutputAddress: addr,
-		OutputAmount: mary.MaryTransactionOutputValue{
-			Amount: 10_000_000,
-			Assets: testMultiAsset(1, "token", 1),
-		},
-	}
-	cc.AddUtxo(addr, common.Utxo{
-		Id: shelley.ShelleyTransactionInput{
-			TxId:        txHash,
-			OutputIndex: 0,
-		},
-		Output: &output,
-	})
+	// The only UTxO is at a SCRIPT address: it can never back collateral
+	// (collateral must be vkey-locked) and there is no other UTxO to fall back
+	// to, so collateral selection must fail.
+	cc.AddUtxo(addr, scriptAddressUtxo(t, 0x01, 10_000_000))
 
 	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
 	script := common.PlutusV2Script([]byte{0x01, 0x02})
@@ -1483,5 +1471,294 @@ func TestResolveCredentialInvalidBech32(t *testing.T) {
 	_, err := a.RegisterStake("not-a-valid-address")
 	if err == nil {
 		t.Error("expected error for invalid bech32")
+	}
+}
+
+// --- Collateral input / spending input overlap ---
+
+// bodyInputRefs collects the regular spending input refs from a built tx body.
+func bodyInputRefs(t *testing.T, a *Apollo) []string {
+	t.Helper()
+	items := a.tx.Body.TxInputs.Items()
+	refs := make([]string, 0, len(items))
+	for _, in := range items {
+		refs = append(refs, hex.EncodeToString(in.TxId.Bytes())+"#"+strconv.Itoa(int(in.OutputIndex)))
+	}
+	return refs
+}
+
+// bodyCollateralRefs collects the collateral input refs from a built tx body.
+func bodyCollateralRefs(t *testing.T, a *Apollo) []string {
+	t.Helper()
+	items := a.tx.Body.TxCollateral.Items()
+	refs := make([]string, 0, len(items))
+	for _, in := range items {
+		refs = append(refs, hex.EncodeToString(in.TxId.Bytes())+"#"+strconv.Itoa(int(in.OutputIndex)))
+	}
+	return refs
+}
+
+// scriptAddressUtxo builds a UTxO locked at a script payment address (type
+// AddressTypeScriptKey), used to verify script-address collateral is rejected.
+func scriptAddressUtxo(t *testing.T, txHashByte byte, lovelace uint64) common.Utxo {
+	t.Helper()
+	var raw [57]byte
+	raw[0] = byte(common.AddressTypeScriptKey) << 4 // network 0, script payment credential
+	raw[1] = 0xCC                                   // script hash bytes
+	raw[29] = 0xDD                                  // stake key hash
+	addr, err := common.NewAddressFromBytes(raw[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var txHash common.Blake2b256
+	txHash[0] = txHashByte
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: lovelace},
+	}
+	return common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txHash, OutputIndex: 0},
+		Output: &output,
+	}
+}
+
+// TestSingleUtxoIsBothInputAndCollateral verifies that a wallet with a single
+// vkey UTxO can build a Plutus script transaction where that UTxO is used as
+// BOTH a regular spending input and the collateral input.
+func TestSingleUtxoIsBothInputAndCollateral(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	const utxoLovelace = 20_000_000
+	addTestUtxo(cc, addr, utxoLovelace, 0x01, 0)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+
+	if len(a.collaterals) != 1 {
+		t.Fatalf("expected 1 collateral, got %d", len(a.collaterals))
+	}
+	collRef := utxoRef(a.collaterals[0])
+
+	inputRefs := bodyInputRefs(t, a)
+	collRefs := bodyCollateralRefs(t, a)
+
+	// The same UTxO ref must appear in both inputs and collateral.
+	if len(collRefs) != 1 || collRefs[0] != collRef {
+		t.Fatalf("collateral ref mismatch: body collateral %v, want [%s]", collRefs, collRef)
+	}
+	count := 0
+	for _, r := range inputRefs {
+		if r == collRef {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("overlapped UTxO must appear exactly once in inputs, found %d times in %v", count, inputRefs)
+	}
+
+	// total_collateral >= ceil(fee * collateralPercent / 100) and <= input ADA.
+	pp, _ := cc.ProtocolParams()
+	fee := a.tx.Body.TxFee
+	required := (fee*uint64(pp.CollateralPercent) + 99) / 100 //nolint:gosec // CollateralPercent is a positive protocol parameter
+	totalColl := a.tx.Body.TxTotalCollateral
+	if totalColl < required {
+		t.Fatalf("total_collateral %d below required %d (fee %d)", totalColl, required, fee)
+	}
+	if totalColl > utxoLovelace {
+		t.Fatalf("total_collateral %d exceeds collateral input ADA %d", totalColl, utxoLovelace)
+	}
+
+	// collateral_return = collateral_input_value - total_collateral (ADA-only here).
+	if a.tx.Body.TxCollateralReturn == nil {
+		t.Fatal("expected a collateral return for the ADA remainder")
+	}
+	gotReturn := a.tx.Body.TxCollateralReturn.Amount()
+	wantReturn := new(big.Int).SetUint64(utxoLovelace - totalColl)
+	if gotReturn == nil || gotReturn.Cmp(wantReturn) != 0 {
+		t.Fatalf("collateral_return = %v, want %v", gotReturn, wantReturn)
+	}
+
+	// Success-path balance must EXCLUDE collateral accounting:
+	// sum(inputs) == sum(outputs) + fee. The wallet has a single UTxO, so the
+	// only spending input is that UTxO. Collateral return / total collateral
+	// must not appear in this equation.
+	if len(inputRefs) != 1 || inputRefs[0] != collRef {
+		t.Fatalf("expected exactly the single UTxO as input, got %v", inputRefs)
+	}
+	inSum := new(big.Int).SetUint64(utxoLovelace)
+	outSum := new(big.Int)
+	for i := range a.tx.Body.TxOutputs {
+		amt := a.tx.Body.TxOutputs[i].Amount()
+		if amt == nil {
+			t.Fatalf("output %d has nil amount", i)
+		}
+		outSum.Add(outSum, amt)
+	}
+	outPlusFee := new(big.Int).Add(outSum, new(big.Int).SetUint64(fee))
+	if inSum.Cmp(outPlusFee) != 0 {
+		t.Fatalf("success-path balance broken: inputs %s != outputs+fee %s (fee %d)", inSum, outPlusFee, fee)
+	}
+}
+
+// TestTwoUtxoWalletPicksSeparateCollateral verifies the regression case: a
+// wallet with two vkey UTxOs still reserves a SEPARATE ADA-only collateral and
+// does not overlap, keeping the transaction shape identical to before.
+func TestTwoUtxoWalletPicksSeparateCollateral(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+	addTestUtxo(cc, addr, 5_000_000, 0x02, 0)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+
+	if a.collateralOverlapRef != "" {
+		t.Fatalf("expected no overlap for a multi-UTxO wallet, got overlap ref %s", a.collateralOverlapRef)
+	}
+	if len(a.collaterals) != 1 {
+		t.Fatalf("expected 1 collateral, got %d", len(a.collaterals))
+	}
+	collRef := utxoRef(a.collaterals[0])
+	for _, r := range bodyInputRefs(t, a) {
+		if r == collRef {
+			t.Fatalf("collateral %s was reused as a regular input on a multi-UTxO wallet", collRef)
+		}
+	}
+}
+
+// TestScriptAddressCollateralRejected verifies an auto-selected collateral is
+// never taken from a script address: only vkey-locked UTxOs are eligible.
+func TestScriptAddressCollateralRejected(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	// Only available UTxO is at a script address.
+	cc.AddUtxo(addr, scriptAddressUtxo(t, 0x01, 20_000_000))
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected error: script-address UTxO must not be eligible as collateral")
+	}
+}
+
+// TestDuplicateCollateralRejected verifies that adding the same UTxO twice as
+// collateral is rejected by validateCollateral.
+func TestDuplicateCollateralRejected(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+
+	var collHash common.Blake2b256
+	collHash[0] = 0x02
+	coll := makeTestUtxo(t, collHash, 0, 10_000_000)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		AddCollateral(coll).
+		AddCollateral(coll). // duplicate
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected duplicate collateral error")
+	}
+}
+
+// TestMaxCollateralInputsEnforced verifies that exceeding MaxCollateralInputs
+// is rejected.
+func TestMaxCollateralInputsEnforced(t *testing.T) {
+	pp := backend.ProtocolParameters{
+		MinFeeConstant:      155381,
+		MinFeeCoefficient:   44,
+		MaxTxSize:           16384,
+		CoinsPerUtxoByte:    "4310",
+		CollateralPercent:   150,
+		MaxCollateralInputs: 2, // small cap for the test
+		MaxValSize:          "5000",
+		PriceMem:            0.0577,
+		PriceStep:           0.0000721,
+		MaxTxExMem:          "14000000",
+		MaxTxExSteps:        "10000000000",
+		KeyDeposits:         "2000000",
+		PoolDeposits:        "500000000",
+	}
+	gp := backend.GenesisParameters{NetworkMagic: 1}
+	cc := fixed.NewFixedChainContext(pp, gp, 0)
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	// Three caller-pinned collateral inputs exceed the cap of 2.
+	for i := byte(2); i <= 4; i++ {
+		var h common.Blake2b256
+		h[0] = i
+		a.AddCollateral(makeTestUtxo(t, h, 0, 6_000_000))
+	}
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected too-many-collateral-inputs error")
 	}
 }

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -1898,3 +1898,39 @@ func TestManualAssetCollateralRejected(t *testing.T) {
 		t.Fatal("expected manual asset-bearing collateral to be rejected")
 	}
 }
+
+// TestExplicitCollateralAmountLeavingDustRejected verifies that an explicit
+// collateral amount that would leave a sub-min-ADA collateral return is
+// rejected rather than silently raising total_collateral (which would forfeit
+// the dust on phase-2 failure and exceed the requested amount).
+func TestExplicitCollateralAmountLeavingDustRejected(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+
+	const collLovelace = 10_000_000
+	var collHash common.Blake2b256
+	collHash[0] = 0x02
+	coll := makeTestUtxo(t, collHash, 0, collLovelace)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	// Request an amount that leaves only 1 lovelace of return, far below min-ADA.
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		AddCollateral(coll).
+		SetCollateralAmount(collLovelace - 1).
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected dust collateral return to be rejected for an explicit amount")
+	}
+}

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -1820,3 +1820,81 @@ func TestExplicitCollateralAmountBelowRequiredRejected(t *testing.T) {
 		t.Fatal("expected insufficient explicit collateral error")
 	}
 }
+
+// TestExplicitCollateralAmountEmittedInBody verifies that an explicit
+// SetCollateralAmount combined with a caller-pinned AddCollateral actually
+// emits total_collateral (body key 18) equal to the requested amount, with a
+// collateral return for the remainder.
+func TestExplicitCollateralAmountEmittedInBody(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+
+	var collHash common.Blake2b256
+	collHash[0] = 0x02
+	coll := makeTestUtxo(t, collHash, 0, 10_000_000)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	const wantAmount = 5_000_000
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		AddCollateral(coll).
+		SetCollateralAmount(wantAmount).
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if a.tx.Body.TxTotalCollateral != wantAmount {
+		t.Fatalf("total_collateral = %d, want %d", a.tx.Body.TxTotalCollateral, wantAmount)
+	}
+	if a.tx.Body.TxCollateralReturn == nil {
+		t.Fatal("expected a collateral return for the remainder")
+	}
+	gotReturn := a.tx.Body.TxCollateralReturn.Amount()
+	wantReturn := big.NewInt(10_000_000 - wantAmount)
+	if gotReturn == nil || gotReturn.Cmp(wantReturn) != 0 {
+		t.Fatalf("collateral_return = %v, want %v", gotReturn, wantReturn)
+	}
+}
+
+// TestManualAssetCollateralRejected verifies that fully manual collateral
+// carrying native assets (with no collateral return) is rejected, because the
+// implicit full-input collateral path cannot return the assets on failure.
+func TestManualAssetCollateralRejected(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+
+	var collHash common.Blake2b256
+	collHash[0] = 0x02
+	coll := makeAssetTestUtxo(t, collHash, 0, 10_000_000, testMultiAsset(1, "token", 1))
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		AddCollateral(coll).
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected manual asset-bearing collateral to be rejected")
+	}
+}

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -1762,3 +1762,61 @@ func TestMaxCollateralInputsEnforced(t *testing.T) {
 		t.Fatal("expected too-many-collateral-inputs error")
 	}
 }
+
+// TestManualScriptAddressCollateralRejected verifies that caller-pinned
+// (AddCollateral) collateral at a script address is rejected by
+// validateCollateral, matching the ledger requirement that collateral be
+// vkey-locked.
+func TestManualScriptAddressCollateralRejected(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		AddCollateral(scriptAddressUtxo(t, 0x02, 10_000_000)).
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected script-address collateral to be rejected")
+	}
+}
+
+// TestExplicitCollateralAmountBelowRequiredRejected verifies that an explicit
+// SetCollateralAmount below ceil(fee * collateralPercent / 100) is reported as
+// an error rather than building a ledger-invalid transaction.
+func TestExplicitCollateralAmountBelowRequiredRejected(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 30_000_000, 0x01, 0)
+	addTestUtxo(cc, addr, 10_000_000, 0x02, 0)
+
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		SetCollateralAmount(1). // far below ceil(fee * collateralPercent / 100)
+		Mint(unit, &datum, &common.ExUnits{Memory: 1, Steps: 1})
+	payment, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.AddPayment(payment)
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected insufficient explicit collateral error")
+	}
+}


### PR DESCRIPTION
## Summary

Allow a single wallet UTxO to be used as BOTH a regular spending input (tx body key 0) and a collateral input (key 13).

The Cardano ledger permits this overlap: collateral is consumed only on phase-2 (script) failure and regular inputs only on success, so the two paths are mutually exclusive. mesh, lucid, and lucid-evolution all allow it; apollo was the outlier in rejecting it, which forced single-UTxO wallets to pre-split their funds before they could build a script transaction.

## What changed

- `setCollateral()` still prefers a separate eligible vkey collateral UTxO and reserves it out of the coin-selection pool. When no dedicated UTxO is free, it records the candidate as an overlap ref without reserving it, so coin selection can still pick it.
- `Complete()` does a two-pass coin selection: if the first pass starves (e.g. a single-UTxO wallet), it releases the auto-selected collateral for overlap and retries once. On retry failure the reservation is restored so a later `Complete()` starts from consistent state. The overlapped UTxO lands exactly once in the inputs and once in the collateral.
- `validateCollateralDistinctFromInputs` was narrowed to `validateCollateral`: it keeps the duplicate-collateral and `MaxCollateralInputs` checks and now also rejects script-address (non-vkey) collateral, but no longer rejects an input/collateral overlap.
- `finalizeCollateral(fee)` sizes `total_collateral = ceil(fee * collateralPercent / 100)` and computes `collateral_return` from the collateral inputs' value alone (excess ADA plus all native assets), with min-ADA handling. It runs in three modes: auto-selected (resized from the final fee), explicit `SetCollateralAmount` (the requested amount is emitted and validated against the minimum and the input total), and fully manual `AddCollateral` (left to the ledger's implicit all-inputs rule, but validated). Collateral is sized inside the fee-convergence loop so the fee accounts for the final collateral footprint.

`collateral_return` is derived from the collateral inputs alone and never touches the success-path `inputs == outputs + fee (+ deposits/withdrawals/mint)` balance.

## Behavior preserved

- Multi-UTxO wallets keep an identical transaction shape: a separate dedicated collateral is selected (first-eligible) and there is no overlap unless coin selection cannot otherwise be satisfied.
- User-pinned collateral (`AddCollateral`, `SetCollateralAmount`, `SetCollateralReturn`) and manual inputs keep their prior behavior, with added local validation so under-funded or asset-stranding collateral is rejected up front rather than producing a ledger-invalid transaction.

## Scope

Scoped to collateral only. No changes to core fee estimation or reference scripts.

## Tests

Added tests for: single-UTxO overlap (UTxO appears once in inputs and once in collateral; `total_collateral` and `collateral_return` correct; success-path balance excludes collateral accounting), multi-UTxO separate-collateral regression, script-address collateral rejection (auto and manual), duplicate collateral, `MaxCollateralInputs` enforcement, explicit-amount emission/below-required/dust rejection, and manual asset-bearing collateral rejection.
