### PR TITLE
fix: balance and converge EvalTx draft shape

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -1122,7 +1122,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	if err != nil {
 		return a, err
 	}
-	totalRequired, err = totalRequired.Add(governanceRequired)
+	balanceRequired, err := totalRequired.Add(governanceRequired)
 	if err != nil {
 		return a, fmt.Errorf("governance value overflow: %w", err)
 	}
@@ -1188,7 +1188,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, fmt.Errorf("preliminary fee overflows int64: max fee=%d reference script fee=%d", prelimFee, refScriptFeeReserve)
 	}
 	prelimFee += refScriptFeeReserve
-	selectionTarget, err := totalRequired.Add(NewSimpleValue(uint64(prelimFee))) //nolint:gosec // maxFee is bounded above and refScriptFeeReserve overflow is checked above
+	selectionTarget, err := balanceRequired.Add(NewSimpleValue(uint64(prelimFee))) //nolint:gosec // maxFee is bounded above and refScriptFeeReserve overflow is checked above
 	if err != nil {
 		return a, fmt.Errorf("selection target overflow: %w", err)
 	}
@@ -1236,19 +1236,8 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, err
 	}
 
-	// Automatic ExUnit estimation for script transactions
-	if a.isEstimateRequired && a.estimateExUnits {
-		if err := a.estimateExecutionUnits(allInputUtxos, outputs); err != nil {
-			return a, fmt.Errorf("ExUnit estimation failed: %w", err)
-		}
-	}
-
-	// Estimate fee with a convergence loop. The initial estimate is computed
-	// without a change output, but the final transaction will likely include
-	// one. After computing the change output, we re-estimate the fee with
-	// the full output set. If the fee increases, we recompute change. This
-	// typically converges in 1-2 iterations.
-	const maxFeeIterations = 3
+	// Estimate the initial fee. The balanced evaluation loop below rebuilds the
+	// complete transaction shape (change, collateral, and ExUnits) until stable.
 	baseOutputs := make([]babbage.BabbageTransactionOutput, len(outputs))
 	copy(baseOutputs, outputs)
 
@@ -1299,143 +1288,68 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		}
 	}
 
-	changeAddr := a.getChangeAddress()
-
-	// buildOutputsWithChange computes the output set (base outputs plus a
-	// change output if needed) for the given fee.
-	buildOutputsWithChange := func(fee int64) ([]babbage.BabbageTransactionOutput, error) {
-		outputs := make([]babbage.BabbageTransactionOutput, len(baseOutputs))
-		copy(outputs, baseOutputs)
-
-		// Calculate change: totalRequired includes deposits, totalInput includes refunds.
-		if fee < 0 {
-			return nil, fmt.Errorf("negative fee: %d", fee)
-		}
-		feeValue := NewSimpleValue(uint64(fee)) //nolint:gosec // validated non-negative above
-		totalNeeded, err := totalRequired.Add(feeValue)
-		if err != nil {
-			return nil, fmt.Errorf("required value overflow: %w", err)
-		}
-		changeValue, err := totalInput.Sub(totalNeeded)
-		if err != nil {
-			return nil, fmt.Errorf("insufficient funds: %w", err)
-		}
-		// Reject burns not covered by inputs and prune zero quantities,
-		// which are invalid in Conway-era output values.
-		changeValue.Assets, err = normalizeChangeAssets(changeValue.Assets)
-		if err != nil {
-			return nil, err
-		}
-
-		if changeValue.Coin > 0 || changeValue.HasAssets() {
-			changeOutput := NewBabbageOutput(changeAddr, changeValue, nil, nil)
-			pp, err := a.Context.ProtocolParams()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get protocol params for change output: %w", err)
-			}
-			minChange, err := MinLovelacePostAlonzo(&changeOutput, pp.CoinsPerUtxoByteValue())
-			if err != nil {
-				return nil, fmt.Errorf("failed to compute min UTxO for change output: %w", err)
-			}
-			if minChange < 0 {
-				return nil, fmt.Errorf("invalid min UTxO for change output: %d", minChange)
-			}
-			if changeValue.Coin >= uint64(minChange) {
-				outputs = append(outputs, changeOutput)
-			} else if changeValue.HasAssets() {
-				// Change has assets but insufficient ADA for min UTxO.
-				// The shortfall must come from available inputs.
-				shortfall := uint64(minChange) - changeValue.Coin
-				changeValue.Coin = uint64(minChange)
-				changeOutput = NewBabbageOutput(changeAddr, changeValue, nil, nil)
-				actualMin, err := MinLovelacePostAlonzo(&changeOutput, pp.CoinsPerUtxoByteValue())
-				if err != nil {
-					return nil, fmt.Errorf("failed to compute actual min UTxO for change output: %w", err)
-				}
-				if actualMin > minChange {
-					// minChange validated non-negative above, actualMin > minChange
-					shortfall += uint64(actualMin) - uint64(minChange) //nolint:gosec
-					changeValue.Coin = uint64(actualMin)               //nolint:gosec
-					changeOutput = NewBabbageOutput(changeAddr, changeValue, nil, nil)
-				}
-				// Verify the shortfall is covered by total input.
-				// totalInput already includes refunds; add deposits to the output side.
-				totalInputCoin := totalInput.Coin
-				totalOutputCoin := uint64(0)
-				for _, out := range outputs {
-					totalOutputCoin += out.OutputAmount.Amount
-				}
-				totalOutputCoin += changeValue.Coin + uint64(fee) //nolint:gosec // validated non-negative above
-				depositAdj := a.certificateDepositAdjustment(stakeDeposit)
-				if depositAdj > 0 {
-					totalOutputCoin += uint64(depositAdj)
-				}
-				totalOutputCoin += governanceRequired.Coin
-				if totalOutputCoin > totalInputCoin {
-					return nil, fmt.Errorf("insufficient funds: need %d more lovelace for change output min UTxO", totalOutputCoin-totalInputCoin)
-				}
-				_ = shortfall // verified via balance check above
-				outputs = append(outputs, changeOutput)
-			}
-			// If change is ADA-only but below min UTxO and has no assets,
-			// it is too small to create an output -- absorbed as additional fee.
-		}
-		return outputs, nil
+	balance := balanceContext{
+		totalInput:         totalInput,
+		totalRequired:      totalRequired,
+		governanceRequired: governanceRequired,
+		stakeDeposit:       stakeDeposit,
+		changeAddress:      a.getChangeAddress(),
 	}
-
+	const maxEvaluationIterations = 5
+	var previousShape string
+	seenShapes := make(map[string]struct{}, maxEvaluationIterations)
 	converged := false
-	for range maxFeeIterations {
-		outputs, err = buildOutputsWithChange(fee)
-		if err != nil {
-			return a, err
+	for range maxEvaluationIterations {
+		balanced, balanceErr := a.buildBalancedOutputs(baseOutputs, fee, balance)
+		if balanceErr != nil {
+			return a, balanceErr
 		}
-
-		// Re-estimate fee with the full output set (including change).
-		// If the user set an explicit fee, skip re-estimation.
-		if a.Fee > 0 {
-			converged = true
-			break
-		}
-		// Size the collateral against the current fee BEFORE re-estimating, so
-		// the fee accounts for the final collateral total/return footprint in
-		// the body. A collateral_return that only materializes after sizing
-		// would otherwise grow the tx past the frozen estimate.
+		outputs, fee = balanced.Outputs, balanced.Fee
 		if err := a.finalizeCollateral(fee); err != nil {
 			return a, err
 		}
-		newFee, err := a.estimateFee(allInputUtxos, outputs)
-		if err != nil {
-			return a, fmt.Errorf("fee re-estimation failed: %w", err)
+
+		if a.isEstimateRequired && a.estimateExUnits {
+			units, evalErr := a.estimateExecutionUnits(allInputUtxos, outputs, fee)
+			if evalErr != nil {
+				return a, fmt.Errorf("ExUnit estimation failed: %w", evalErr)
+			}
+			a.applyExecutionUnits(units, allInputUtxos)
 		}
-		newFee += a.FeePadding
-		if newFee < 0 {
-			newFee = 0
+
+		body, bodyErr := a.buildBody(allInputUtxos, outputs, uint64(fee))
+		if bodyErr != nil {
+			return a, bodyErr
 		}
-		if newFee <= fee {
-			// Fee did not increase; the current estimate is sufficient.
+		bodyBytes, bodyErr := cbor.Encode(&body)
+		if bodyErr != nil {
+			return a, fmt.Errorf("failed to encode evaluation shape: %w", bodyErr)
+		}
+		shape := string(bodyBytes)
+		newFee := fee
+		if !a.forceFee && a.Fee == 0 {
+			newFee, err = a.estimateFee(allInputUtxos, outputs)
+			if err != nil {
+				return a, fmt.Errorf("fee re-estimation failed: %w", err)
+			}
+			newFee += a.FeePadding
+			if newFee < 0 {
+				newFee = 0
+			}
+		}
+		if newFee == fee && previousShape == shape {
 			converged = true
 			break
 		}
+		if _, seen := seenShapes[shape]; seen {
+			return a, errors.New("evaluation transaction did not converge after 5 iterations")
+		}
+		seenShapes[shape] = struct{}{}
+		previousShape = shape
 		fee = newFee
 	}
 	if !converged {
-		// The final iteration raised the fee after outputs were computed;
-		// rebuild the change output against the final fee so the transaction
-		// still conserves value.
-		outputs, err = buildOutputsWithChange(fee)
-		if err != nil {
-			return a, err
-		}
-	}
-
-	// Recompute total collateral and the collateral return from the FINAL fee.
-	// setCollateral() runs before coin selection and fee estimation, so it can
-	// only size collateral from a preliminary (max-by-size) fee. The ledger
-	// requires total collateral >= ceil(fee * collateralPercent / 100) against
-	// the ACTUAL fee, so a stale preliminary value triggers
-	// InsufficientCollateral. Resize here now that the fee is final.
-	if err := a.finalizeCollateral(fee); err != nil {
-		return a, err
+		return a, errors.New("evaluation transaction did not converge after 5 iterations")
 	}
 
 	// Build transaction body
@@ -1846,33 +1760,25 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 // estimateExecutionUnits builds a preliminary transaction and evaluates it
 // against the chain to get actual execution units for script redeemers.
 // The returned ExUnits include a buffer for safety.
-func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) error {
+func (a *Apollo) estimateExecutionUnits(
+	inputs []common.Utxo,
+	outputs []babbage.BabbageTransactionOutput,
+	fee int64,
+) (map[common.RedeemerKey]common.ExUnits, error) {
 	// Build preliminary tx with current (possibly zero) ExUnits. The fee field
 	// is `omitempty`, so a zero fee is dropped from the CBOR and the body has no
 	// fee (key 2). Strict evaluators (Ogmios, and Blockfrost which proxies it)
 	// reject such a body with "field fee with key 2, not decoded". Use a
 	// non-zero placeholder fee so the field is always present; its value does
 	// not affect script evaluation.
-	placeholderFee, feeErr := a.Context.MaxTxFee()
-	if feeErr != nil || placeholderFee == 0 {
-		placeholderFee = 2_000_000
+	if fee < 0 {
+		return nil, fmt.Errorf("negative fee: %d", fee)
 	}
-	body, err := a.buildBody(inputs, outputs, placeholderFee)
+	body, err := a.buildBody(inputs, outputs, uint64(fee)) //nolint:gosec // validated non-negative above
 	if err != nil {
-		return fmt.Errorf("failed to build preliminary tx body: %w", err)
+		return nil, fmt.Errorf("failed to build preliminary tx body: %w", err)
 	}
 	ws := a.buildWitnessSet(inputs)
-
-	// Add fake vkey witnesses for a realistic tx
-	witnessCount := 1 + len(a.requiredSigners)
-	fakeWitnesses := make([]common.VkeyWitness, witnessCount)
-	for i := range fakeWitnesses {
-		fakeWitnesses[i] = common.VkeyWitness{
-			Vkey:      make([]byte, 32),
-			Signature: make([]byte, 64),
-		}
-	}
-	ws.VkeyWitnesses = cbor.NewSetType(fakeWitnesses, true)
 
 	prelimTx := conway.ConwayTransaction{
 		Body:       body,
@@ -1882,7 +1788,7 @@ func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.
 	if a.auxiliaryData != nil {
 		md, mdErr := a.buildMetadata()
 		if mdErr != nil {
-			return mdErr
+			return nil, mdErr
 		}
 		if md != nil {
 			prelimTx.TxMetadata = md
@@ -1890,20 +1796,24 @@ func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.
 	}
 	txBytes, err := cbor.Encode(&prelimTx)
 	if err != nil {
-		return fmt.Errorf("failed to encode preliminary tx: %w", err)
+		return nil, fmt.Errorf("failed to encode preliminary tx: %w", err)
 	}
 
 	evalResult, err := a.Context.EvaluateTx(txBytes, inputs)
 	if err != nil {
-		return fmt.Errorf("EvaluateTx failed: %w", err)
+		return nil, fmt.Errorf("EvaluateTx failed: %w", err)
 	}
 	if len(evalResult) == 0 {
-		return errors.New("EvaluateTx returned no results")
+		return nil, errors.New("EvaluateTx returned no results")
 	}
 
-	// Update redeemers with evaluated ExUnits + buffer. Results that do not
+	// Validate every result before changing registered redeemers. Results that do not
 	// match a registered redeemer indicate a misbehaving evaluation backend;
 	// fail closed rather than sign a transaction with zero execution budgets.
+	validated := make(map[common.RedeemerKey]common.ExUnits, len(evalResult))
+	seenSpend := make(map[string]bool, len(a.redeemers))
+	seenMint := make(map[string]bool, len(a.mintRedeemers))
+	seenStake := make(map[string]bool, len(a.stakeRedeemers))
 	for evalKey, evalUnits := range evalResult {
 		bufferedUnits := common.ExUnits{
 			Memory: bufferExUnits(evalUnits.Memory, 1+ExMemoryBuffer),
@@ -1913,66 +1823,92 @@ func (a *Apollo) estimateExecutionUnits(inputs []common.Utxo, outputs []babbage.
 		case common.RedeemerTagSpend:
 			// Find the spending redeemer for this input index
 			if uint64(evalKey.Index) >= uint64(len(inputs)) {
-				return fmt.Errorf("EvaluateTx returned spend redeemer index %d out of range (%d inputs)", evalKey.Index, len(inputs))
+				return nil, fmt.Errorf("EvaluateTx returned spend redeemer index %d out of range (%d inputs)", evalKey.Index, len(inputs))
 			}
 			ref := utxoRef(inputs[evalKey.Index])
 			entry, ok := a.redeemers[ref]
 			if !ok {
-				return fmt.Errorf("EvaluateTx returned a result for input %s, which has no registered redeemer", ref)
+				return nil, fmt.Errorf("EvaluateTx returned a result for input %s, which has no registered redeemer", ref)
 			}
-			entry.ExUnits = bufferedUnits
-			a.redeemers[ref] = entry
+			_ = entry
+			seenSpend[ref] = true
 		case common.RedeemerTagMint:
 			sortedPolicies := a.sortedMintPolicyIds()
 			if uint64(evalKey.Index) >= uint64(len(sortedPolicies)) {
-				return fmt.Errorf("EvaluateTx returned mint redeemer index %d out of range (%d policies)", evalKey.Index, len(sortedPolicies))
+				return nil, fmt.Errorf("EvaluateTx returned mint redeemer index %d out of range (%d policies)", evalKey.Index, len(sortedPolicies))
 			}
 			policyHex := sortedPolicies[evalKey.Index]
 			entry, ok := a.mintRedeemers[policyHex]
 			if !ok {
-				return fmt.Errorf("EvaluateTx returned a result for mint policy %s, which has no registered redeemer", policyHex)
+				return nil, fmt.Errorf("EvaluateTx returned a result for mint policy %s, which has no registered redeemer", policyHex)
 			}
-			entry.ExUnits = bufferedUnits
-			a.mintRedeemers[policyHex] = entry
+			_ = entry
+			seenMint[policyHex] = true
 		case common.RedeemerTagReward:
 			sortedWdAddrs := a.sortedWithdrawalKeys()
 			if uint64(evalKey.Index) >= uint64(len(sortedWdAddrs)) {
-				return fmt.Errorf("EvaluateTx returned withdrawal redeemer index %d out of range (%d withdrawals)", evalKey.Index, len(sortedWdAddrs))
+				return nil, fmt.Errorf("EvaluateTx returned withdrawal redeemer index %d out of range (%d withdrawals)", evalKey.Index, len(sortedWdAddrs))
 			}
 			addrKey := sortedWdAddrs[evalKey.Index]
 			wd := a.withdrawals[addrKey]
 			skhHex := hex.EncodeToString(wd.Address.StakeKeyHash().Bytes())
 			entry, ok := a.stakeRedeemers[skhHex]
 			if !ok {
-				return fmt.Errorf("EvaluateTx returned a result for withdrawal %s, which has no registered redeemer", skhHex)
+				return nil, fmt.Errorf("EvaluateTx returned a result for withdrawal %s, which has no registered redeemer", skhHex)
 			}
-			entry.ExUnits = bufferedUnits
-			a.stakeRedeemers[skhHex] = entry
+			_ = entry
+			seenStake[skhHex] = true
 		default:
-			return fmt.Errorf("EvaluateTx returned unsupported redeemer tag %d", evalKey.Tag)
+			return nil, fmt.Errorf("EvaluateTx returned unsupported redeemer tag %d", evalKey.Tag)
 		}
+		validated[evalKey] = bufferedUnits
 	}
 
 	// Every registered redeemer must have received an execution budget; a
 	// redeemer left at zero ExUnits would fail phase-2 validation on-chain
 	// and forfeit the collateral.
-	for ref, entry := range a.redeemers {
-		if entry.ExUnits.Memory == 0 && entry.ExUnits.Steps == 0 {
-			return fmt.Errorf("execution-unit evaluation returned no result for spend redeemer on input %s", ref)
+	for ref := range a.redeemers {
+		if !seenSpend[ref] {
+			return nil, fmt.Errorf("execution-unit evaluation returned no result for spend redeemer on input %s", ref)
 		}
 	}
-	for policyHex, entry := range a.mintRedeemers {
-		if entry.ExUnits.Memory == 0 && entry.ExUnits.Steps == 0 {
-			return fmt.Errorf("execution-unit evaluation returned no result for mint redeemer on policy %s", policyHex)
+	for policyHex := range a.mintRedeemers {
+		if !seenMint[policyHex] {
+			return nil, fmt.Errorf("execution-unit evaluation returned no result for mint redeemer on policy %s", policyHex)
 		}
 	}
-	for skhHex, entry := range a.stakeRedeemers {
-		if entry.ExUnits.Memory == 0 && entry.ExUnits.Steps == 0 {
-			return fmt.Errorf("execution-unit evaluation returned no result for withdrawal redeemer on stake key %s", skhHex)
+	for skhHex := range a.stakeRedeemers {
+		if !seenStake[skhHex] {
+			return nil, fmt.Errorf("execution-unit evaluation returned no result for withdrawal redeemer on stake key %s", skhHex)
 		}
 	}
 
-	return nil
+	return validated, nil
+}
+
+// applyExecutionUnits is deliberately separate from estimateExecutionUnits:
+// callers only reach it after the complete evaluator response was validated.
+func (a *Apollo) applyExecutionUnits(units map[common.RedeemerKey]common.ExUnits, inputs []common.Utxo) {
+	for key, exUnits := range units {
+		switch key.Tag {
+		case common.RedeemerTagSpend:
+			ref := utxoRef(inputs[key.Index])
+			entry := a.redeemers[ref]
+			entry.ExUnits = exUnits
+			a.redeemers[ref] = entry
+		case common.RedeemerTagMint:
+			policy := a.sortedMintPolicyIds()[key.Index]
+			entry := a.mintRedeemers[policy]
+			entry.ExUnits = exUnits
+			a.mintRedeemers[policy] = entry
+		case common.RedeemerTagReward:
+			wd := a.withdrawals[a.sortedWithdrawalKeys()[key.Index]]
+			stakeKey := hex.EncodeToString(wd.Address.StakeKeyHash().Bytes())
+			entry := a.stakeRedeemers[stakeKey]
+			entry.ExUnits = exUnits
+			a.stakeRedeemers[stakeKey] = entry
+		}
+	}
 }
 
 // bufferExUnits scales evaluated execution units by a safety factor, saturating

--- a/apollo.go
+++ b/apollo.go
@@ -1317,7 +1317,10 @@ func (a *Apollo) Complete() (*Apollo, error) {
 			a.applyExecutionUnits(units, allInputUtxos)
 		}
 
-		body, bodyErr := a.buildBody(allInputUtxos, outputs, uint64(fee))
+		if fee < 0 {
+			return a, fmt.Errorf("negative fee: %d", fee)
+		}
+		body, bodyErr := a.buildBody(allInputUtxos, outputs, uint64(fee)) //nolint:gosec // validated non-negative above
 		if bodyErr != nil {
 			return a, bodyErr
 		}

--- a/evaluation_balance.go
+++ b/evaluation_balance.go
@@ -1,0 +1,105 @@
+package apollo
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// balanceContext contains every value in the Cardano balance equation that is
+// not a regular output or transaction fee. It is shared by provisional script
+// evaluation and final transaction construction so both see the same change.
+type balanceContext struct {
+	totalInput         Value
+	totalRequired      Value
+	governanceRequired Value
+	stakeDeposit       int64
+	changeAddress      common.Address
+}
+
+type balancedOutputs struct {
+	Outputs []babbage.BabbageTransactionOutput
+	Fee     int64
+}
+
+// buildBalancedOutputs appends change to baseOutputs for the supplied fee.
+// ADA-only change below min-UTxO is added to the fee; native assets are never
+// discarded and must be carried in a valid change output.
+func (a *Apollo) buildBalancedOutputs(
+	baseOutputs []babbage.BabbageTransactionOutput,
+	requestedFee int64,
+	ctx balanceContext,
+) (balancedOutputs, error) {
+	if requestedFee < 0 {
+		return balancedOutputs{}, fmt.Errorf("negative fee: %d", requestedFee)
+	}
+	outputs := make([]babbage.BabbageTransactionOutput, len(baseOutputs))
+	copy(outputs, baseOutputs)
+
+	needed, err := ctx.totalRequired.Add(ctx.governanceRequired)
+	if err != nil {
+		return balancedOutputs{}, fmt.Errorf("required value overflow: %w", err)
+	}
+	needed, err = needed.Add(NewSimpleValue(uint64(requestedFee))) //nolint:gosec // checked non-negative above
+	if err != nil {
+		return balancedOutputs{}, fmt.Errorf("required value overflow: %w", err)
+	}
+	change, err := ctx.totalInput.Sub(needed)
+	if err != nil {
+		return balancedOutputs{}, fmt.Errorf("insufficient funds: %w", err)
+	}
+	change.Assets, err = normalizeChangeAssets(change.Assets)
+	if err != nil {
+		return balancedOutputs{}, err
+	}
+	if change.Coin == 0 && !change.HasAssets() {
+		return balancedOutputs{Outputs: outputs, Fee: requestedFee}, nil
+	}
+
+	changeOutput := NewBabbageOutput(ctx.changeAddress, change, nil, nil)
+	pp, err := a.Context.ProtocolParams()
+	if err != nil {
+		return balancedOutputs{}, fmt.Errorf("failed to get protocol params for change output: %w", err)
+	}
+	minChange, err := MinLovelacePostAlonzo(&changeOutput, pp.CoinsPerUtxoByteValue())
+	if err != nil {
+		return balancedOutputs{}, fmt.Errorf("failed to compute min UTxO for change output: %w", err)
+	}
+	if minChange < 0 {
+		return balancedOutputs{}, fmt.Errorf("invalid min UTxO for change output: %d", minChange)
+	}
+
+	if change.Coin < uint64(minChange) {
+		if !change.HasAssets() {
+			if uint64(requestedFee) > math.MaxInt64-change.Coin { //nolint:gosec // checked non-negative above
+				return balancedOutputs{}, errorsNewFeeOverflow(requestedFee, change.Coin)
+			}
+			return balancedOutputs{Outputs: outputs, Fee: requestedFee + int64(change.Coin)}, nil //nolint:gosec // bound checked above
+		}
+		// A token-bearing output must meet its min-UTxO requirement. Raising
+		// its ADA consumes extra change, so prove the selected inputs cover it.
+		change.Coin = uint64(minChange)
+		changeOutput = NewBabbageOutput(ctx.changeAddress, change, nil, nil)
+		actualMin, minErr := MinLovelacePostAlonzo(&changeOutput, pp.CoinsPerUtxoByteValue())
+		if minErr != nil {
+			return balancedOutputs{}, fmt.Errorf("failed to compute actual min UTxO for change output: %w", minErr)
+		}
+		if actualMin < 0 {
+			return balancedOutputs{}, fmt.Errorf("invalid min UTxO for change output: %d", actualMin)
+		}
+		change.Coin = uint64(actualMin)
+		changeOutput = NewBabbageOutput(ctx.changeAddress, change, nil, nil)
+		neededWithChange, addErr := needed.Add(NewSimpleValue(change.Coin))
+		if addErr != nil || !ctx.totalInput.GreaterOrEqual(neededWithChange) {
+			return balancedOutputs{}, fmt.Errorf("insufficient funds for asset change min UTxO")
+		}
+	}
+	outputs = append(outputs, changeOutput)
+	return balancedOutputs{Outputs: outputs, Fee: requestedFee}, nil
+}
+
+func errorsNewFeeOverflow(fee int64, dust uint64) error {
+	return fmt.Errorf("fee overflow absorbing %d lovelace dust into %d", dust, fee)
+}

--- a/evaluation_balance.go
+++ b/evaluation_balance.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -35,7 +36,7 @@ func (a *Apollo) buildBalancedOutputs(
 	if requestedFee < 0 {
 		return balancedOutputs{}, fmt.Errorf("negative fee: %d", requestedFee)
 	}
-	outputs := make([]babbage.BabbageTransactionOutput, len(baseOutputs))
+	outputs := make([]babbage.BabbageTransactionOutput, len(baseOutputs), len(baseOutputs)+1)
 	copy(outputs, baseOutputs)
 
 	needed, err := ctx.totalRequired.Add(ctx.governanceRequired)
@@ -93,7 +94,7 @@ func (a *Apollo) buildBalancedOutputs(
 		changeOutput = NewBabbageOutput(ctx.changeAddress, change, nil, nil)
 		neededWithChange, addErr := needed.Add(NewSimpleValue(change.Coin))
 		if addErr != nil || !ctx.totalInput.GreaterOrEqual(neededWithChange) {
-			return balancedOutputs{}, fmt.Errorf("insufficient funds for asset change min UTxO")
+			return balancedOutputs{}, errors.New("insufficient funds for asset change min UTxO")
 		}
 	}
 	outputs = append(outputs, changeOutput)

--- a/evaluation_balance_test.go
+++ b/evaluation_balance_test.go
@@ -1,0 +1,90 @@
+package apollo
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func evaluationAsset(t *testing.T, quantity int64) *common.MultiAsset[common.MultiAssetTypeOutput] {
+	t.Helper()
+	var policy common.Blake2b224
+	policy[0] = 1
+	assets := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
+			policy: {cbor.NewByteString([]byte("token")): big.NewInt(quantity)},
+		},
+	)
+	return &assets
+}
+
+func TestBalancedOutputsAbsorbsAdaDustIntoFee(t *testing.T) {
+	a := New(setupFixedContext())
+	got, err := a.buildBalancedOutputs(nil, 2_000_000, balanceContext{
+		totalInput:    NewSimpleValue(2_000_100),
+		totalRequired: Value{},
+		changeAddress: testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Outputs) != 0 {
+		t.Fatalf("expected no dust change output, got %d outputs", len(got.Outputs))
+	}
+	if got.Fee != 2_000_100 {
+		t.Fatalf("fee = %d, want dust absorbed into 2000100", got.Fee)
+	}
+}
+
+func TestBalancedOutputsNeverDropsAssetChange(t *testing.T) {
+	a := New(setupFixedContext())
+	got, err := a.buildBalancedOutputs(nil, 2_000_000, balanceContext{
+		totalInput:    NewValue(5_000_000, evaluationAsset(t, 1)),
+		totalRequired: Value{},
+		changeAddress: testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Outputs) != 1 || !ValueFromMaryValue(got.Outputs[0].OutputAmount).HasAssets() {
+		t.Fatal("asset-bearing change was not retained")
+	}
+}
+
+func TestBalancedOutputsRejectsNegativeFee(t *testing.T) {
+	a := New(setupFixedContext())
+	_, err := a.buildBalancedOutputs(nil, -1, balanceContext{changeAddress: testAddress(t)})
+	if err == nil {
+		t.Fatal("expected negative fee error")
+	}
+}
+
+func TestBalancedOutputsRejectsOverflow(t *testing.T) {
+	a := New(setupFixedContext())
+	_, err := a.buildBalancedOutputs(nil, 1, balanceContext{
+		totalInput:    NewSimpleValue(math.MaxUint64),
+		totalRequired: NewSimpleValue(math.MaxUint64),
+		changeAddress: testAddress(t),
+	})
+	if err == nil {
+		t.Fatal("expected required value overflow")
+	}
+}
+
+func TestBalancedOutputsIncludesWithdrawal(t *testing.T) {
+	a := New(setupFixedContext())
+	got, err := a.buildBalancedOutputs(nil, 2_000_000, balanceContext{
+		totalInput:    NewSimpleValue(5_000_000),
+		totalRequired: NewSimpleValue(1_000_000),
+		changeAddress: testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Fee != 2_000_000 || len(got.Outputs) != 1 || got.Outputs[0].OutputAmount.Amount != 2_000_000 {
+		t.Fatalf("withdrawal-derived input did not become balanced change: %#v", got)
+	}
+}

--- a/evaluation_balance_test.go
+++ b/evaluation_balance_test.go
@@ -75,9 +75,11 @@ func TestBalancedOutputsRejectsOverflow(t *testing.T) {
 }
 
 func TestBalancedOutputsIncludesWithdrawal(t *testing.T) {
+	// Withdrawals are modeled as additional totalInput before balancing.
 	a := New(setupFixedContext())
+	const withdrawal = uint64(2_000_000)
 	got, err := a.buildBalancedOutputs(nil, 2_000_000, balanceContext{
-		totalInput:    NewSimpleValue(5_000_000),
+		totalInput:    NewSimpleValue(3_000_000 + withdrawal),
 		totalRequired: NewSimpleValue(1_000_000),
 		changeAddress: testAddress(t),
 	})
@@ -86,5 +88,77 @@ func TestBalancedOutputsIncludesWithdrawal(t *testing.T) {
 	}
 	if got.Fee != 2_000_000 || len(got.Outputs) != 1 || got.Outputs[0].OutputAmount.Amount != 2_000_000 {
 		t.Fatalf("withdrawal-derived input did not become balanced change: %#v", got)
+	}
+}
+
+func TestBalancedOutputsIncludesCertificateDeposit(t *testing.T) {
+	// Certificate deposits are part of totalRequired (as Complete() does).
+	a := New(setupFixedContext())
+	const payment, fee, deposit = uint64(1_000_000), int64(2_000_000), uint64(StakeDeposit)
+	got, err := a.buildBalancedOutputs(nil, fee, balanceContext{
+		totalInput:    NewSimpleValue(10_000_000),
+		totalRequired: NewSimpleValue(payment + deposit),
+		stakeDeposit:  StakeDeposit,
+		changeAddress: testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantChange := 10_000_000 - payment - deposit - uint64(fee)
+	if len(got.Outputs) != 1 || got.Outputs[0].OutputAmount.Amount != wantChange {
+		t.Fatalf("deposit was not reserved from change: got %#v, want change %d", got, wantChange)
+	}
+}
+
+func TestBalancedOutputsIncludesCertificateRefund(t *testing.T) {
+	// Deregistration refunds are part of totalInput (as Complete() does).
+	a := New(setupFixedContext())
+	const payment, fee, refund = uint64(1_000_000), int64(2_000_000), uint64(StakeDeposit)
+	got, err := a.buildBalancedOutputs(nil, fee, balanceContext{
+		totalInput:    NewSimpleValue(5_000_000 + refund),
+		totalRequired: NewSimpleValue(payment),
+		stakeDeposit:  StakeDeposit,
+		changeAddress: testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantChange := 5_000_000 + refund - payment - uint64(fee)
+	if len(got.Outputs) != 1 || got.Outputs[0].OutputAmount.Amount != wantChange {
+		t.Fatalf("refund was not added to change: got %#v, want change %d", got, wantChange)
+	}
+}
+
+func TestBalancedOutputsIncludesGovernanceValues(t *testing.T) {
+	// Governance must be applied via governanceRequired, not double-counted in
+	// totalRequired (Complete keeps those fields separate).
+	a := New(setupFixedContext())
+	const payment, fee, donation = uint64(1_000_000), int64(2_000_000), uint64(5_000_000)
+	got, err := a.buildBalancedOutputs(nil, fee, balanceContext{
+		totalInput:         NewSimpleValue(20_000_000),
+		totalRequired:      NewSimpleValue(payment),
+		governanceRequired: NewSimpleValue(donation),
+		changeAddress:      testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantChange := 20_000_000 - payment - donation - uint64(fee)
+	if len(got.Outputs) != 1 || got.Outputs[0].OutputAmount.Amount != wantChange {
+		t.Fatalf("governance was not reserved from change: got %#v, want change %d", got, wantChange)
+	}
+
+	// If governance were also folded into totalRequired, change would under-count.
+	doubleCounted, err := a.buildBalancedOutputs(nil, fee, balanceContext{
+		totalInput:         NewSimpleValue(20_000_000),
+		totalRequired:      NewSimpleValue(payment + donation),
+		governanceRequired: NewSimpleValue(donation),
+		changeAddress:      testAddress(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doubleCounted.Outputs[0].OutputAmount.Amount == wantChange {
+		t.Fatal("governance double-count check failed: separate fields must change the result")
 	}
 }

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -19,20 +19,20 @@ func testRedeemerDatum() common.Datum {
 	return common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
 }
 
-type evalCapture struct {
+type balancedEvalCapture struct {
 	TxCbor []byte
 	Tx     conway.ConwayTransaction
 	Utxos  []common.Utxo
 }
 
-// capturingEvalContext is a FixedChainContext wrapper that records every
+// balancedEvalContext is a FixedChainContext wrapper that records every
 // EvaluateTx call, optionally asserts value conservation, and returns
 // configured ExUnits. It never performs network I/O.
-type capturingEvalContext struct {
+type balancedEvalContext struct {
 	*fixed.FixedChainContext
 	t *testing.T
 
-	calls []evalCapture
+	calls []balancedEvalCapture
 
 	// assertTx is invoked after decoding each EvaluateTx payload.
 	assertTx func(call int, tx *conway.ConwayTransaction, utxos []common.Utxo)
@@ -41,14 +41,14 @@ type capturingEvalContext struct {
 	resultFor func(call int, tx *conway.ConwayTransaction, utxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
 }
 
-func (c *capturingEvalContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+func (c *balancedEvalContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
 	c.t.Helper()
 	var tx conway.ConwayTransaction
 	if _, err := cbor.Decode(txCbor, &tx); err != nil {
-		return nil, fmt.Errorf("capturingEvalContext: decode EvaluateTx CBOR: %w", err)
+		return nil, fmt.Errorf("balancedEvalContext: decode EvaluateTx CBOR: %w", err)
 	}
 	call := len(c.calls)
-	cap := evalCapture{
+	cap := balancedEvalCapture{
 		TxCbor: append([]byte(nil), txCbor...),
 		Tx:     tx,
 		Utxos:  append([]common.Utxo(nil), additionalUtxos...),
@@ -58,7 +58,7 @@ func (c *capturingEvalContext) EvaluateTx(txCbor []byte, additionalUtxos []commo
 		c.assertTx(call, &tx, additionalUtxos)
 	}
 	if c.resultFor == nil {
-		return nil, errors.New("capturingEvalContext: resultFor not configured")
+		return nil, errors.New("balancedEvalContext: resultFor not configured")
 	}
 	return c.resultFor(call, &tx, additionalUtxos)
 }
@@ -69,7 +69,7 @@ func mintRedeemerUnits(memory, steps int64) map[common.RedeemerKey]common.ExUnit
 	}
 }
 
-func setupMintEvalBuilder(t *testing.T, cc *capturingEvalContext, paymentLovelace int64, mintQty int64) *Apollo {
+func setupMintEvalBuilder(t *testing.T, cc *balancedEvalContext, paymentLovelace int64, mintQty int64) *Apollo {
 	t.Helper()
 	addr := testAddress(t)
 	addTestUtxo(cc.FixedChainContext, addr, 50_000_000, 0x01, 0)
@@ -184,7 +184,7 @@ func assertAssetConservedDraft(t *testing.T, tx *conway.ConwayTransaction, utxos
 }
 
 func TestEstimateExecutionUnitsDraftConservesAda(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
@@ -212,7 +212,7 @@ func TestEstimateExecutionUnitsDraftConservesMintedAssets(t *testing.T) {
 		policy[i] = 0xab
 	}
 	name := []byte("token")
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
@@ -244,7 +244,7 @@ func TestEstimateExecutionUnitsDraftConservesBurnedAssets(t *testing.T) {
 		},
 	)
 
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
@@ -281,7 +281,7 @@ func TestEstimateExecutionUnitsDraftConservesBurnedAssets(t *testing.T) {
 }
 
 func TestEvaluationReRunsWhenChangeOutputAppears(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(_ int, tx *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
@@ -312,7 +312,7 @@ func TestEvaluationReRunsWhenChangeOutputAppears(t *testing.T) {
 }
 
 func TestEvaluationReRunsWhenFeeChanges(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(_ int, tx *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
@@ -342,7 +342,7 @@ func TestEvaluationReRunsWhenFeeChanges(t *testing.T) {
 }
 
 func TestEvaluationReRunsWhenCollateralChanges(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(_ int, tx *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
@@ -372,7 +372,7 @@ func TestEvaluationReRunsWhenCollateralChanges(t *testing.T) {
 }
 
 func TestEvaluationConvergesOnFinalScriptVisibleShape(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
@@ -414,7 +414,7 @@ func TestEvaluationConvergesOnFinalScriptVisibleShape(t *testing.T) {
 }
 
 func TestEvaluationFailsClosedOnShapeCycle(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(call int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
@@ -436,7 +436,7 @@ func TestEvaluationFailsClosedOnShapeCycle(t *testing.T) {
 }
 
 func TestEvaluationDoesNotMutatePaymentsOnFailure(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
@@ -474,7 +474,7 @@ func TestEvaluationDoesNotMutatePaymentsOnFailure(t *testing.T) {
 }
 
 func TestEvaluationKeepsDeterministicOutputOrder(t *testing.T) {
-	cc := &capturingEvalContext{
+	cc := &balancedEvalContext{
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -1,0 +1,524 @@
+package apollo
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+func testRedeemerDatum() common.Datum {
+	return common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+}
+
+type evalCapture struct {
+	TxCbor []byte
+	Tx     conway.ConwayTransaction
+	Utxos  []common.Utxo
+}
+
+// capturingEvalContext is a FixedChainContext wrapper that records every
+// EvaluateTx call, optionally asserts value conservation, and returns
+// configured ExUnits. It never performs network I/O.
+type capturingEvalContext struct {
+	*fixed.FixedChainContext
+	t *testing.T
+
+	calls []evalCapture
+
+	// assertTx is invoked after decoding each EvaluateTx payload.
+	assertTx func(call int, tx *conway.ConwayTransaction, utxos []common.Utxo)
+
+	// resultFor returns ExUnits (or an error) for the call.
+	resultFor func(call int, tx *conway.ConwayTransaction, utxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
+}
+
+func (c *capturingEvalContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	c.t.Helper()
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(txCbor, &tx); err != nil {
+		return nil, fmt.Errorf("capturingEvalContext: decode EvaluateTx CBOR: %w", err)
+	}
+	call := len(c.calls)
+	cap := evalCapture{
+		TxCbor: append([]byte(nil), txCbor...),
+		Tx:     tx,
+		Utxos:  append([]common.Utxo(nil), additionalUtxos...),
+	}
+	c.calls = append(c.calls, cap)
+	if c.assertTx != nil {
+		c.assertTx(call, &tx, additionalUtxos)
+	}
+	if c.resultFor == nil {
+		return nil, fmt.Errorf("capturingEvalContext: resultFor not configured")
+	}
+	return c.resultFor(call, &tx, additionalUtxos)
+}
+
+func mintRedeemerUnits(memory, steps int64) map[common.RedeemerKey]common.ExUnits {
+	return map[common.RedeemerKey]common.ExUnits{
+		{Tag: common.RedeemerTagMint, Index: 0}: {Memory: memory, Steps: steps},
+	}
+}
+
+func setupMintEvalBuilder(t *testing.T, cc *capturingEvalContext, paymentLovelace int64, mintQty int64) *Apollo {
+	t.Helper()
+	addr := testAddress(t)
+	addTestUtxo(cc.FixedChainContext, addr, 50_000_000, 0x01, 0)
+	addTestUtxo(cc.FixedChainContext, addr, 20_000_000, 0x02, 0)
+
+	policyHex := strings.Repeat("ab", 28)
+	redeemer := testRedeemerDatum()
+	units := []Unit(nil)
+	if mintQty > 0 {
+		units = []Unit{NewUnit(policyHex, "746f6b656e", mintQty)}
+	}
+	p, err := NewPayment(validTestAddrBech32, paymentLovelace, units)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Mint(NewUnit(policyHex, "746f6b656e", mintQty), &redeemer, nil)
+	return a
+}
+
+func sumInputCoin(utxos []common.Utxo) uint64 {
+	var total uint64
+	for _, u := range utxos {
+		total += u.Output.Amount().Uint64()
+	}
+	return total
+}
+
+func sumOutputCoin(tx *conway.ConwayTransaction) uint64 {
+	var total uint64
+	for _, out := range tx.Body.TxOutputs {
+		total += out.OutputAmount.Amount
+	}
+	return total
+}
+
+func sumWithdrawalCoin(tx *conway.ConwayTransaction) uint64 {
+	var total uint64
+	for _, amt := range tx.Body.TxWithdrawals {
+		total += amt
+	}
+	return total
+}
+
+func assertAdaConservedDraft(t *testing.T, tx *conway.ConwayTransaction, utxos []common.Utxo) {
+	t.Helper()
+	inCoin := sumInputCoin(utxos) + sumWithdrawalCoin(tx)
+	outCoin := sumOutputCoin(tx) + tx.Body.TxFee + tx.Body.TxDonation
+	for _, proposal := range tx.Body.TxProposalProcedures {
+		outCoin += proposal.Deposit()
+	}
+	// Stake registration deposits / deregistration refunds.
+	for _, cert := range tx.Body.TxCertificates {
+		switch cert.Type {
+		case uint(common.CertificateTypeStakeRegistration),
+			uint(common.CertificateTypeRegistration),
+			uint(common.CertificateTypeStakeRegistrationDelegation),
+			uint(common.CertificateTypeVoteRegistrationDelegation),
+			uint(common.CertificateTypeStakeVoteRegistrationDelegation):
+			outCoin += StakeDeposit
+		case uint(common.CertificateTypeStakeDeregistration),
+			uint(common.CertificateTypeDeregistration):
+			inCoin += StakeDeposit
+		}
+	}
+	if inCoin != outCoin {
+		t.Fatalf("EvaluateTx draft does not conserve ADA: inputs(+wd/refund)=%d outputs(+fee/gov/deposit)=%d fee=%d outs=%d",
+			inCoin, outCoin, tx.Body.TxFee, len(tx.Body.TxOutputs))
+	}
+}
+
+func assetQty(assets *common.MultiAsset[common.MultiAssetTypeOutput], policy common.Blake2b224, name []byte) *big.Int {
+	if assets == nil {
+		return big.NewInt(0)
+	}
+	q := assets.Asset(policy, name)
+	if q == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(q)
+}
+
+func mintQty(mint *common.MultiAsset[common.MultiAssetTypeMint], policy common.Blake2b224, name []byte) *big.Int {
+	if mint == nil {
+		return big.NewInt(0)
+	}
+	q := mint.Asset(policy, name)
+	if q == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(q)
+}
+
+func assertAssetConservedDraft(t *testing.T, tx *conway.ConwayTransaction, utxos []common.Utxo, policy common.Blake2b224, name []byte) {
+	t.Helper()
+	in := big.NewInt(0)
+	for _, u := range utxos {
+		in.Add(in, assetQty(u.Output.Assets(), policy, name))
+	}
+	in.Add(in, mintQty(tx.Body.TxMint, policy, name))
+
+	out := big.NewInt(0)
+	for _, o := range tx.Body.TxOutputs {
+		out.Add(out, assetQty(o.OutputAmount.Assets, policy, name))
+	}
+	if in.Cmp(out) != 0 {
+		t.Fatalf("EvaluateTx draft does not conserve asset %x: in(+mint)=%s out=%s", name, in, out)
+	}
+}
+
+func TestEstimateExecutionUnitsDraftConservesAda(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
+			assertAdaConservedDraft(t, tx, utxos)
+			if len(tx.WitnessSet.VkeyWitnesses.Items()) != 0 {
+				t.Fatal("estimateExecutionUnits must not inject fake vkey witnesses")
+			}
+		},
+		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			return mintRedeemerUnits(1_000, 1_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 5)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.calls) == 0 {
+		t.Fatal("expected EvaluateTx to be called")
+	}
+}
+
+func TestEstimateExecutionUnitsDraftConservesMintedAssets(t *testing.T) {
+	var policy common.Blake2b224
+	for i := range policy {
+		policy[i] = 0xab
+	}
+	name := []byte("token")
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
+			assertAdaConservedDraft(t, tx, utxos)
+			assertAssetConservedDraft(t, tx, utxos, policy, name)
+			if tx.Body.TxMint == nil {
+				t.Fatal("expected mint in evaluation draft")
+			}
+		},
+		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			return mintRedeemerUnits(2_000, 2_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 5)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+}
+
+func TestEstimateExecutionUnitsDraftConservesBurnedAssets(t *testing.T) {
+	var policy common.Blake2b224
+	for i := range policy {
+		policy[i] = 0xab
+	}
+	name := []byte("token")
+	assets := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
+			policy: {cbor.NewByteString(name): big.NewInt(5)},
+		},
+	)
+
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
+			assertAdaConservedDraft(t, tx, utxos)
+			assertAssetConservedDraft(t, tx, utxos, policy, name)
+		},
+		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			return mintRedeemerUnits(2_000, 2_000), nil
+		},
+	}
+	addr := testAddress(t)
+	var txHash common.Blake2b256
+	txHash[0] = 0x11
+	cc.AddUtxo(addr, makeAssetTestUtxo(t, txHash, 0, 30_000_000, &assets))
+	addTestUtxo(cc.FixedChainContext, addr, 20_000_000, 0x12, 0)
+
+	policyHex := strings.Repeat("ab", 28)
+	redeemer := testRedeemerDatum()
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Mint(NewUnit(policyHex, "746f6b656e", -5), &redeemer, nil)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.calls) == 0 {
+		t.Fatal("expected EvaluateTx to be called")
+	}
+}
+
+func TestEvaluationReRunsWhenChangeOutputAppears(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		resultFor: func(_ int, tx *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			// Larger budget once a change output is present (balanced draft).
+			if len(tx.Body.TxOutputs) >= 2 {
+				return mintRedeemerUnits(800_000, 800_000), nil
+			}
+			return mintRedeemerUnits(1_000, 1_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.calls) < 2 {
+		t.Fatalf("expected re-evaluation after change/fee rebuild, got %d EvaluateTx calls", len(cc.calls))
+	}
+	sawChange := false
+	for _, call := range cc.calls {
+		if len(call.Tx.Body.TxOutputs) >= 2 {
+			sawChange = true
+			break
+		}
+	}
+	if !sawChange {
+		t.Fatal("expected at least one evaluation draft to include a change output")
+	}
+}
+
+func TestEvaluationReRunsWhenFeeChanges(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		resultFor: func(_ int, tx *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			// Fee-dependent budgets: low preliminary fee gets a larger budget;
+			// once the draft fee has grown, return a slightly smaller but still
+			// high budget so fee stays in the high bucket and the loop settles.
+			if tx.Body.TxFee < 250_000 {
+				return mintRedeemerUnits(3_000_000, 3_000_000), nil
+			}
+			return mintRedeemerUnits(2_800_000, 2_800_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.calls) < 2 {
+		t.Fatalf("expected fee-driven re-evaluation, got %d calls", len(cc.calls))
+	}
+	fees := map[uint64]bool{}
+	for _, call := range cc.calls {
+		fees[call.Tx.Body.TxFee] = true
+	}
+	if len(fees) < 2 {
+		t.Fatalf("expected EvaluateTx drafts with distinct fees, got %#v", fees)
+	}
+}
+
+func TestEvaluationReRunsWhenCollateralChanges(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		resultFor: func(_ int, tx *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			// Collateral-dependent budgets: low preliminary collateral gets a
+			// large budget; once finalizeCollateral grows with fee, return a
+			// distinct but still-high budget that keeps collateral elevated.
+			if tx.Body.TxTotalCollateral < 400_000 {
+				return mintRedeemerUnits(3_500_000, 3_500_000), nil
+			}
+			return mintRedeemerUnits(3_200_000, 3_200_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.calls) < 2 {
+		t.Fatalf("expected collateral-driven re-evaluation, got %d calls", len(cc.calls))
+	}
+	collaterals := map[uint64]bool{}
+	for _, call := range cc.calls {
+		collaterals[call.Tx.Body.TxTotalCollateral] = true
+	}
+	if len(collaterals) < 2 {
+		t.Fatalf("expected EvaluateTx drafts with distinct total_collateral, got %#v", collaterals)
+	}
+}
+
+func TestEvaluationConvergesOnFinalScriptVisibleShape(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		assertTx: func(_ int, tx *conway.ConwayTransaction, utxos []common.Utxo) {
+			assertAdaConservedDraft(t, tx, utxos)
+		},
+		resultFor: func(call int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			// Stable budgets after the first call so the loop can settle.
+			if call == 0 {
+				return mintRedeemerUnits(500_000, 500_000), nil
+			}
+			return mintRedeemerUnits(500_000, 500_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)
+	a, err := a.Complete()
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.calls) < 2 {
+		t.Fatalf("expected at least two evaluations for shape confirmation, got %d", len(cc.calls))
+	}
+	final := a.GetTx()
+	last := cc.calls[len(cc.calls)-1].Tx
+	if final.Body.TxFee != last.Body.TxFee {
+		t.Fatalf("final fee %d != last evaluated fee %d", final.Body.TxFee, last.Body.TxFee)
+	}
+	if len(final.Body.TxOutputs) != len(last.Body.TxOutputs) {
+		t.Fatalf("final outputs %d != last evaluated outputs %d", len(final.Body.TxOutputs), len(last.Body.TxOutputs))
+	}
+	if final.Body.TxTotalCollateral != last.Body.TxTotalCollateral {
+		t.Fatalf("final collateral %d != last evaluated collateral %d", final.Body.TxTotalCollateral, last.Body.TxTotalCollateral)
+	}
+	for i := range final.Body.TxOutputs {
+		if final.Body.TxOutputs[i].OutputAmount.Amount != last.Body.TxOutputs[i].OutputAmount.Amount {
+			t.Fatalf("output %d amount mismatch: final=%d eval=%d", i,
+				final.Body.TxOutputs[i].OutputAmount.Amount, last.Body.TxOutputs[i].OutputAmount.Amount)
+		}
+	}
+}
+
+func TestEvaluationFailsClosedOnShapeCycle(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		resultFor: func(call int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			// Alternate budgets so fee/change/collateral oscillate and shapes cycle.
+			if call%2 == 0 {
+				return mintRedeemerUnits(4_000_000, 4_000_000), nil
+			}
+			return mintRedeemerUnits(1_000, 1_000), nil
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)
+	_, err := a.Complete()
+	if err == nil {
+		t.Fatal("expected cycle/non-convergence error")
+	}
+	if !strings.Contains(err.Error(), "evaluation transaction did not converge after 5 iterations") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEvaluationDoesNotMutatePaymentsOnFailure(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			return nil, fmt.Errorf("synthetic evaluator failure")
+		},
+	}
+	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)
+	before := make([]Value, len(a.payments))
+	for i, p := range a.payments {
+		v, err := p.ToValue()
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[i] = v
+	}
+	_, err := a.Complete()
+	if err == nil {
+		t.Fatal("expected Complete to fail")
+	}
+	if len(a.payments) != len(before) {
+		t.Fatalf("payments mutated on failure: len %d -> %d", len(before), len(a.payments))
+	}
+	for i, p := range a.payments {
+		v, err := p.ToValue()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.Coin != before[i].Coin {
+			t.Fatalf("payment %d lovelace mutated: %d -> %d", i, before[i].Coin, v.Coin)
+		}
+	}
+	if a.tx != nil {
+		t.Fatal("failed Complete must not leave a built transaction")
+	}
+}
+
+func TestEvaluationKeepsDeterministicOutputOrder(t *testing.T) {
+	cc := &capturingEvalContext{
+		FixedChainContext: setupFixedContext(),
+		t:                 t,
+		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+			return mintRedeemerUnits(10_000, 10_000), nil
+		},
+	}
+	addr := testAddress(t)
+	addTestUtxo(cc.FixedChainContext, addr, 80_000_000, 0x21, 0)
+	addTestUtxo(cc.FixedChainContext, addr, 20_000_000, 0x22, 0)
+
+	policyHex := strings.Repeat("cd", 28)
+	redeemer := testRedeemerDatum()
+	p1, err := NewPayment(validTestAddrBech32, 3_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := NewPayment(validTestAddrBech32, 7_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p1).
+		AddPayment(p2).
+		SetTtl(50_000_000).
+		Mint(NewUnit(policyHex, "746f6b656e", 1), &redeemer, nil)
+	a, err = a.Complete()
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	outs := a.GetTx().Body.TxOutputs
+	if len(outs) < 2 {
+		t.Fatalf("expected at least payment outputs, got %d", len(outs))
+	}
+	if outs[0].OutputAmount.Amount != 3_000_000 || outs[1].OutputAmount.Amount != 7_000_000 {
+		t.Fatalf("payment output order not preserved: %d, %d", outs[0].OutputAmount.Amount, outs[1].OutputAmount.Amount)
+	}
+	for _, call := range cc.calls {
+		draft := call.Tx.Body.TxOutputs
+		if len(draft) < 2 {
+			t.Fatalf("eval draft missing payments: %d outputs", len(draft))
+		}
+		if draft[0].OutputAmount.Amount != 3_000_000 || draft[1].OutputAmount.Amount != 7_000_000 {
+			t.Fatalf("eval draft output order not preserved: %d, %d",
+				draft[0].OutputAmount.Amount, draft[1].OutputAmount.Amount)
+		}
+	}
+}

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -57,7 +58,7 @@ func (c *capturingEvalContext) EvaluateTx(txCbor []byte, additionalUtxos []commo
 		c.assertTx(call, &tx, additionalUtxos)
 	}
 	if c.resultFor == nil {
-		return nil, fmt.Errorf("capturingEvalContext: resultFor not configured")
+		return nil, errors.New("capturingEvalContext: resultFor not configured")
 	}
 	return c.resultFor(call, &tx, additionalUtxos)
 }
@@ -439,7 +440,7 @@ func TestEvaluationDoesNotMutatePaymentsOnFailure(t *testing.T) {
 		FixedChainContext: setupFixedContext(),
 		t:                 t,
 		resultFor: func(_ int, _ *conway.ConwayTransaction, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-			return nil, fmt.Errorf("synthetic evaluator failure")
+			return nil, errors.New("synthetic evaluator failure")
 		},
 	}
 	a := setupMintEvalBuilder(t, cc, 2_000_000, 1)


### PR DESCRIPTION
## Summary
Apollo's ExUnit estimation builds a preliminary EvalTx that sets `MaxTxFee` without a matching change output. Strict UTxO RPC evaluation rejects this with `PreservationOfValue`. Permissive backends still evaluate a script-visible shape that can diverge from the final transaction.

## Root cause
`estimateExecutionUnits` ran before change/collateral finalization and did not share the final balance equation.

## Fix
- Extract shared `buildBalancedOutputs` for provisional and final construction
- Absorb ADA-only dust into fee; never drop asset-bearing change
- Converge fee/outputs/collateral/ExUnits for up to 5 iterations with cycle detection
- Validate evaluator results before mutating redeemers

## API / compatibility
No public Wallet API changes. No UTxO RPC-specific core code.

## Backend impact
| Backend | Impact |
|---------|--------|
| UTxO RPC | Unblocks strict phase-1 EvalTx |
| Blockfrost/Ogmios/Maestro | Evaluate closer-to-final script shape |
| Fixed/Cache | Unchanged semantics |

## Related (independent, not stacked)
- #247 script data hash
- #251 required-signer witnesses
- #252 UTxO RPC EvalError reporting
- #253 UTxO RPC purpose encoding

## Test plan
- [x] `go test . -run "TestEstimateExecutionUnitsDraft|TestBalancedOutputs|TestEvaluation" -count=1`
- [x] `go test . ./backend ./backend/utxorpc ./backend/blockfrost ./backend/maestro ./plutusencoder -count=1`
- [x] CI `go-test` / `lint` / CodeQL green on this PR
- [ ] Reviewer: mint-only tx with surplus input ADA — EvalTx draft conserves value (no `PreservationOfValue`)
- [ ] Reviewer: confirm final completed tx shape matches last-evaluated balanced draft (fee/change/collateral)
- [ ] Reviewer: asset-bearing change and dust-to-fee cases still complete successfully
