### PR TITLE
fix(utxorpc): surface Cardano EvalTx errors

### DIFF
--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -25,6 +26,16 @@ import (
 type UtxoRpcChainContext struct {
 	client    *sdk.UtxorpcClient
 	networkId uint8
+}
+
+// EvaluationError reports deterministic Cardano transaction-evaluation errors
+// returned by the UTxO RPC provider.
+type EvaluationError struct {
+	Messages []string
+}
+
+func (e *EvaluationError) Error() string {
+	return strings.Join(e.Messages, "; ")
 }
 
 // NewUtxoRpcChainContext creates a new UTxO RPC chain context.
@@ -311,7 +322,7 @@ func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, _ []common.Utxo) (map[co
 	u.client.AddHeadersToRequest(req)
 	resp, err := u.client.EvalTx(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("evaluate transaction: %w", err)
 	}
 	return evalTxResponseToExUnits(resp.Msg)
 }
@@ -332,6 +343,19 @@ func evalTxResponseToExUnits(msg *submit.EvalTxResponse) (map[common.RedeemerKey
 	if cardanoReport == nil {
 		return nil, errors.New("no cardano evaluation report in response")
 	}
+	if responseErrors := cardanoReport.GetErrors(); len(responseErrors) > 0 {
+		messages := make([]string, 0, len(responseErrors))
+		for _, responseError := range responseErrors {
+			message := strings.TrimSpace(responseError.GetMsg())
+			if message != "" {
+				messages = append(messages, message)
+			}
+		}
+		if len(messages) == 0 {
+			messages = []string{"script evaluation failed without an error message"}
+		}
+		return nil, &EvaluationError{Messages: messages}
+	}
 	result := make(map[common.RedeemerKey]common.ExUnits)
 	for _, redeemer := range cardanoReport.GetRedeemers() {
 		tag, err := utxorpcPurposeToRedeemerTag(redeemer.GetPurpose())
@@ -341,6 +365,9 @@ func evalTxResponseToExUnits(msg *submit.EvalTxResponse) (map[common.RedeemerKey
 		key := common.RedeemerKey{
 			Tag:   tag,
 			Index: redeemer.GetIndex(),
+		}
+		if _, exists := result[key]; exists {
+			return nil, fmt.Errorf("duplicate redeemer in evaluation report for %d:%d", tag, redeemer.GetIndex())
 		}
 		eu := redeemer.GetExUnits()
 		if eu == nil {

--- a/backend/utxorpc/utxorpc_test.go
+++ b/backend/utxorpc/utxorpc_test.go
@@ -1,12 +1,121 @@
 package utxorpc
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	submit "github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit"
 )
+
+func evalTxResponse(errors []*cardano.EvalError, redeemers []*cardano.Redeemer) *submit.EvalTxResponse {
+	return &submit.EvalTxResponse{
+		Report: &submit.AnyChainEval{
+			Chain: &submit.AnyChainEval_Cardano{
+				Cardano: &cardano.TxEval{
+					Errors:    errors,
+					Redeemers: redeemers,
+				},
+			},
+		},
+	}
+}
+
+func TestEvalTxResponseRejectsSingleEvaluationError(t *testing.T) {
+	msg := evalTxResponse([]*cardano.EvalError{
+		{Msg: "PreservationOfValue"},
+	}, nil)
+
+	_, err := evalTxResponseToExUnits(msg)
+	var evaluationErr *EvaluationError
+	if !errors.As(err, &evaluationErr) {
+		t.Fatalf("expected EvaluationError, got %v", err)
+	}
+	if !reflect.DeepEqual(evaluationErr.Messages, []string{"PreservationOfValue"}) {
+		t.Fatalf("unexpected messages: %#v", evaluationErr.Messages)
+	}
+}
+
+func TestEvalTxResponsePreservesMultipleEvaluationErrors(t *testing.T) {
+	msg := evalTxResponse([]*cardano.EvalError{
+		{Msg: "  PreservationOfValue  "},
+		{Msg: "ReqSignerMissing"},
+		{Msg: " ScriptIntegrityHash "},
+		{Msg: "Plutus phase-2 error"},
+	}, nil)
+
+	_, err := evalTxResponseToExUnits(msg)
+	var evaluationErr *EvaluationError
+	if !errors.As(err, &evaluationErr) {
+		t.Fatalf("expected EvaluationError, got %v", err)
+	}
+	want := []string{
+		"PreservationOfValue",
+		"ReqSignerMissing",
+		"ScriptIntegrityHash",
+		"Plutus phase-2 error",
+	}
+	if !reflect.DeepEqual(evaluationErr.Messages, want) {
+		t.Fatalf("unexpected messages: got %#v, want %#v", evaluationErr.Messages, want)
+	}
+}
+
+func TestEvalTxResponseRejectsBlankEvaluationErrors(t *testing.T) {
+	msg := evalTxResponse([]*cardano.EvalError{
+		nil,
+		{Msg: " \t\n "},
+	}, nil)
+
+	_, err := evalTxResponseToExUnits(msg)
+	var evaluationErr *EvaluationError
+	if !errors.As(err, &evaluationErr) {
+		t.Fatalf("expected EvaluationError, got %v", err)
+	}
+	if !reflect.DeepEqual(evaluationErr.Messages, []string{"script evaluation failed without an error message"}) {
+		t.Fatalf("unexpected messages: %#v", evaluationErr.Messages)
+	}
+}
+
+func TestEvalTxResponseRejectsErrorsWithRedeemers(t *testing.T) {
+	msg := evalTxResponse(
+		[]*cardano.EvalError{{Msg: "Plutus phase-2 error"}},
+		[]*cardano.Redeemer{{
+			Purpose: cardano.RedeemerPurpose_REDEEMER_PURPOSE_SPEND,
+			Index:   0,
+			ExUnits: &cardano.ExUnits{Memory: 1700, Steps: 476468},
+		}},
+	)
+
+	result, err := evalTxResponseToExUnits(msg)
+	if result != nil {
+		t.Fatalf("expected no partial result, got %#v", result)
+	}
+	var evaluationErr *EvaluationError
+	if !errors.As(err, &evaluationErr) {
+		t.Fatalf("expected EvaluationError, got %v", err)
+	}
+}
+
+func TestEvalTxResponseRejectsDuplicateRedeemerKey(t *testing.T) {
+	msg := evalTxResponse(nil, []*cardano.Redeemer{
+		{
+			Purpose: cardano.RedeemerPurpose_REDEEMER_PURPOSE_SPEND,
+			Index:   0,
+			ExUnits: &cardano.ExUnits{Memory: 1700, Steps: 476468},
+		},
+		{
+			Purpose: cardano.RedeemerPurpose_REDEEMER_PURPOSE_SPEND,
+			Index:   0,
+			ExUnits: &cardano.ExUnits{Memory: 250, Steps: 1000},
+		},
+	})
+
+	if _, err := evalTxResponseToExUnits(msg); err == nil {
+		t.Fatal("expected error for duplicate redeemer key")
+	}
+}
 
 func TestEvalTxResponseToExUnitsRejectsNilResponse(t *testing.T) {
 	if _, err := evalTxResponseToExUnits(nil); err == nil {


### PR DESCRIPTION
## Summary
UTxO RPC `TxEval.errors` were ignored, so deterministic ledger failures such as `PreservationOfValue`, `ReqSignerMissing`, and `ScriptIntegrityHash` surfaced as the misleading `script evaluation returned no results`.

## Root cause
`evalTxResponseToExUnits` only inspected redeemers and never read `cardanoReport.GetErrors()`.

## Fix
- Typed `EvaluationError` with ordered trimmed messages
- Parse errors before budgets; reject blank error entries
- Never return partial budgets when errors are present
- Reject duplicate redeemer keys
- Wrap transport errors with `%w`

## Backend impact
UTxO RPC only. Other backends untouched.

## Related (independent, not stacked)
- #253 purpose-compat PR
- #250 / #251 core evaluation PRs
- #247 script data hash

## Test plan
- [x] `go test ./backend/utxorpc -run "TestEvalTxResponse" -count=1`
- [x] `go test ./backend/utxorpc -count=1`
- [x] CI `go-test` / `lint` / CodeQL green on this PR
- [ ] Reviewer: fixture/response with `PreservationOfValue` / `ReqSignerMissing` / `ScriptIntegrityHash` returns `*EvaluationError` (not “no results”)
- [ ] Reviewer: errors + redeemers coexist → error only, no partial budgets
- [ ] Reviewer: `errors.As(err, &EvaluationError)` works for callers
