### PR TITLE
fix: script data hash empty datums + Blockfrost cost_models_raw

### DIFF
--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -718,6 +718,11 @@ type bfProtocolParams struct {
 	MaxCollateralIn    int64           `json:"max_collateral_inputs"`
 	CoinsPerUtxoSize   string          `json:"coins_per_utxo_size"`
 	CostModels         json.RawMessage `json:"cost_models"`
+	// CostModelsRaw is the canonical flat integer array per language. Prefer
+	// this over named cost_models: Blockfrost's keyed/named maps can be
+	// truncated or reordered after Plutus cost-model parameter bumps, which
+	// yields ScriptIntegrityHashMismatch even when EvaluateTx succeeds.
+	CostModelsRaw json.RawMessage `json:"cost_models_raw"`
 	// BlockFrost exposes the Conway reference-script base price under this flat
 	// key (lovelace per byte for the first tier); it does not return the
 	// structured min_fee_reference_scripts_{base,range,multiplier} triple.
@@ -768,12 +773,22 @@ func (p *bfProtocolParams) toProtocolParams() (backend.ProtocolParameters, error
 	}
 
 	// Parse cost models from BlockFrost JSON.
-	// BlockFrost may return cost models as either:
+	// Prefer cost_models_raw (canonical integer arrays). Fall back to
+	// cost_models which may be either:
 	//   - array format:  {"PlutusV1": [205665, 812, ...]}
 	//   - keyed format:  {"PlutusV1": {"addInteger-cpu-arguments-intercept": 205665, ...}}
 	// Both formats use keys "PlutusV1", "PlutusV2", "PlutusV3" which match
 	// the canonical form expected by ComputeScriptDataHash.
-	if len(p.CostModels) > 0 {
+	if len(p.CostModelsRaw) > 0 && string(p.CostModelsRaw) != "null" {
+		var rawModels map[string][]int64
+		if err := json.Unmarshal(p.CostModelsRaw, &rawModels); err != nil {
+			return pp, fmt.Errorf("failed to parse cost_models_raw: %w", err)
+		}
+		if len(rawModels) > 0 {
+			pp.CostModels = rawModels
+		}
+	}
+	if pp.CostModels == nil && len(p.CostModels) > 0 {
 		var arrayModels map[string][]int64
 		if err := json.Unmarshal(p.CostModels, &arrayModels); err == nil {
 			pp.CostModels = arrayModels

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -333,6 +333,63 @@ func TestProtocolParamsParsesRefScriptCostPerByte(t *testing.T) {
 	}
 }
 
+func TestProtocolParamsPrefersCostModelsRaw(t *testing.T) {
+	const body = `{
+		"min_fee_a": 44,
+		"min_fee_b": 155381,
+		"max_tx_size": 16384,
+		"coins_per_utxo_size": "4310",
+		"collateral_percent": 150,
+		"max_collateral_inputs": 3,
+		"cost_models": {
+			"PlutusV3": {"addInteger-cpu-arguments-intercept": 1, "addInteger-cpu-arguments-slope": 2}
+		},
+		"cost_models_raw": {
+			"PlutusV3": [100, 200, 300, 400]
+		}
+	}`
+
+	var raw bfProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	pp, err := raw.toProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := pp.CostModels["PlutusV3"]
+	if len(got) != 4 || got[0] != 100 || got[3] != 400 {
+		t.Fatalf("expected cost_models_raw values, got %v", got)
+	}
+}
+
+func TestProtocolParamsFallsBackToNamedCostModels(t *testing.T) {
+	const body = `{
+		"min_fee_a": 44,
+		"min_fee_b": 155381,
+		"max_tx_size": 16384,
+		"coins_per_utxo_size": "4310",
+		"collateral_percent": 150,
+		"max_collateral_inputs": 3,
+		"cost_models": {
+			"PlutusV2": [9, 8, 7]
+		}
+	}`
+
+	var raw bfProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	pp, err := raw.toProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := pp.CostModels["PlutusV2"]
+	if len(got) != 3 || got[0] != 9 {
+		t.Fatalf("expected named cost_models fallback, got %v", got)
+	}
+}
+
 // sampleCommonUtxo builds a resolved gouroboros UTxO for additional-UTxO
 // request-shaping tests: a known tx ref, address, lovelace coin, one native
 // asset, and a PlutusV2 reference script.

--- a/evaluation_script_hash_test.go
+++ b/evaluation_script_hash_test.go
@@ -1,0 +1,135 @@
+package apollo
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+type capturingEvalContext struct {
+	*fixed.FixedChainContext
+	lastTxCbor []byte
+	result     map[common.RedeemerKey]common.ExUnits
+}
+
+func (c *capturingEvalContext) EvaluateTx(txCbor []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	c.lastTxCbor = append([]byte(nil), txCbor...)
+	return c.result, nil
+}
+
+func TestEstimateExecutionUnitsUsesLedgerCorrectScriptDataHash(t *testing.T) {
+	pp := backend.ProtocolParameters{
+		MinFeeConstant:      155381,
+		MinFeeCoefficient:   44,
+		MaxTxSize:           16384,
+		CoinsPerUtxoByte:    "4310",
+		CollateralPercent:   150,
+		MaxCollateralInputs: 3,
+		MaxValSize:          "5000",
+		PriceMem:            0.0577,
+		PriceStep:           0.0000721,
+		MaxTxExMem:          "14000000",
+		MaxTxExSteps:        "10000000000",
+		KeyDeposits:         "2000000",
+		PoolDeposits:        "500000000",
+		CostModels: map[string][]int64{
+			"PlutusV2": {4, 5, 6},
+			"PlutusV3": {7, 8, 9},
+		},
+	}
+	gp := backend.GenesisParameters{NetworkMagic: 1}
+	base := fixed.NewFixedChainContext(pp, gp, 0)
+	cc := &capturingEvalContext{
+		FixedChainContext: base,
+		result: map[common.RedeemerKey]common.ExUnits{
+			{Tag: common.RedeemerTagMint, Index: 0}: {Memory: 1000, Steps: 2000},
+		},
+	}
+
+	addr := testAddress(t)
+	addTestUtxo(base, addr, 20_000_000, 0x11, 0)
+	addTestUtxo(base, addr, 10_000_000, 0x12, 0)
+
+	inlineDatum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(42))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	policyHex := strings.Repeat("ab", 28)
+	unit := NewUnit(policyHex, "746f6b656e", 1)
+	redeemer := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddInputAddress(addr).
+		AttachScript(script).
+		Mint(unit, &redeemer, nil).
+		PayToContract(addr, &inlineDatum, 2_000_000).
+		SetTtl(50_000_000)
+
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if len(cc.lastTxCbor) == 0 {
+		t.Fatal("EvaluateTx was not called")
+	}
+	if len(a.datums) != 0 {
+		t.Fatalf("inline output datum must not become a witness datum, got %d", len(a.datums))
+	}
+
+	var prelim conway.ConwayTransaction
+	if _, err := cbor.Decode(cc.lastTxCbor, &prelim); err != nil {
+		t.Fatalf("decode preliminary EvalTx: %v", err)
+	}
+	if prelim.Body.TxScriptDataHash == nil {
+		t.Fatal("preliminary body missing script data hash")
+	}
+	if len(prelim.WitnessSet.WsPlutusData.Items()) != 0 {
+		t.Fatalf("expected no witness datums, got %d", len(prelim.WitnessSet.WsPlutusData.Items()))
+	}
+
+	// Independent ledger preimage: redeemers || (omit empty datums) || lang views.
+	redeemerMap := prelim.WitnessSet.WsRedeemers.Redeemers
+	if len(redeemerMap) == 0 {
+		t.Fatal("expected mint redeemer in preliminary witness set")
+	}
+	expected, err := ComputeScriptDataHash(redeemerMap, nil, map[string][]int64{
+		"PlutusV2": {4, 5, 6},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected == nil {
+		t.Fatal("expected independent script data hash")
+	}
+	if *prelim.Body.TxScriptDataHash != *expected {
+		t.Fatalf("preliminary TxScriptDataHash mismatch:\n got %x\nwant %x",
+			prelim.Body.TxScriptDataHash.Bytes(), expected.Bytes())
+	}
+
+	// Legacy empty-datum-array preimage must not match.
+	redeemerBytes, err := cbor.Encode(redeemerMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyDatums, err := cbor.Encode([]common.Datum{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{1: {}},
+		map[uint][]int64{1: {4, 5, 6}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), emptyDatums...), langViews...))
+	if *prelim.Body.TxScriptDataHash == legacy {
+		t.Fatal("preliminary hash unexpectedly matches empty-datums legacy preimage")
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -490,7 +490,13 @@ func NewVkeyWitnessFromSkey(
 	}
 }
 
-// ComputeScriptDataHash computes the script data hash per the Alonzo spec.
+// ComputeScriptDataHash computes the script data hash per the ledger rules:
+// blake2b-256(redeemers_cbor || datums_cbor || lang_views_cbor).
+//
+// When there are no witness datums, datums_cbor is omitted entirely (Alonzo,
+// Babbage, and Conway). Encoding an empty datum array here produces
+// ScriptIntegrityHashMismatch on submit for mint/spend txs that only carry
+// inline output datums.
 func ComputeScriptDataHash(
 	redeemers map[common.RedeemerKey]common.RedeemerValue,
 	datums []common.Datum,
@@ -505,6 +511,7 @@ func ComputeScriptDataHash(
 	if len(redeemers) > 0 {
 		redeemerBytes, err = cbor.Encode(redeemers)
 	} else {
+		// Empty Conway redeemer map must be 0xa0, not CBOR null.
 		redeemerBytes, err = cbor.Encode(map[common.RedeemerKey]common.RedeemerValue{})
 	}
 	if err != nil {
@@ -514,11 +521,9 @@ func ComputeScriptDataHash(
 	var datumBytes []byte
 	if len(datums) > 0 {
 		datumBytes, err = cbor.Encode(datums)
-	} else {
-		datumBytes, err = cbor.Encode([]common.Datum{})
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode datums: %w", err)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode datums: %w", err)
+		}
 	}
 
 	// Encode cost models as language views using gouroboros, which

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -535,3 +535,85 @@ func TestSignMessage64ByteKey(t *testing.T) {
 		t.Errorf("expected 64-byte signature, got %d", len(sig))
 	}
 }
+
+func TestComputeScriptDataHashOmitsEmptyDatums(t *testing.T) {
+	redeemerKey := common.RedeemerKey{Tag: common.RedeemerTagMint, Index: 0}
+	redeemerVal := common.RedeemerValue{
+		ExUnits: common.ExUnits{Memory: 1000, Steps: 2000},
+	}
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		redeemerKey: redeemerVal,
+	}
+	costs := map[string][]int64{
+		"PlutusV3": {1, 2, 3, 4, 5},
+	}
+
+	got, err := ComputeScriptDataHash(redeemers, nil, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected hash")
+	}
+
+	redeemerBytes, err := cbor.Encode(redeemers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{2: {}},
+		map[uint][]int64{2: costs["PlutusV3"]},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ledger preimage: redeemers || (no datums) || lang views.
+	want := common.Blake2b256Hash(append(append([]byte{}, redeemerBytes...), langViews...))
+	if *got != want {
+		t.Fatalf("hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+
+	// Pre-fix Apollo behavior encoded an empty datum array and must not match.
+	emptyDatums, err := cbor.Encode([]common.Datum{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), emptyDatums...), langViews...))
+	if *got == legacy {
+		t.Fatal("hash unexpectedly matches empty-datums preimage")
+	}
+}
+
+func TestComputeScriptDataHashIncludesNonEmptyDatums(t *testing.T) {
+	redeemerKey := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		redeemerKey: {ExUnits: common.ExUnits{Memory: 1, Steps: 2}},
+	}
+	datums := []common.Datum{{}}
+	costs := map[string][]int64{"PlutusV2": {9, 8, 7}}
+
+	got, err := ComputeScriptDataHash(redeemers, datums, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redeemerBytes, err := cbor.Encode(redeemers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	datumBytes, err := cbor.Encode(datums)
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{1: {}},
+		map[uint][]int64{1: costs["PlutusV2"]},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), datumBytes...), langViews...))
+	if *got != want {
+		t.Fatalf("hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+}
+

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -614,6 +615,114 @@ func TestComputeScriptDataHashIncludesNonEmptyDatums(t *testing.T) {
 	want := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), datumBytes...), langViews...))
 	if *got != want {
 		t.Fatalf("hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+}
+
+func TestComputeScriptDataHashIncludesWitnessDatums(t *testing.T) {
+	// Alias coverage for the plan-named witness-datum case.
+	TestComputeScriptDataHashIncludesNonEmptyDatums(t)
+}
+
+func TestComputeScriptDataHashInlineDatumIsNotWitnessDatum(t *testing.T) {
+	// Inline output datums are not passed into ComputeScriptDataHash; only
+	// witness datums are. An empty witness-datum slice must omit datums CBOR.
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: common.RedeemerTagMint, Index: 0}: {ExUnits: common.ExUnits{Memory: 10, Steps: 20}},
+	}
+	costs := map[string][]int64{"PlutusV3": {1, 2, 3}}
+	got, err := ComputeScriptDataHash(redeemers, nil, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redeemerBytes, err := cbor.Encode(redeemers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{2: {}},
+		map[uint][]int64{2: costs["PlutusV3"]},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOmit := common.Blake2b256Hash(append(append([]byte{}, redeemerBytes...), langViews...))
+	if *got != wantOmit {
+		t.Fatalf("expected omit-datums preimage, got %x want %x", got.Bytes(), wantOmit.Bytes())
+	}
+}
+
+func TestComputeScriptDataHashPlutusV1LanguageView(t *testing.T) {
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: common.RedeemerTagSpend, Index: 0}: {ExUnits: common.ExUnits{Memory: 1, Steps: 1}},
+	}
+	costs := map[string][]int64{"PlutusV1": {100, 200, 300}}
+	got, err := ComputeScriptDataHash(redeemers, nil, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redeemerBytes, err := cbor.Encode(redeemers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{0: {}},
+		map[uint][]int64{0: costs["PlutusV1"]},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := common.Blake2b256Hash(append(append([]byte{}, redeemerBytes...), langViews...))
+	if *got != want {
+		t.Fatalf("PlutusV1 language-view hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+}
+
+func TestComputeScriptDataHashMultipleLanguagesDeterministic(t *testing.T) {
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: common.RedeemerTagMint, Index: 0}: {ExUnits: common.ExUnits{Memory: 1, Steps: 1}},
+	}
+	costs := map[string][]int64{
+		"PlutusV2": {4, 5, 6},
+		"PlutusV3": {7, 8, 9},
+	}
+	got1, err := ComputeScriptDataHash(redeemers, nil, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, err := ComputeScriptDataHash(redeemers, nil, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *got1 != *got2 {
+		t.Fatalf("hash not deterministic across calls: %x vs %x", got1.Bytes(), got2.Bytes())
+	}
+	redeemerBytes, err := cbor.Encode(redeemers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{1: {}, 2: {}},
+		map[uint][]int64{1: costs["PlutusV2"], 2: costs["PlutusV3"]},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := common.Blake2b256Hash(append(append([]byte{}, redeemerBytes...), langViews...))
+	if *got1 != want {
+		t.Fatalf("multi-language hash mismatch:\n got %x\nwant %x", got1.Bytes(), want.Bytes())
+	}
+}
+
+func TestComputeScriptDataHashRejectsUnsupportedLanguage(t *testing.T) {
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: common.RedeemerTagSpend, Index: 0}: {ExUnits: common.ExUnits{Memory: 1, Steps: 1}},
+	}
+	_, err := ComputeScriptDataHash(redeemers, nil, map[string][]int64{"PlutusV9": {1}})
+	if err == nil {
+		t.Fatal("expected error for unsupported language")
+	}
+	if !strings.Contains(err.Error(), "unsupported cost model language") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes `ScriptIntegrityHashMismatch` / `ConwayUtxowFailure` on submit for Plutus txs that have redeemers but **no witness datums** (e.g. minting with an inline output datum only).

### 1. Shared: `ComputeScriptDataHash` (all backends)

**Bug:** `helpers.ComputeScriptDataHash` always CBOR-encoded an empty datum list when `datums` was empty:

```go
datumBytes, err = cbor.Encode([]common.Datum{})
```

**Ledger rule** (Alonzo / Babbage / Conway in `gouroboros`): datums are included in the script integrity preimage **only when witness Plutus data is non-empty**. Otherwise the preimage is:

```text
blake2b-256(redeemers_cbor || lang_views_cbor)
```

not

```text
blake2b-256(redeemers_cbor || 0x80 || lang_views_cbor)
```

That wrong hash is written into `TxScriptDataHash`. `EvaluateTx` can still succeed (evaluator does not enforce the same check), then Blockfrost/node reject submit with `ScriptIntegrityHashMismatch`.

**Fix:** omit datum CBOR when `len(datums) == 0`. This is **backend-agnostic** — Ogmios, Maestro, UTxO RPC, Blockfrost, and Fixed all call the same helper via `Complete()`.

### 2. Blockfrost-only: prefer `cost_models_raw`

**Not present on other backends:** Ogmios/Maestro/UTxO RPC already expose cost models as integer arrays from the node/API.

Blockfrost returns both `cost_models` (often named/keyed maps) and `cost_models_raw` (canonical flat arrays). Named maps can be truncated/reordered after Plutus cost-model parameter bumps, so language views diverge from the chain and produce the same class of integrity-hash failure even when evaluation succeeds. Prefer `cost_models_raw` when present; keep named `cost_models` as fallback (same approach as [cardano-client-lib#624](https://github.com/bloxbean/cardano-client-lib/pull/624)).

## Backend audit

| Backend | Empty-datums hash bug | Cost-model source | Change in this PR |
|---------|----------------------|-------------------|-------------------|
| Shared `ComputeScriptDataHash` | Yes | N/A | Fixed |
| Blockfrost | Via shared helper | Named `cost_models` (+ raw) | Prefer `cost_models_raw` |
| Ogmios | Via shared helper | Array `plutusCostModels` | None (already arrays) |
| Maestro | Via shared helper | Array `plutus:v*` | None (already arrays) |
| UTxO RPC | Via shared helper | Protobuf value lists | None (already arrays) |
| Fixed / cache | Via shared helper | Caller-supplied | None beyond shared fix |

## Related (independent, not stacked)
- #250 balanced EvalTx draft
- #251 required-signer witnesses
- #252 / #253 UTxO RPC parser PRs

## Test plan
- [x] `go test . -run "TestComputeScriptDataHash|TestEstimateExecutionUnitsUsesLedgerCorrectScriptDataHash" -count=1`
- [x] `go test ./backend/blockfrost -count=1` — includes `TestProtocolParamsPrefersCostModelsRaw` and fallback
- [x] CI `go-test` / `lint` / CodeQL green on this PR
- [ ] Reviewer: rebuild a mint-only Conway tx (redeemers, inline output datum, no witness datums) against preprod Blockfrost and confirm submit no longer returns `ScriptIntegrityHashMismatch`
- [ ] Reviewer: confirm Ogmios/Maestro/UTxO RPC still build+submit script txs (shared hash change only)
- [ ] Reviewer: preliminary EvalTx CBOR script-data hash matches independent omit-empty-datums preimage
