### PR TITLE
feat(backend): expose backend capabilities

### DIFF
--- a/backend/base.go
+++ b/backend/base.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -11,6 +12,134 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
+
+// Capability identifies an optional ChainContext operation. A ChainContext
+// always has the corresponding method for source compatibility, but a
+// particular backend may not be able to implement every operation.
+type Capability uint32
+
+const (
+	CapabilityProtocolParams Capability = 1 << iota
+	CapabilityGenesisParams
+	CapabilityCurrentEpoch
+	CapabilityMaxTxFee
+	CapabilityTip
+	CapabilityUtxos
+	CapabilitySubmitTx
+	CapabilityEvaluateTx
+	// CapabilityEvaluateTxAdditionalUtxos indicates that EvaluateTx honours
+	// its additionalUtxos argument for off-chain or chained inputs.
+	CapabilityEvaluateTxAdditionalUtxos
+	CapabilityUtxoByRef
+	CapabilityScriptCbor
+)
+
+// AllCapabilities is the set implied by the historic ChainContext contract.
+// It is used for contexts that do not opt into CapabilityReporter so existing
+// third-party implementations remain source- and behavior-compatible.
+const AllCapabilities = CapabilityProtocolParams |
+	CapabilityGenesisParams |
+	CapabilityCurrentEpoch |
+	CapabilityMaxTxFee |
+	CapabilityTip |
+	CapabilityUtxos |
+	CapabilitySubmitTx |
+	CapabilityEvaluateTx |
+	CapabilityEvaluateTxAdditionalUtxos |
+	CapabilityUtxoByRef |
+	CapabilityScriptCbor
+
+// CapabilitySet is a bit set of backend capabilities.
+type CapabilitySet uint32
+
+// Has reports whether every requested capability is present.
+func (s CapabilitySet) Has(capability Capability) bool {
+	return Capability(s)&capability == capability
+}
+
+// CapabilityReporter is an optional extension to ChainContext. It is kept
+// separate from ChainContext so implementations outside this module are not
+// forced to add a method when capability reporting is introduced.
+type CapabilityReporter interface {
+	Capabilities() CapabilitySet
+}
+
+// CapabilitiesOf returns the capabilities reported by ctx. Contexts that do
+// not implement CapabilityReporter are treated as supporting the historic
+// complete ChainContext contract.
+func CapabilitiesOf(ctx ChainContext) CapabilitySet {
+	if reporter, ok := ctx.(CapabilityReporter); ok {
+		return reporter.Capabilities()
+	}
+	return CapabilitySet(AllCapabilities)
+}
+
+// Supports reports whether ctx reports support for every requested capability.
+func Supports(ctx ChainContext, capability Capability) bool {
+	return CapabilitiesOf(ctx).Has(capability)
+}
+
+func (c Capability) String() string {
+	switch c {
+	case CapabilityProtocolParams:
+		return "protocol parameter queries"
+	case CapabilityGenesisParams:
+		return "genesis parameter queries"
+	case CapabilityCurrentEpoch:
+		return "current epoch queries"
+	case CapabilityMaxTxFee:
+		return "maximum transaction fee queries"
+	case CapabilityTip:
+		return "chain tip queries"
+	case CapabilityUtxos:
+		return "address UTxO queries"
+	case CapabilitySubmitTx:
+		return "transaction submission"
+	case CapabilityEvaluateTx:
+		return "transaction evaluation"
+	case CapabilityEvaluateTxAdditionalUtxos:
+		return "transaction evaluation with additional UTxOs"
+	case CapabilityUtxoByRef:
+		return "UTxO reference queries"
+	case CapabilityScriptCbor:
+		return "script CBOR lookup"
+	default:
+		return fmt.Sprintf("unknown capability (%d)", c)
+	}
+}
+
+// ErrUnsupported is returned when a ChainContext operation cannot be
+// implemented by its backend. Use errors.Is to check the category and
+// errors.As with UnsupportedError to inspect the operation.
+var ErrUnsupported = errors.New("backend operation unsupported")
+
+// UnsupportedError identifies a backend operation that is unavailable.
+type UnsupportedError struct {
+	Backend    string
+	Capability Capability
+}
+
+func (e *UnsupportedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Backend == "" {
+		return fmt.Sprintf("%s is unsupported", e.Capability)
+	}
+	return fmt.Sprintf("%s does not support %s", e.Backend, e.Capability)
+}
+
+// Unwrap lets callers use errors.Is(err, ErrUnsupported).
+func (e *UnsupportedError) Unwrap() error {
+	return ErrUnsupported
+}
+
+// NewUnsupportedError constructs an error for an unavailable backend
+// capability. Backends should return this instead of a provider-specific
+// message when support is known to be absent locally.
+func NewUnsupportedError(backendName string, capability Capability) *UnsupportedError {
+	return &UnsupportedError{Backend: backendName, Capability: capability}
+}
 
 // ChainContext provides an interface for interacting with a Cardano blockchain.
 type ChainContext interface {
@@ -27,12 +156,10 @@ type ChainContext interface {
 	// resolved UTxOs supplied to the evaluator (e.g. spending inputs that are
 	// not yet confirmed on-chain, such as off-chain or chained inputs), so that
 	// script execution-unit estimation can resolve inputs the backend cannot
-	// see on-chain. Ogmios, Blockfrost, and Maestro forward/respect
-	// additionalUtxos. UTxO RPC currently ignores additionalUtxos and can only
-	// evaluate transactions whose inputs are already visible on-chain; it does
-	// NOT support evaluation of off-chain or chained inputs. Passing non-empty
-	// additionalUtxos to such a backend is not an error, but those UTxOs will
-	// not be considered.
+	// see on-chain. Callers that require additional UTxOs to be considered must
+	// check CapabilityEvaluateTxAdditionalUtxos before relying on this behavior.
+	// Backends that do not report that capability may ignore additionalUtxos or
+	// return ErrUnsupported when the argument is non-empty.
 	EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
 	UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error)
 	ScriptCbor(scriptHash common.Blake2b224) ([]byte, error)

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -39,6 +39,15 @@ type BlockFrostChainContext struct {
 	genesisCacheAt time.Time
 }
 
+// Capabilities reports the ChainContext feature set implemented by Blockfrost.
+// The hosted evaluate-with-UTxOs endpoint cannot resolve every additional UTxO
+// shape, notably asset-bearing off-chain outputs, so it is not advertised as a
+// general chained-input evaluator.
+func (b *BlockFrostChainContext) Capabilities() backend.CapabilitySet {
+	return backend.CapabilitySet(backend.AllCapabilities) &^
+		backend.CapabilitySet(backend.CapabilityEvaluateTxAdditionalUtxos)
+}
+
 const (
 	cacheExpiry                   = 5 * time.Minute
 	maxBlockfrostResponseBytes    = 10 * 1024 * 1024

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -18,7 +18,19 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+
+	"github.com/Salvionied/apollo/v2/backend"
 )
+
+func TestBlockfrostCapabilities(t *testing.T) {
+	ctx := NewBlockFrostChainContext("http://localhost", 0, "")
+	if !backend.Supports(ctx, backend.CapabilityEvaluateTx|backend.CapabilityScriptCbor) {
+		t.Fatalf("Blockfrost capabilities = %b, want evaluation and script lookup", ctx.Capabilities())
+	}
+	if backend.Supports(ctx, backend.CapabilityEvaluateTxAdditionalUtxos) {
+		t.Fatal("Blockfrost must not report general additional-UTxO evaluation support")
+	}
+}
 
 func testAddress(t *testing.T) common.Address {
 	t.Helper()

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -29,6 +29,11 @@ func NewCachedChainContext(inner backend.ChainContext, ttl time.Duration) *Cache
 	}
 }
 
+// Capabilities preserves the feature set of the wrapped context.
+func (c *CachedChainContext) Capabilities() backend.CapabilitySet {
+	return backend.CapabilitiesOf(c.inner)
+}
+
 func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
 	c.mu.Lock()
 	if c.cachedParams != nil && time.Since(c.paramsCacheAt) < c.ttl {

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -1,0 +1,18 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+func TestCapabilitiesMatchWrappedContext(t *testing.T) {
+	ctx := NewCachedChainContext(fixed.NewEmptyFixedChainContext(), 0)
+	if !backend.Supports(ctx, backend.CapabilityProtocolParams|backend.CapabilityUtxoByRef) {
+		t.Fatal("cache did not preserve supported capabilities")
+	}
+	if backend.Supports(ctx, backend.CapabilitySubmitTx) {
+		t.Fatal("cache reported unsupported wrapped capability")
+	}
+}

--- a/backend/capabilities_test.go
+++ b/backend/capabilities_test.go
@@ -1,0 +1,62 @@
+package backend
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func TestCapabilitySetHas(t *testing.T) {
+	capabilities := CapabilitySet(CapabilityProtocolParams | CapabilitySubmitTx)
+	if !capabilities.Has(CapabilityProtocolParams | CapabilitySubmitTx) {
+		t.Fatal("expected both reported capabilities to be present")
+	}
+	if capabilities.Has(CapabilityScriptCbor) {
+		t.Fatal("unexpected script CBOR capability")
+	}
+}
+
+func TestCapabilitiesOfLegacyChainContextDefaultsToHistoricContract(t *testing.T) {
+	if got := CapabilitiesOf(legacyChainContext{}); got != CapabilitySet(AllCapabilities) {
+		t.Fatalf("CapabilitiesOf() = %b, want %b", got, AllCapabilities)
+	}
+}
+
+func TestUnsupportedErrorIdentity(t *testing.T) {
+	err := NewUnsupportedError("test backend", CapabilityScriptCbor)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("errors.Is(%v, ErrUnsupported) = false", err)
+	}
+	var unsupported *UnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("errors.As(%v, *UnsupportedError) = false", err)
+	}
+	if unsupported.Backend != "test backend" || unsupported.Capability != CapabilityScriptCbor {
+		t.Fatalf("unexpected unsupported error: %#v", unsupported)
+	}
+}
+
+// legacyChainContext intentionally does not implement CapabilityReporter.
+// It models ChainContext implementations compiled before capabilities existed.
+type legacyChainContext struct{}
+
+func (legacyChainContext) ProtocolParams() (ProtocolParameters, error) {
+	return ProtocolParameters{}, nil
+}
+func (legacyChainContext) GenesisParams() (GenesisParameters, error)   { return GenesisParameters{}, nil }
+func (legacyChainContext) NetworkId() uint8                            { return 0 }
+func (legacyChainContext) CurrentEpoch() (uint64, error)               { return 0, nil }
+func (legacyChainContext) MaxTxFee() (uint64, error)                   { return 0, nil }
+func (legacyChainContext) Tip() (uint64, error)                        { return 0, nil }
+func (legacyChainContext) Utxos(common.Address) ([]common.Utxo, error) { return nil, nil }
+func (legacyChainContext) SubmitTx([]byte) (common.Blake2b256, error) {
+	return common.Blake2b256{}, nil
+}
+func (legacyChainContext) EvaluateTx([]byte, []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	return nil, nil
+}
+func (legacyChainContext) UtxoByRef(common.Blake2b256, uint32) (*common.Utxo, error) {
+	return nil, nil
+}
+func (legacyChainContext) ScriptCbor(common.Blake2b224) ([]byte, error) { return nil, nil }

--- a/backend/fixed/fixed.go
+++ b/backend/fixed/fixed.go
@@ -22,6 +22,16 @@ type FixedChainContext struct {
 	utxosByRef     map[string]common.Utxo   // keyed by "txid#index"
 }
 
+// Capabilities reports the deterministic in-memory operations provided by the
+// fixed test context. It intentionally does not pretend to be a chain node.
+func (f *FixedChainContext) Capabilities() backend.CapabilitySet {
+	return backend.CapabilitySet(backend.CapabilityProtocolParams |
+		backend.CapabilityGenesisParams |
+		backend.CapabilityMaxTxFee |
+		backend.CapabilityUtxos |
+		backend.CapabilityUtxoByRef)
+}
+
 // NewFixedChainContext creates a new FixedChainContext with the given protocol parameters.
 func NewFixedChainContext(pp backend.ProtocolParameters, gp backend.GenesisParameters, networkId uint8) *FixedChainContext {
 	return &FixedChainContext{
@@ -105,6 +115,9 @@ func (f *FixedChainContext) NetworkId() uint8 {
 }
 
 func (f *FixedChainContext) CurrentEpoch() (uint64, error) {
+	// Preserve the fixed context's historic deterministic placeholder. It is
+	// intentionally not reported as CapabilityCurrentEpoch because it is not
+	// derived from chain state.
 	return 0, nil
 }
 
@@ -117,6 +130,9 @@ func (f *FixedChainContext) MaxTxFee() (uint64, error) {
 }
 
 func (f *FixedChainContext) Tip() (uint64, error) {
+	// Preserve the fixed context's historic deterministic placeholder. It is
+	// intentionally not reported as CapabilityTip because it is not derived
+	// from chain state.
 	return 0, nil
 }
 
@@ -130,11 +146,11 @@ func (f *FixedChainContext) Utxos(address common.Address) ([]common.Utxo, error)
 }
 
 func (f *FixedChainContext) SubmitTx(_ []byte) (common.Blake2b256, error) {
-	return common.Blake2b256{}, errors.New("cannot submit tx with fixed chain context")
+	return common.Blake2b256{}, backend.NewUnsupportedError("fixed chain context", backend.CapabilitySubmitTx)
 }
 
 func (f *FixedChainContext) EvaluateTx(_ []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-	return nil, errors.New("cannot evaluate tx with fixed chain context")
+	return nil, backend.NewUnsupportedError("fixed chain context", backend.CapabilityEvaluateTx)
 }
 
 func (f *FixedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
@@ -148,5 +164,5 @@ func (f *FixedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*
 }
 
 func (f *FixedChainContext) ScriptCbor(_ common.Blake2b224) ([]byte, error) {
-	return nil, errors.New("not implemented in fixed chain context")
+	return nil, backend.NewUnsupportedError("fixed chain context", backend.CapabilityScriptCbor)
 }

--- a/backend/fixed/fixed_test.go
+++ b/backend/fixed/fixed_test.go
@@ -1,0 +1,60 @@
+package fixed
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	"github.com/Salvionied/apollo/v2/backend"
+)
+
+func TestFixedCapabilitiesAndUnsupportedOperations(t *testing.T) {
+	ctx := NewEmptyFixedChainContext()
+	if !backend.Supports(ctx, backend.CapabilityProtocolParams|backend.CapabilityUtxoByRef) {
+		t.Fatal("expected fixed context capabilities to be reported")
+	}
+	if backend.Supports(ctx, backend.CapabilityCurrentEpoch|backend.CapabilityTip|backend.CapabilitySubmitTx|backend.CapabilityEvaluateTx) {
+		t.Fatal("fixed context must not report chain-node capabilities")
+	}
+
+	for _, call := range []struct {
+		name string
+		call func() (uint64, error)
+	}{
+		{"current epoch", ctx.CurrentEpoch},
+		{"tip", ctx.Tip},
+	} {
+		t.Run(call.name, func(t *testing.T) {
+			value, err := call.call()
+			if err != nil {
+				t.Fatalf("expected legacy zero-value result, got %v", err)
+			}
+			if value != 0 {
+				t.Fatalf("expected legacy zero-value result, got %d", value)
+			}
+		})
+	}
+
+	tests := []struct {
+		name       string
+		capability backend.Capability
+		call       func() error
+	}{
+		{"submit", backend.CapabilitySubmitTx, func() error { _, err := ctx.SubmitTx(nil); return err }},
+		{"evaluate", backend.CapabilityEvaluateTx, func() error { _, err := ctx.EvaluateTx(nil, nil); return err }},
+		{"script", backend.CapabilityScriptCbor, func() error { _, err := ctx.ScriptCbor(common.Blake2b224{}); return err }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if !errors.Is(err, backend.ErrUnsupported) {
+				t.Fatalf("expected ErrUnsupported, got %v", err)
+			}
+			var unsupported *backend.UnsupportedError
+			if !errors.As(err, &unsupported) || unsupported.Capability != test.capability {
+				t.Fatalf("unexpected unsupported error: %#v", err)
+			}
+		})
+	}
+}

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -36,6 +36,11 @@ type MaestroChainContext struct {
 	apiKey string
 }
 
+// Capabilities reports the Maestro operations supported by this client.
+func (m *MaestroChainContext) Capabilities() backend.CapabilitySet {
+	return backend.CapabilitySet(backend.AllCapabilities) &^ backend.CapabilitySet(backend.CapabilityGenesisParams)
+}
+
 // NewMaestroChainContext creates a new Maestro chain context.
 func NewMaestroChainContext(networkId uint8, projectId string) (*MaestroChainContext, error) {
 	networkStr := networkString(networkId)
@@ -175,7 +180,7 @@ func (m *MaestroChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 }
 
 func (m *MaestroChainContext) GenesisParams() (backend.GenesisParameters, error) {
-	return backend.GenesisParameters{}, errors.New("genesis params not available via Maestro API")
+	return backend.GenesisParameters{}, backend.NewUnsupportedError("Maestro", backend.CapabilityGenesisParams)
 }
 
 func (m *MaestroChainContext) NetworkId() uint8 {

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
 	"net/http"
@@ -16,7 +17,31 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/maestro-org/go-sdk/models"
+
+	"github.com/Salvionied/apollo/v2/backend"
 )
+
+func TestMaestroCapabilitiesAndUnsupportedGenesis(t *testing.T) {
+	ctx, err := NewMaestroChainContextWithNetwork(0, "project-id", "preprod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !backend.Supports(ctx, backend.CapabilityEvaluateTxAdditionalUtxos|backend.CapabilityScriptCbor) {
+		t.Fatal("expected Maestro supported capabilities")
+	}
+	if backend.Supports(ctx, backend.CapabilityGenesisParams) {
+		t.Fatal("Maestro reported genesis parameter support")
+	}
+
+	_, err = ctx.GenesisParams()
+	if !errors.Is(err, backend.ErrUnsupported) {
+		t.Fatalf("expected ErrUnsupported, got %v", err)
+	}
+	var unsupported *backend.UnsupportedError
+	if !errors.As(err, &unsupported) || unsupported.Capability != backend.CapabilityGenesisParams {
+		t.Fatalf("unexpected unsupported error: %#v", err)
+	}
+}
 
 func testAddress(t *testing.T) common.Address {
 	t.Helper()

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -31,6 +31,17 @@ type OgmiosChainContext struct {
 	networkId uint8
 }
 
+// Capabilities reports the operations supported by the configured Ogmios
+// client. Address UTxO queries and script lookup require the optional Kupo
+// client; UTxO-by-reference queries are served directly by Ogmios.
+func (o *OgmiosChainContext) Capabilities() backend.CapabilitySet {
+	capabilities := backend.CapabilitySet(backend.AllCapabilities)
+	if o.kupo == nil {
+		capabilities &^= backend.CapabilitySet(backend.CapabilityUtxos | backend.CapabilityScriptCbor)
+	}
+	return capabilities
+}
+
 // NewOgmiosChainContext creates a new Ogmios chain context.
 func NewOgmiosChainContext(ogmiosClient *ogmigo.Client, kupoClient *kugo.Client, networkId uint8) *OgmiosChainContext {
 	return &OgmiosChainContext{
@@ -102,7 +113,7 @@ func (o *OgmiosChainContext) Tip() (uint64, error) {
 
 func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
 	if o.kupo == nil {
-		return nil, errors.New("kupo client required for UTxO lookup")
+		return nil, backend.NewUnsupportedError("Ogmios without Kupo", backend.CapabilityUtxos)
 	}
 	ctx := context.Background()
 	matches, err := o.kupo.Matches(ctx, kugo.OnlyUnspent(), kugo.Address(address.String()))
@@ -345,7 +356,7 @@ func (o *OgmiosChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (
 
 func (o *OgmiosChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
 	if o.kupo == nil {
-		return nil, errors.New("kupo client required for script lookup")
+		return nil, backend.NewUnsupportedError("Ogmios without Kupo", backend.CapabilityScriptCbor)
 	}
 	ctx := context.Background()
 	hashHex := hex.EncodeToString(scriptHash.Bytes())

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +20,40 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+
+	"github.com/Salvionied/apollo/v2/backend"
 )
+
+func TestOgmiosCapabilitiesWithoutKupo(t *testing.T) {
+	ctx := NewOgmiosChainContext(nil, nil, 0)
+	if !backend.Supports(ctx, backend.CapabilityEvaluateTx|backend.CapabilityUtxoByRef) {
+		t.Fatal("expected Ogmios-supported capabilities")
+	}
+	if backend.Supports(ctx, backend.CapabilityUtxos|backend.CapabilityScriptCbor) {
+		t.Fatal("Ogmios without Kupo reported Kupo capabilities")
+	}
+
+	tests := []struct {
+		name       string
+		capability backend.Capability
+		call       func() error
+	}{
+		{"utxos", backend.CapabilityUtxos, func() error { _, err := ctx.Utxos(testAddress(t)); return err }},
+		{"script", backend.CapabilityScriptCbor, func() error { _, err := ctx.ScriptCbor(common.Blake2b224{}); return err }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if !errors.Is(err, backend.ErrUnsupported) {
+				t.Fatalf("expected ErrUnsupported, got %v", err)
+			}
+			var unsupported *backend.UnsupportedError
+			if !errors.As(err, &unsupported) || unsupported.Capability != test.capability {
+				t.Fatalf("unexpected unsupported error: %#v", err)
+			}
+		})
+	}
+}
 
 func testAddress(t *testing.T) common.Address {
 	t.Helper()

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -31,6 +31,13 @@ type UtxoRpcChainContext struct {
 	networkId uint8
 }
 
+// Capabilities reports the UTxO RPC operations supported by this client.
+func (u *UtxoRpcChainContext) Capabilities() backend.CapabilitySet {
+	return backend.CapabilitySet(backend.AllCapabilities) &^
+		backend.CapabilitySet(backend.CapabilityGenesisParams|backend.CapabilityCurrentEpoch|
+			backend.CapabilityEvaluateTxAdditionalUtxos|backend.CapabilityScriptCbor)
+}
+
 // EvaluationError reports deterministic Cardano transaction-evaluation errors
 // returned by the UTxO RPC provider.
 type EvaluationError struct {
@@ -217,7 +224,7 @@ func (u *UtxoRpcChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 }
 
 func (u *UtxoRpcChainContext) GenesisParams() (backend.GenesisParameters, error) {
-	return backend.GenesisParameters{}, errors.New("genesis params not available via UTxO RPC")
+	return backend.GenesisParameters{}, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityGenesisParams)
 }
 
 func (u *UtxoRpcChainContext) NetworkId() uint8 {
@@ -225,7 +232,7 @@ func (u *UtxoRpcChainContext) NetworkId() uint8 {
 }
 
 func (u *UtxoRpcChainContext) CurrentEpoch() (uint64, error) {
-	return 0, errors.New("epoch query not available via UTxO RPC")
+	return 0, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityCurrentEpoch)
 }
 
 func (u *UtxoRpcChainContext) MaxTxFee() (uint64, error) {
@@ -309,14 +316,13 @@ func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 	return result, nil
 }
 
-// EvaluateTx evaluates the scripts in a transaction. The additionalUtxos
-// argument is IGNORED: the utxorpc EvalTx schema (submit.EvalTxRequest) carries
-// only the raw transaction CBOR and has no field for additional/resolved
-// UTxOs. This backend can therefore only evaluate transactions whose inputs
-// are already visible on-chain to the provider and does NOT support evaluating
-// off-chain or chained inputs. Passing a non-empty additionalUtxos is not an
-// error, but those UTxOs have no effect.
-func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, _ []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+// EvaluateTx evaluates the scripts in a transaction. UTxO RPC has no wire
+// field for additional/resolved UTxOs, so off-chain or chained inputs cannot
+// be evaluated by this backend.
+func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	if len(additionalUtxos) > 0 {
+		return nil, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityEvaluateTxAdditionalUtxos)
+	}
 	expected, err := expectedRedeemerKeys(txCbor)
 	if err != nil {
 		return nil, err
@@ -516,7 +522,7 @@ func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 }
 
 func (u *UtxoRpcChainContext) ScriptCbor(_ common.Blake2b224) ([]byte, error) {
-	return nil, errors.New("script lookup not available via UTxO RPC")
+	return nil, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityScriptCbor)
 }
 
 func utxoFromRpc(item *query.AnyUtxoData) (common.Utxo, error) {

--- a/backend/utxorpc/utxorpc_test.go
+++ b/backend/utxorpc/utxorpc_test.go
@@ -13,7 +13,45 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	submit "github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit"
+
+	"github.com/Salvionied/apollo/v2/backend"
 )
+
+func TestUtxoRpcCapabilitiesAndUnsupportedOperations(t *testing.T) {
+	ctx := NewUtxoRpcChainContext("http://localhost", 0, nil)
+	if !backend.Supports(ctx, backend.CapabilityEvaluateTx|backend.CapabilityUtxoByRef) {
+		t.Fatal("expected UTxO RPC supported capabilities")
+	}
+	if backend.Supports(ctx, backend.CapabilityGenesisParams|backend.CapabilityEvaluateTxAdditionalUtxos) {
+		t.Fatal("UTxO RPC reported unavailable capabilities")
+	}
+
+	tests := []struct {
+		name       string
+		capability backend.Capability
+		call       func() error
+	}{
+		{"genesis", backend.CapabilityGenesisParams, func() error { _, err := ctx.GenesisParams(); return err }},
+		{"epoch", backend.CapabilityCurrentEpoch, func() error { _, err := ctx.CurrentEpoch(); return err }},
+		{"additional utxos", backend.CapabilityEvaluateTxAdditionalUtxos, func() error {
+			_, err := ctx.EvaluateTx(nil, []common.Utxo{{}})
+			return err
+		}},
+		{"script", backend.CapabilityScriptCbor, func() error { _, err := ctx.ScriptCbor(common.Blake2b224{}); return err }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if !errors.Is(err, backend.ErrUnsupported) {
+				t.Fatalf("expected ErrUnsupported, got %v", err)
+			}
+			var unsupported *backend.UnsupportedError
+			if !errors.As(err, &unsupported) || unsupported.Capability != test.capability {
+				t.Fatalf("unexpected unsupported error: %#v", err)
+			}
+		})
+	}
+}
 
 func evalTxResponse(errors []*cardano.EvalError, redeemers []*cardano.Redeemer) *submit.EvalTxResponse {
 	return &submit.EvalTxResponse{


### PR DESCRIPTION
## Summary
- add an optional, backward-compatible backend capability reporting API
- return typed unsupported errors for unavailable provider operations
- reject unsupported UTxO RPC additional UTxOs instead of silently ignoring them

## Validation
- go test -race ./...
- go test -race ./backend/...