### PR TITLE
fix(blockfrost): UtxoByRef fills missing tx_hash from /txs/{hash}/utxos

### DIFF
--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -605,15 +605,27 @@ func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint3
 		return nil, err
 	}
 
+	// Blockfrost GET /txs/{hash}/utxos returns the tx id only at the top level
+	// ("hash"). Output objects omit tx_hash (unlike /addresses/{addr}/utxos).
+	// hydrateUtxo/toUtxo require TxHash, so fill it from the request hash (or
+	// the response top-level hash) before parsing.
 	var txUtxos struct {
+		Hash    string          `json:"hash"`
 		Outputs []bfAddressUTxO `json:"outputs"`
 	}
 	if err := json.Unmarshal(data, &txUtxos); err != nil {
 		return nil, err
 	}
+	fallbackHash := hashHex
+	if txUtxos.Hash != "" {
+		fallbackHash = txUtxos.Hash
+	}
 
 	for _, raw := range txUtxos.Outputs {
 		if int64(raw.OutputIndex) == int64(index) {
+			if raw.TxHash == "" {
+				raw.TxHash = fallbackHash
+			}
 			addr, err := common.NewAddress(raw.Address)
 			if err != nil {
 				return nil, err

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -84,6 +84,59 @@ func TestHydrateUtxoResolvesInlineDatumAndReferenceScript(t *testing.T) {
 	}
 }
 
+func TestUtxoByRefFillsMissingTxHashOnTxUtxosOutputs(t *testing.T) {
+	addr := testAddress(t)
+	const txHashHex = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/txs/"+txHashHex+"/utxos" {
+			http.NotFound(w, r)
+			return
+		}
+		// Mirror Blockfrost /txs/{hash}/utxos: top-level hash only; outputs omit tx_hash.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"hash":   txHashHex,
+			"inputs": []any{},
+			"outputs": []map[string]any{
+				{
+					"address":      addr.String(),
+					"amount":       []map[string]string{{"unit": "lovelace", "quantity": "2000000"}},
+					"output_index": 1,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ctx := NewBlockFrostChainContext(server.URL, 0, "test-project")
+	hashBytes, err := hex.DecodeString(txHashHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var txHash common.Blake2b256
+	copy(txHash[:], hashBytes)
+
+	utxo, err := ctx.UtxoByRef(txHash, 1)
+	if err != nil {
+		t.Fatalf("UtxoByRef: %v", err)
+	}
+	if utxo == nil {
+		t.Fatal("expected utxo")
+	}
+	if got := hex.EncodeToString(utxo.Id.Id().Bytes()); got != txHashHex {
+		t.Fatalf("utxo tx id = %s, want %s", got, txHashHex)
+	}
+	if utxo.Id.Index() != 1 {
+		t.Fatalf("utxo index = %d, want 1", utxo.Id.Index())
+	}
+	out, ok := utxo.Output.(*babbage.BabbageTransactionOutput)
+	if !ok {
+		t.Fatalf("unexpected output type %T", utxo.Output)
+	}
+	if out.OutputAmount.Amount != 2_000_000 {
+		t.Fatalf("lovelace = %d, want 2000000", out.OutputAmount.Amount)
+	}
+}
+
 func TestEvaluateTxRejectsRedeemerIndexOverflow(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v0/utils/txs/evaluate" {


### PR DESCRIPTION
## Summary

Fixes Blockfrost `UtxoByRef` so it works with `GET /txs/{hash}/utxos`.

### Bug

`UtxoByRef` fetches `/txs/{hash}/utxos` and hydrates matching outputs via `toUtxo`, which **requires** `tx_hash` on each output.

Blockfrost's transaction UTxO schema puts the id only at the top level (`hash`). **Outputs omit `tx_hash`** (unlike `/addresses/{addr}/utxos`, which includes it). Hydration then fails with an invalid/empty tx hash length error.

Callers that treat any `UtxoByRef` error as \"not confirmed yet\" (e.g. await-output polling) loop forever even though the tx is on-chain and visible on explorers.

### Fix

Before `hydrateUtxo`, if an output's `TxHash` is empty, set it from:

1. the request path hash, or
2. the response top-level `hash` when present

### Backend audit

| Backend | `UtxoByRef` source | Same bug? |
|---------|---------------------|-----------|
| **Blockfrost** | `/txs/{hash}/utxos` outputs without `tx_hash` | **Yes — fixed** |
| Ogmios | `UtxosByTxIn` (includes tx id) | No |
| Maestro | `TransactionOutputFromReference` (includes `TxHash`) | No |
| UTxO RPC | `ReadUtxos` by key (hash in request) | No |

Related: script-data-hash / `cost_models_raw` fixes are in a separate PR (#247).

## Test plan

- [x] `TestUtxoByRefFillsMissingTxHashOnTxUtxosOutputs` — httptest fixture mirroring Blockfrost (top-level `hash`, outputs without `tx_hash`)
- [x] `go test ./backend/blockfrost/`
- [ ] Reviewer: call `UtxoByRef` for a confirmed preprod tx output index and confirm a non-nil UTxO with the correct id/index