### PR TITLE
fix(blockfrost): prefer /utils/txs/evaluate over /evaluate/utxos

### DIFF
--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -292,30 +292,76 @@ func (b *BlockFrostChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, err
 }
 
 func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-	// When resolved UTxOs are supplied (e.g. inputs not yet confirmed
-	// on-chain), the bare /utils/txs/evaluate endpoint (cbor body) cannot carry
-	// them. Switch to /utils/txs/evaluate/utxos with a JSON body that includes
-	// the additional UTxO set.
-	if len(additionalUtxos) > 0 {
-		reqBody, err := buildEvalUtxosRequest(txCbor, additionalUtxos)
-		if err != nil {
-			return nil, err
-		}
-		data, err := b.request("POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
-		if err != nil {
-			return nil, err
-		}
-		return parseEvaluateTxResponse(data)
+	// Prefer /utils/txs/evaluate (hex body). Apollo always passes spending
+	// inputs as additionalUtxos even when they are already on-chain; posting
+	// them to /utils/txs/evaluate/utxos re-encodes inline datums and reference
+	// scripts into a large JSON body. Hosted Blockfrost→Ogmios has returned
+	// jsonwsp faults ("failed to decode payload from base64 or base16") for
+	// that path on script-spend txs, while the same txs evaluate successfully
+	// via the bare endpoint which resolves inputs from chain state.
+	//
+	// Fall back to /evaluate/utxos only when the simple path reports missing
+	// inputs (UTxOs not yet visible on-chain).
+	result, err := b.evaluateTxSimple(txCbor)
+	if err == nil {
+		return result, nil
 	}
+	if len(additionalUtxos) == 0 || !isMissingInputsEvalError(err) {
+		return nil, err
+	}
+	return b.evaluateTxWithAdditionalUtxos(txCbor, additionalUtxos)
+}
 
-	// BlockFrost expects the transaction CBOR hex-encoded in the request body
-	// (with Content-Type application/cbor), not the raw CBOR bytes.
+// evaluateTxSimple POSTs hex-encoded transaction CBOR to /utils/txs/evaluate.
+// BlockFrost expects the hex string in the body with Content-Type
+// application/cbor (not raw CBOR bytes).
+func (b *BlockFrostChainContext) evaluateTxSimple(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
 	body := strings.NewReader(hex.EncodeToString(txCbor))
 	data, err := b.request("POST", "/utils/txs/evaluate", body, "application/cbor")
 	if err != nil {
 		return nil, err
 	}
 	return parseEvaluateTxResponse(data)
+}
+
+// evaluateTxWithAdditionalUtxos POSTs to /utils/txs/evaluate/utxos with a JSON
+// body carrying the transaction CBOR hex and a resolved additional UTxO set.
+func (b *BlockFrostChainContext) evaluateTxWithAdditionalUtxos(
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	reqBody, err := buildEvalUtxosRequest(txCbor, additionalUtxos)
+	if err != nil {
+		return nil, err
+	}
+	data, err := b.request("POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
+	if err != nil {
+		return nil, err
+	}
+	return parseEvaluateTxResponse(data)
+}
+
+// isMissingInputsEvalError reports whether an EvaluateTx failure indicates the
+// backend could not resolve transaction inputs from chain state (so supplying
+// additionalUtxos may help).
+func isMissingInputsEvalError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(s, "unknowninputs"),
+		strings.Contains(s, "unknown inputs"),
+		strings.Contains(s, "unknown_inputs"),
+		strings.Contains(s, "nonexistinginput"),
+		strings.Contains(s, "non-existing input"),
+		strings.Contains(s, "non_existing_input"):
+		return true
+	case strings.Contains(s, "missing") && strings.Contains(s, "input"):
+		return true
+	default:
+		return false
+	}
 }
 
 // buildEvalUtxosRequest marshals the JSON body for the
@@ -385,10 +431,17 @@ func bfAdditionalUtxoItemFromUtxo(utxo common.Utxo) (bfAdditionalUtxoItem, error
 	}
 
 	// Inline datum CBOR hex goes in Datum; a bare datum hash goes in DatumHash.
+	// Prefer the original on-chain CBOR bytes when present so the evaluate
+	// endpoint sees a canonical encoding (MarshalCBOR re-encodes Plutus Data
+	// and can diverge from the ledger bytes).
 	if datum := out.Datum(); datum != nil {
-		datumCbor, err := datum.MarshalCBOR()
-		if err != nil {
-			return bfAdditionalUtxoItem{}, fmt.Errorf("failed to encode inline datum: %w", err)
+		datumCbor := datum.Cbor()
+		if len(datumCbor) == 0 {
+			var err error
+			datumCbor, err = datum.MarshalCBOR()
+			if err != nil {
+				return bfAdditionalUtxoItem{}, fmt.Errorf("failed to encode inline datum: %w", err)
+			}
 		}
 		datumHex := hex.EncodeToString(datumCbor)
 		txOut.Datum = &datumHex

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -291,25 +291,64 @@ func (b *BlockFrostChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, err
 	return result, nil
 }
 
+// evaluateSimpleRetries / evaluateSimpleRetryWait cover Blockfrost evaluate
+// indexing lag right after a tx is confirmed (common when chaining mint/update
+// onto a just-confirmed script UTxO). The hosted /evaluate/utxos fallback is
+// unsafe for asset-bearing additional UTxOs (Ogmios jsonwsp base16/base64
+// faults), so retrying the simple endpoint is preferred.
+//
+// These are package-level vars so tests can shrink the backoff without sleeping
+// for the production intervals.
+var (
+	evaluateSimpleRetries   = 6
+	evaluateSimpleRetryWait = 2 * time.Second
+)
+
 func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	// Prefer /utils/txs/evaluate (hex body). Apollo always passes spending
 	// inputs as additionalUtxos even when they are already on-chain; posting
 	// them to /utils/txs/evaluate/utxos re-encodes inline datums and reference
-	// scripts into a large JSON body. Hosted Blockfrost→Ogmios has returned
-	// jsonwsp faults ("failed to decode payload from base64 or base16") for
-	// that path on script-spend txs, while the same txs evaluate successfully
-	// via the bare endpoint which resolves inputs from chain state.
+	// scripts into a large JSON body. Hosted Blockfrost→Ogmios rejects that
+	// path for additional UTxOs that include native assets (jsonwsp fault:
+	// "failed to decode payload from base64 or base16"), while the same txs
+	// evaluate successfully via the bare endpoint once inputs are visible.
 	//
-	// Fall back to /evaluate/utxos only when the simple path reports missing
-	// inputs (UTxOs not yet visible on-chain).
-	result, err := b.evaluateTxSimple(txCbor)
-	if err == nil {
-		return result, nil
+	// On missing-input failures, retry the simple endpoint (indexing lag)
+	// before falling back to /evaluate/utxos, and only fall back when the
+	// additional set has no native assets.
+	var lastErr error
+	for attempt := 1; attempt <= evaluateSimpleRetries; attempt++ {
+		result, err := b.evaluateTxSimple(txCbor)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !isMissingInputsEvalError(err) {
+			return nil, err
+		}
+		if attempt < evaluateSimpleRetries {
+			time.Sleep(evaluateSimpleRetryWait)
+		}
 	}
-	if len(additionalUtxos) == 0 || !isMissingInputsEvalError(err) {
-		return nil, err
+	if len(additionalUtxos) == 0 || additionalUtxosContainNativeAssets(additionalUtxos) {
+		return nil, lastErr
 	}
 	return b.evaluateTxWithAdditionalUtxos(txCbor, additionalUtxos)
+}
+
+// additionalUtxosContainNativeAssets reports whether any resolved UTxO carries
+// a multi-asset balance. Hosted Blockfrost /evaluate/utxos currently faults on
+// those entries, so they must not be used as an evaluate fallback.
+func additionalUtxosContainNativeAssets(utxos []common.Utxo) bool {
+	for _, utxo := range utxos {
+		if utxo.Output == nil {
+			continue
+		}
+		if assets := utxo.Output.Assets(); assets != nil && len(assets.Policies()) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // evaluateTxSimple POSTs hex-encoded transaction CBOR to /utils/txs/evaluate.
@@ -516,15 +555,28 @@ func jsonValuePresent(raw json.RawMessage) bool {
 // BlockFrost proxies Ogmios, so the payload may be either the legacy Ogmios v5
 // jsonwsp shape ({"result":{"EvaluationResult":{...}}}) or the Ogmios v6 shape
 // ({"result":[{"validator":...,"budget":...}, ...]}, with failures reported as
-// a top-level {"error":{...}} object). Any other shape, and any response with
+// a top-level {"error":{...}} object). Hosted Blockfrost also sometimes returns
+// a bare Ogmios v5 jsonwsp/fault object. Any other shape, and any response with
 // zero evaluation results, is an error.
 func parseEvaluateTxResponse(data []byte) (map[common.RedeemerKey]common.ExUnits, error) {
 	var envelope struct {
+		Type   string          `json:"type"`
 		Result json.RawMessage `json:"result"`
 		Error  json.RawMessage `json:"error"`
+		Fault  json.RawMessage `json:"fault"`
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return nil, fmt.Errorf("failed to parse evaluate response: %w", err)
+	}
+	if envelope.Type == "jsonwsp/fault" || jsonValuePresent(envelope.Fault) {
+		var fault struct {
+			Code   string `json:"code"`
+			String string `json:"string"`
+		}
+		if err := json.Unmarshal(envelope.Fault, &fault); err == nil && fault.String != "" {
+			return nil, fmt.Errorf("ogmios evaluate fault (%s): %s", fault.Code, fault.String)
+		}
+		return nil, fmt.Errorf("ogmios evaluate fault: %s", evalErrorSnippet(data))
 	}
 	if jsonValuePresent(envelope.Error) {
 		var ogmiosErr struct {

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
 	"math/big"
@@ -622,13 +623,13 @@ func TestBuildEvalUtxosRequestRejectsOverflowQuantity(t *testing.T) {
 	}
 }
 
-func TestEvaluateTxWithAdditionalUtxosTargetsUtxosEndpoint(t *testing.T) {
-	var gotPath, gotContentType, gotBody string
+func TestEvaluateTxPrefersSimpleEndpointWhenAdditionalUtxosProvided(t *testing.T) {
+	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		gotContentType = r.Header.Get("Content-Type")
-		body, _ := io.ReadAll(r.Body)
-		gotBody = string(body)
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/api/v0/utils/txs/evaluate" {
+			t.Errorf("unexpected path %q; simple evaluate should succeed without /evaluate/utxos", r.URL.Path)
+		}
 		_, _ = w.Write([]byte(`{"result":{"EvaluationResult":{"spend:0":{"memory":1700,"steps":476468}}}}`))
 	}))
 	defer server.Close()
@@ -638,23 +639,52 @@ func TestEvaluateTxWithAdditionalUtxosTargetsUtxosEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotPath != "/api/v0/utils/txs/evaluate/utxos" {
-		t.Fatalf("path = %q, want /api/v0/utils/txs/evaluate/utxos", gotPath)
-	}
-	if gotContentType != "application/json" {
-		t.Fatalf("content-type = %q, want application/json", gotContentType)
-	}
-	// Body must be valid JSON carrying the cbor + additionalUtxoSet keys.
-	var parsed map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(gotBody), &parsed); err != nil {
-		t.Fatalf("request body is not JSON: %v", err)
-	}
-	if _, ok := parsed["additionalUtxoSet"]; !ok {
-		t.Fatal("request body missing additionalUtxoSet")
+	if len(paths) != 1 || paths[0] != "/api/v0/utils/txs/evaluate" {
+		t.Fatalf("paths = %v, want single /api/v0/utils/txs/evaluate", paths)
 	}
 	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
 	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
 		t.Fatalf("unexpected ExUnits %+v", eu)
+	}
+}
+
+func TestEvaluateTxFallsBackToUtxosOnMissingInputs(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v0/utils/txs/evaluate":
+			// Mimic Ogmios/Blockfrost reporting unknown inputs on the simple path.
+			_, _ = w.Write([]byte(`{"result":{"EvaluationFailure":{"UnknownInputs":["abc#0"]}}}`))
+		case "/api/v0/utils/txs/evaluate/utxos":
+			_, _ = w.Write([]byte(`{"result":{"EvaluationResult":{"spend:0":{"memory":1700,"steps":476468}}}}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	ctx := NewBlockFrostChainContext(server.URL, 0, "")
+	result, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{sampleCommonUtxo(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPaths := []string{"/api/v0/utils/txs/evaluate", "/api/v0/utils/txs/evaluate/utxos"}
+	if len(paths) != 2 || paths[0] != wantPaths[0] || paths[1] != wantPaths[1] {
+		t.Fatalf("paths = %v, want %v", paths, wantPaths)
+	}
+	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
+		t.Fatalf("unexpected ExUnits %+v", eu)
+	}
+}
+
+func TestIsMissingInputsEvalError(t *testing.T) {
+	if !isMissingInputsEvalError(errors.New(`script evaluation failed: {"UnknownInputs":[]}`)) {
+		t.Fatal("expected UnknownInputs to match")
+	}
+	if isMissingInputsEvalError(errors.New(`unrecognized evaluate response: failed to decode payload from base64 or base16`)) {
+		t.Fatal("decode fault must not trigger utxos fallback")
 	}
 }
 

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -649,6 +649,12 @@ func TestEvaluateTxPrefersSimpleEndpointWhenAdditionalUtxosProvided(t *testing.T
 }
 
 func TestEvaluateTxFallsBackToUtxosOnMissingInputs(t *testing.T) {
+	prevRetries, prevWait := evaluateSimpleRetries, evaluateSimpleRetryWait
+	evaluateSimpleRetries, evaluateSimpleRetryWait = 2, 0
+	defer func() {
+		evaluateSimpleRetries, evaluateSimpleRetryWait = prevRetries, prevWait
+	}()
+
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
@@ -665,13 +671,23 @@ func TestEvaluateTxFallsBackToUtxosOnMissingInputs(t *testing.T) {
 	defer server.Close()
 
 	ctx := NewBlockFrostChainContext(server.URL, 0, "")
-	result, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{sampleCommonUtxo(t)})
+	// ADA-only additional UTxO: fallback to /evaluate/utxos is allowed.
+	result, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{sampleAdaOnlyUtxo(t)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantPaths := []string{"/api/v0/utils/txs/evaluate", "/api/v0/utils/txs/evaluate/utxos"}
-	if len(paths) != 2 || paths[0] != wantPaths[0] || paths[1] != wantPaths[1] {
+	wantPaths := []string{
+		"/api/v0/utils/txs/evaluate",
+		"/api/v0/utils/txs/evaluate",
+		"/api/v0/utils/txs/evaluate/utxos",
+	}
+	if len(paths) != len(wantPaths) {
 		t.Fatalf("paths = %v, want %v", paths, wantPaths)
+	}
+	for i := range wantPaths {
+		if paths[i] != wantPaths[i] {
+			t.Fatalf("paths = %v, want %v", paths, wantPaths)
+		}
 	}
 	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
 	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
@@ -679,12 +695,85 @@ func TestEvaluateTxFallsBackToUtxosOnMissingInputs(t *testing.T) {
 	}
 }
 
+func TestEvaluateTxRetriesSimpleWhenAdditionalUtxosHaveAssets(t *testing.T) {
+	prevRetries, prevWait := evaluateSimpleRetries, evaluateSimpleRetryWait
+	evaluateSimpleRetries, evaluateSimpleRetryWait = 3, 0
+	defer func() {
+		evaluateSimpleRetries, evaluateSimpleRetryWait = prevRetries, prevWait
+	}()
+
+	var paths []string
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/api/v0/utils/txs/evaluate" {
+			t.Errorf("unexpected path %q; asset-bearing UTxOs must not use /evaluate/utxos", r.URL.Path)
+			return
+		}
+		attempts++
+		if attempts < 3 {
+			_, _ = w.Write([]byte(`{"result":{"EvaluationFailure":{"UnknownInputs":["abc#0"]}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"result":{"EvaluationResult":{"spend:0":{"memory":1700,"steps":476468}}}}`))
+	}))
+	defer server.Close()
+
+	ctx := NewBlockFrostChainContext(server.URL, 0, "")
+	result, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{sampleCommonUtxo(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 3 {
+		t.Fatalf("simple attempts = %d, want 3", attempts)
+	}
+	for _, p := range paths {
+		if p != "/api/v0/utils/txs/evaluate" {
+			t.Fatalf("paths = %v, want only simple evaluate", paths)
+		}
+	}
+	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
+		t.Fatalf("unexpected ExUnits %+v", eu)
+	}
+}
+
+func TestParseEvaluateTxResponseOgmiosFault(t *testing.T) {
+	data := []byte(`{"type":"jsonwsp/fault","version":"1.0","servicename":"ogmios",` +
+		`"fault":{"code":"client","string":"Invalid request: failed to decode payload from base64 or base16."}}`)
+	_, err := parseEvaluateTxResponse(data)
+	if err == nil {
+		t.Fatal("expected fault error")
+	}
+	if !strings.Contains(err.Error(), "failed to decode payload") {
+		t.Fatalf("error should include fault string, got: %v", err)
+	}
+}
+
 func TestIsMissingInputsEvalError(t *testing.T) {
 	if !isMissingInputsEvalError(errors.New(`script evaluation failed: {"UnknownInputs":[]}`)) {
 		t.Fatal("expected UnknownInputs to match")
 	}
-	if isMissingInputsEvalError(errors.New(`unrecognized evaluate response: failed to decode payload from base64 or base16`)) {
+	if isMissingInputsEvalError(errors.New(`ogmios evaluate fault (client): failed to decode payload from base64 or base16`)) {
 		t.Fatal("decode fault must not trigger utxos fallback")
+	}
+}
+
+// sampleAdaOnlyUtxo builds a resolved ADA-only UTxO suitable for the
+// /evaluate/utxos fallback path (no native assets).
+func sampleAdaOnlyUtxo(t *testing.T) common.Utxo {
+	t.Helper()
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x44
+	}
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: testAddress(t),
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 2_000_000},
+	}
+	return common.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 0},
+		Output: &output,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Prefer Blockfrost `/utils/txs/evaluate` for ExUnit estimation when spending inputs are already on-chain; only fall back to `/utils/txs/evaluate/utxos` when the simple path reports missing/unknown inputs.
- Apollo always passes spending inputs as `additionalUtxos`, which forced every script-spend evaluation onto `/evaluate/utxos`. Hosted Blockfrost→Ogmios currently rejects that path for additional UTxOs that include native assets (jsonwsp fault: `failed to decode payload from base64 or base16`), even though the same Conway txs evaluate successfully via the bare endpoint.
- Prefer original on-chain datum CBOR bytes over re-encoding when building the additional UTxO set for the fallback path.

## Test plan
- [x] `go test ./backend/blockfrost/`
- [ ] Manual: Blockfrost EvaluateTx for a confirmed on-chain script-spend hits `/utils/txs/evaluate` and returns ExUnits
- [ ] Manual: EvaluateTx with missing inputs still falls back to `/utils/txs/evaluate/utxos`
