### PR TITLE
feat: normalize Plutus V4 backend handling

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -28,6 +28,10 @@ const (
 	StakeDeposit   = 2_000_000
 )
 
+// ErrPlutusV4RequiresDijkstra reports that an operation needs a Dijkstra-era
+// transaction witness set, while Apollo currently builds Conway transactions.
+var ErrPlutusV4RequiresDijkstra = errors.New("plutus V4 requires Dijkstra transaction support; Apollo currently builds Conway transactions")
+
 // Apollo is the main transaction builder.
 type Apollo struct {
 	Context            backend.ChainContext
@@ -299,8 +303,19 @@ func (a *Apollo) Mint(unit Unit, redeemer *common.Datum, exUnits *common.ExUnits
 }
 
 // AttachScript attaches a script to the witness set, deduplicating by hash.
-// Accepts PlutusV1Script, PlutusV2Script, PlutusV3Script, or NativeScript.
+// It accepts NativeScript and PlutusV1Script through PlutusV3Script. Plutus V4
+// witnesses require Dijkstra-era transaction support and cause Complete to
+// return ErrPlutusV4RequiresDijkstra.
 func (a *Apollo) AttachScript(script common.Script) *Apollo {
+	scriptType, err := scriptRefType(script)
+	if err != nil {
+		a.setErrOnce(err)
+		return a
+	}
+	if scriptType == common.ScriptRefTypePlutusV4 {
+		a.setErrOnce(ErrPlutusV4RequiresDijkstra)
+		return a
+	}
 	hash := script.Hash().String()
 	if a.hasScriptHash(hash) {
 		return a
@@ -309,12 +324,20 @@ func (a *Apollo) AttachScript(script common.Script) *Apollo {
 	switch s := script.(type) {
 	case common.PlutusV1Script:
 		a.v1scripts = append(a.v1scripts, s)
+	case *common.PlutusV1Script:
+		a.v1scripts = append(a.v1scripts, *s)
 	case common.PlutusV2Script:
 		a.v2scripts = append(a.v2scripts, s)
+	case *common.PlutusV2Script:
+		a.v2scripts = append(a.v2scripts, *s)
 	case common.PlutusV3Script:
 		a.v3scripts = append(a.v3scripts, s)
+	case *common.PlutusV3Script:
+		a.v3scripts = append(a.v3scripts, *s)
 	case common.NativeScript:
 		a.nativescripts = append(a.nativescripts, s)
+	case *common.NativeScript:
+		a.nativescripts = append(a.nativescripts, *s)
 	}
 	return a
 }
@@ -418,8 +441,13 @@ func (a *Apollo) PayToAddress(addr common.Address, lovelace int64, units ...Unit
 }
 
 // PayToAddressWithReferenceScript pays to address with a reference script attached.
-// The script type (V1/V2/V3/Native) is detected automatically.
+// The script type is detected automatically. Plutus V4 reference scripts
+// require Dijkstra-era transaction support and are rejected by this
+// Conway-era builder.
 func (a *Apollo) PayToAddressWithReferenceScript(addr common.Address, lovelace int64, script common.Script, units ...Unit) (*Apollo, error) {
+	if isPlutusV4Script(script) {
+		return a, ErrPlutusV4RequiresDijkstra
+	}
 	ref, err := NewScriptRef(script)
 	if err != nil {
 		return a, fmt.Errorf("failed to create script ref: %w", err)
@@ -1732,11 +1760,15 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 	seen := make(map[string]struct{})
 	total := 0
 
-	addScript := func(script common.Script) {
+	addScript := func(script common.Script) error {
 		if script == nil {
-			return
+			return nil
+		}
+		if isPlutusV4Script(script) {
+			return ErrPlutusV4RequiresDijkstra
 		}
 		total += len(script.RawScriptBytes())
+		return nil
 	}
 
 	// Spending inputs already resolved by the caller carry their outputs.
@@ -1746,7 +1778,9 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 			continue
 		}
 		seen[ref] = struct{}{}
-		addScript(utxo.Output.ScriptRef())
+		if err := addScript(utxo.Output.ScriptRef()); err != nil {
+			return 0, err
+		}
 	}
 
 	// Reference inputs must be resolved against the chain context.
@@ -1766,7 +1800,9 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 		if utxo == nil {
 			return 0, fmt.Errorf("reference input %s not found for reference-script fee", ref)
 		}
-		addScript(utxo.Output.ScriptRef())
+		if err := addScript(utxo.Output.ScriptRef()); err != nil {
+			return 0, err
+		}
 	}
 
 	return total, nil
@@ -2181,9 +2217,6 @@ func (a *Apollo) usedScriptCostModels(
 	inputs []common.Utxo,
 	available map[string][]int64,
 ) (map[string][]int64, error) {
-	if len(available) == 0 {
-		return nil, nil
-	}
 	used := make(map[string]struct{})
 	if len(a.v1scripts) > 0 {
 		used["PlutusV1"] = struct{}{}
@@ -2195,7 +2228,9 @@ func (a *Apollo) usedScriptCostModels(
 		used["PlutusV3"] = struct{}{}
 	}
 	for _, utxo := range inputs {
-		addScriptLanguage(used, utxo.Output.ScriptRef())
+		if err := addScriptLanguage(used, utxo.Output.ScriptRef()); err != nil {
+			return nil, err
+		}
 	}
 	for _, refInput := range a.referenceInputs {
 		utxo, err := a.Context.UtxoByRef(refInput.TxId, refInput.OutputIndex)
@@ -2208,8 +2243,13 @@ func (a *Apollo) usedScriptCostModels(
 			)
 		}
 		if utxo != nil {
-			addScriptLanguage(used, utxo.Output.ScriptRef())
+			if err := addScriptLanguage(used, utxo.Output.ScriptRef()); err != nil {
+				return nil, err
+			}
 		}
+	}
+	if len(available) == 0 {
+		return nil, nil
 	}
 	if len(used) == 0 {
 		if len(a.redeemers) == 0 && len(a.mintRedeemers) == 0 && len(a.stakeRedeemers) == 0 {
@@ -2884,7 +2924,7 @@ func redeemerEntriesEqual(lhs, rhs redeemerEntry) bool {
 	return bytes.Equal(lhsBytes, rhsBytes)
 }
 
-func addScriptLanguage(used map[string]struct{}, script common.Script) {
+func addScriptLanguage(used map[string]struct{}, script common.Script) error {
 	switch script.(type) {
 	case common.PlutusV1Script, *common.PlutusV1Script:
 		used["PlutusV1"] = struct{}{}
@@ -2892,6 +2932,18 @@ func addScriptLanguage(used map[string]struct{}, script common.Script) {
 		used["PlutusV2"] = struct{}{}
 	case common.PlutusV3Script, *common.PlutusV3Script:
 		used["PlutusV3"] = struct{}{}
+	case common.PlutusV4Script, *common.PlutusV4Script:
+		return ErrPlutusV4RequiresDijkstra
+	}
+	return nil
+}
+
+func isPlutusV4Script(script common.Script) bool {
+	switch script.(type) {
+	case common.PlutusV4Script, *common.PlutusV4Script:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -576,6 +576,40 @@ func TestAttachScriptV3Dedup(t *testing.T) {
 	}
 }
 
+func TestAttachScriptV4RequiresDijkstra(t *testing.T) {
+	a := New(setupFixedContext())
+	a.AttachScript(common.PlutusV4Script([]byte{0x01, 0x02, 0x03}))
+
+	if a.err != ErrPlutusV4RequiresDijkstra {
+		t.Fatalf("AttachScript error = %v, want %v", a.err, ErrPlutusV4RequiresDijkstra)
+	}
+	if _, err := a.Complete(); err != ErrPlutusV4RequiresDijkstra {
+		t.Fatalf("Complete error = %v, want %v", err, ErrPlutusV4RequiresDijkstra)
+	}
+}
+
+func TestAttachScriptPointer(t *testing.T) {
+	a := New(setupFixedContext())
+	script := common.PlutusV1Script([]byte{0x01, 0x02, 0x03})
+
+	a.AttachScript(&script)
+
+	if len(a.v1scripts) != 1 {
+		t.Fatalf("attached script count = %d, want 1", len(a.v1scripts))
+	}
+}
+
+func TestAttachScriptPlutusV4PointerRequiresDijkstra(t *testing.T) {
+	a := New(setupFixedContext())
+	script := common.PlutusV4Script([]byte{0x01, 0x02, 0x03})
+
+	a.AttachScript(&script)
+
+	if a.err != ErrPlutusV4RequiresDijkstra {
+		t.Fatalf("AttachScript error = %v, want %v", a.err, ErrPlutusV4RequiresDijkstra)
+	}
+}
+
 func TestAttachScriptNativeScript(t *testing.T) {
 	cc := setupFixedContext()
 	a := New(cc)
@@ -958,8 +992,8 @@ func TestNewScriptRefV1(t *testing.T) {
 	if ref == nil {
 		t.Fatal("expected non-nil ScriptRef")
 	}
-	if ref.Type != 1 {
-		t.Errorf("expected type 1, got %d", ref.Type)
+	if ref.Type != common.ScriptRefTypePlutusV1 {
+		t.Errorf("expected type %d, got %d", common.ScriptRefTypePlutusV1, ref.Type)
 	}
 }
 
@@ -972,8 +1006,8 @@ func TestNewScriptRefV2(t *testing.T) {
 	if ref == nil {
 		t.Fatal("expected non-nil ScriptRef")
 	}
-	if ref.Type != 2 {
-		t.Errorf("expected type 2, got %d", ref.Type)
+	if ref.Type != common.ScriptRefTypePlutusV2 {
+		t.Errorf("expected type %d, got %d", common.ScriptRefTypePlutusV2, ref.Type)
 	}
 }
 
@@ -986,8 +1020,113 @@ func TestNewScriptRefV3(t *testing.T) {
 	if ref == nil {
 		t.Fatal("expected non-nil ScriptRef")
 	}
-	if ref.Type != 3 {
-		t.Errorf("expected type 3, got %d", ref.Type)
+	if ref.Type != common.ScriptRefTypePlutusV3 {
+		t.Errorf("expected type %d, got %d", common.ScriptRefTypePlutusV3, ref.Type)
+	}
+}
+
+func TestNewScriptRefV4(t *testing.T) {
+	script := common.PlutusV4Script([]byte{0x01, 0x02})
+	ref, err := NewScriptRef(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref == nil {
+		t.Fatal("expected non-nil ScriptRef")
+	}
+	if ref.Type != common.ScriptRefTypePlutusV4 {
+		t.Errorf("expected type %d, got %d", common.ScriptRefTypePlutusV4, ref.Type)
+	}
+}
+
+func TestNewScriptRefPointerScripts(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x01})
+	v2 := common.PlutusV2Script([]byte{0x02})
+	v3 := common.PlutusV3Script([]byte{0x03})
+	v4 := common.PlutusV4Script([]byte{0x04})
+	var keyHash common.Blake2b224
+	native, err := NewNativeScriptPubkey(keyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		script     common.Script
+		scriptType uint
+	}{
+		{name: "native", script: &native, scriptType: common.ScriptRefTypeNativeScript},
+		{name: "PlutusV1", script: &v1, scriptType: common.ScriptRefTypePlutusV1},
+		{name: "PlutusV2", script: &v2, scriptType: common.ScriptRefTypePlutusV2},
+		{name: "PlutusV3", script: &v3, scriptType: common.ScriptRefTypePlutusV3},
+		{name: "PlutusV4", script: &v4, scriptType: common.ScriptRefTypePlutusV4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := NewScriptRef(tt.script)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ref.Type != tt.scriptType {
+				t.Fatalf("script ref type = %d, want %d", ref.Type, tt.scriptType)
+			}
+		})
+	}
+}
+
+func TestNewScriptRefRejectsNilScriptPointer(t *testing.T) {
+	var script *common.PlutusV4Script
+	if _, err := NewScriptRef(script); err == nil {
+		t.Fatal("NewScriptRef accepted a nil script pointer")
+	}
+}
+
+func TestPayToAddressWithPlutusV4ReferenceScriptRequiresDijkstra(t *testing.T) {
+	a := New(setupFixedContext())
+	_, err := a.PayToAddressWithReferenceScript(
+		testAddress(t),
+		2_000_000,
+		common.PlutusV4Script([]byte{0x01, 0x02}),
+	)
+	if err != ErrPlutusV4RequiresDijkstra {
+		t.Fatalf("PayToAddressWithReferenceScript error = %v, want %v", err, ErrPlutusV4RequiresDijkstra)
+	}
+}
+
+func TestUsedScriptCostModelsRejectsPlutusV4ReferenceScript(t *testing.T) {
+	ref, err := NewScriptRef(common.PlutusV4Script([]byte{0x01, 0x02}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(setupFixedContext())
+	_, err = a.usedScriptCostModels(
+		[]common.Utxo{{
+			Output: &babbage.BabbageTransactionOutput{TxOutScriptRef: ref},
+		}},
+		nil,
+	)
+	if err != ErrPlutusV4RequiresDijkstra {
+		t.Fatalf("usedScriptCostModels error = %v, want %v", err, ErrPlutusV4RequiresDijkstra)
+	}
+}
+
+func TestTotalReferenceScriptSizeRejectsPlutusV4(t *testing.T) {
+	ref, err := NewScriptRef(common.PlutusV4Script([]byte{0x01, 0x02}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var txHash common.Blake2b256
+	txHash[0] = 1
+	a := New(setupFixedContext())
+	_, err = a.totalReferenceScriptSize([]common.Utxo{{
+		Id: shelley.ShelleyTransactionInput{TxId: txHash, OutputIndex: 0},
+		Output: &babbage.BabbageTransactionOutput{
+			TxOutScriptRef: ref,
+		},
+	}})
+	if err != ErrPlutusV4RequiresDijkstra {
+		t.Fatalf("totalReferenceScriptSize error = %v, want %v", err, ErrPlutusV4RequiresDijkstra)
 	}
 }
 

--- a/backend/base.go
+++ b/backend/base.go
@@ -318,6 +318,8 @@ func ScriptRefFromBytes(scriptType uint, scriptBytes []byte, expectedHashHex str
 		script = common.PlutusV2Script(scriptBytes)
 	case common.ScriptRefTypePlutusV3:
 		script = common.PlutusV3Script(scriptBytes)
+	case common.ScriptRefTypePlutusV4:
+		script = common.PlutusV4Script(scriptBytes)
 	default:
 		return nil, fmt.Errorf("unsupported script ref type %d", scriptType)
 	}

--- a/backend/base_test.go
+++ b/backend/base_test.go
@@ -215,6 +215,22 @@ func TestScriptRefFromBytesVerifiesHash(t *testing.T) {
 	}
 }
 
+func TestScriptRefFromBytesPlutusV4(t *testing.T) {
+	script := common.PlutusV4Script([]byte{0x01, 0x02, 0x03})
+	correctHash := hex.EncodeToString(script.Hash().Bytes())
+
+	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV4, script, correctHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Type != common.ScriptRefTypePlutusV4 {
+		t.Fatalf("script ref type = %d, want %d", ref.Type, common.ScriptRefTypePlutusV4)
+	}
+	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
+		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
+	}
+}
+
 func TestScriptRefFromBytesRejectsHashMismatch(t *testing.T) {
 	script := common.PlutusV2Script([]byte{0x01, 0x02, 0x03})
 	// The same bytes hashed as PlutusV1 produce a different script hash.

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -894,8 +894,8 @@ func (p *bfProtocolParams) toProtocolParams() (backend.ProtocolParameters, error
 	// cost_models which may be either:
 	//   - array format:  {"PlutusV1": [205665, 812, ...]}
 	//   - keyed format:  {"PlutusV1": {"addInteger-cpu-arguments-intercept": 205665, ...}}
-	// Both formats use keys "PlutusV1", "PlutusV2", "PlutusV3" which match
-	// the canonical form expected by ComputeScriptDataHash.
+	// Both formats use keys "PlutusV1" through "PlutusV4" which match the
+	// canonical form expected by ComputeScriptDataHash.
 	if len(p.CostModelsRaw) > 0 && string(p.CostModelsRaw) != "null" {
 		var rawModels map[string][]int64
 		if err := json.Unmarshal(p.CostModelsRaw, &rawModels); err != nil {
@@ -1163,6 +1163,13 @@ func scriptRefFromHash(
 		return &common.ScriptRef{
 			Type:   common.ScriptRefTypePlutusV3,
 			Script: v3,
+		}, nil
+	}
+	v4 := common.PlutusV4Script(scriptCbor)
+	if v4.Hash() == scriptHash {
+		return &common.ScriptRef{
+			Type:   common.ScriptRefTypePlutusV4,
+			Script: v4,
 		}, nil
 	}
 	return nil, errors.New("unable to determine reference script language from script hash")

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -399,7 +399,8 @@ func TestProtocolParamsPrefersCostModelsRaw(t *testing.T) {
 			"PlutusV3": {"addInteger-cpu-arguments-intercept": 1, "addInteger-cpu-arguments-slope": 2}
 		},
 		"cost_models_raw": {
-			"PlutusV3": [100, 200, 300, 400]
+			"PlutusV3": [100, 200, 300, 400],
+			"PlutusV4": [500, 600]
 		}
 	}`
 
@@ -414,6 +415,9 @@ func TestProtocolParamsPrefersCostModelsRaw(t *testing.T) {
 	got := pp.CostModels["PlutusV3"]
 	if len(got) != 4 || got[0] != 100 || got[3] != 400 {
 		t.Fatalf("expected cost_models_raw values, got %v", got)
+	}
+	if got := pp.CostModels["PlutusV4"]; len(got) != 2 || got[0] != 500 || got[1] != 600 {
+		t.Fatalf("expected PlutusV4 cost_models_raw values, got %v", got)
 	}
 }
 
@@ -706,6 +710,20 @@ func TestBfScriptRefFromScriptLanguageDetection(t *testing.T) {
 	}
 	if v4.PlutusV4 == nil || *v4.PlutusV4 != wantHex || v4.PlutusV1 != nil || v4.PlutusV2 != nil || v4.PlutusV3 != nil {
 		t.Fatalf("v4 mis-tagged: %+v", v4)
+	}
+}
+
+func TestScriptRefFromHashDetectsPlutusV4(t *testing.T) {
+	script := common.PlutusV4Script([]byte{0x49, 0x48, 0x01, 0x00})
+	ref, err := scriptRefFromHash(script.Hash(), script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Type != common.ScriptRefTypePlutusV4 {
+		t.Fatalf("script ref type = %d, want %d", ref.Type, common.ScriptRefTypePlutusV4)
+	}
+	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
+		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
 	}
 }
 

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -143,9 +143,9 @@ func (m *MaestroChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 
 	// Parse cost models from Maestro response.
 	// PlutusCostModels is typed as `any`; when unmarshaled from JSON it is
-	// map[string]interface{} with keys like "plutus:v1", "plutus:v2", "plutus:v3"
+	// map[string]interface{} with keys like "plutus:v1" through "plutus:v4"
 	// and values that are []interface{} of float64.
-	// ComputeScriptDataHash expects keys "PlutusV1", "PlutusV2", "PlutusV3".
+	// ComputeScriptDataHash expects keys "PlutusV1" through "PlutusV4".
 	if rawModels, ok := data.PlutusCostModels.(map[string]any); ok {
 		pp.CostModels = make(map[string][]int64, len(rawModels))
 		for key, val := range rawModels {
@@ -603,6 +603,8 @@ func maestroScriptRef(scriptType string, scriptCbor []byte, expectedHashHex stri
 		refType = common.ScriptRefTypePlutusV2
 	case "plutusv3":
 		refType = common.ScriptRefTypePlutusV3
+	case "plutusv4":
+		refType = common.ScriptRefTypePlutusV4
 	default:
 		return nil, fmt.Errorf("unknown script type %q", scriptType)
 	}
@@ -610,7 +612,7 @@ func maestroScriptRef(scriptType string, scriptCbor []byte, expectedHashHex stri
 }
 
 // maestroCostModelKey translates Maestro cost model keys to the canonical form
-// expected by ComputeScriptDataHash ("PlutusV1", "PlutusV2", "PlutusV3").
+// expected by ComputeScriptDataHash ("PlutusV1" through "PlutusV4").
 func maestroCostModelKey(key string) string {
 	switch key {
 	case "plutus:v1":
@@ -619,6 +621,8 @@ func maestroCostModelKey(key string) string {
 		return "PlutusV2"
 	case "plutus:v3":
 		return "PlutusV3"
+	case "plutus:v4":
+		return "PlutusV4"
 	default:
 		return key
 	}

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -172,6 +172,25 @@ func TestMaestroScriptRefVerifiesHash(t *testing.T) {
 	}
 }
 
+func TestMaestroScriptRefPlutusV4(t *testing.T) {
+	scriptBytes := []byte{0x01, 0x02, 0x03}
+	correctHash := hex.EncodeToString(common.PlutusV4Script(scriptBytes).Hash().Bytes())
+
+	ref, err := maestroScriptRef("plutusv4", scriptBytes, correctHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
+		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
+	}
+}
+
+func TestMaestroCostModelKeyPlutusV4(t *testing.T) {
+	if got := maestroCostModelKey("plutus:v4"); got != "PlutusV4" {
+		t.Fatalf("cost model key = %q, want PlutusV4", got)
+	}
+}
+
 func TestMaestroScriptRefRejectsUnknownType(t *testing.T) {
 	if _, err := maestroScriptRef("plutusv9", []byte{0x01}, ""); err == nil {
 		t.Fatal("expected unknown script type error")

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -447,8 +447,8 @@ func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, e
 	}
 
 	// Parse cost models from Ogmios JSON.
-	// Ogmios uses keys like "plutus:v1", "plutus:v2", "plutus:v3".
-	// ComputeScriptDataHash expects "PlutusV1", "PlutusV2", "PlutusV3".
+	// Ogmios uses keys like "plutus:v1" through "plutus:v4".
+	// ComputeScriptDataHash expects "PlutusV1" through "PlutusV4".
 	if len(p.CostModels) > 0 {
 		var rawModels map[string][]int64
 		if err := json.Unmarshal(p.CostModels, &rawModels); err != nil {
@@ -464,7 +464,7 @@ func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, e
 }
 
 // ogmiosCostModelKey translates Ogmios cost model keys to the canonical form
-// expected by ComputeScriptDataHash ("PlutusV1", "PlutusV2", "PlutusV3").
+// expected by ComputeScriptDataHash ("PlutusV1" through "PlutusV4").
 func ogmiosCostModelKey(key string) string {
 	switch key {
 	case "plutus:v1":
@@ -473,6 +473,8 @@ func ogmiosCostModelKey(key string) string {
 		return "PlutusV2"
 	case "plutus:v3":
 		return "PlutusV3"
+	case "plutus:v4":
+		return "PlutusV4"
 	default:
 		return key
 	}
@@ -509,6 +511,11 @@ func (g *ogmiosGenesisConfig) toGenesisParams() backend.GenesisParameters {
 type datumFetcher interface {
 	Datum(ctx context.Context, datumHash string) (string, error)
 }
+
+// Kugo v1.3.1 does not export a Plutus V4 language constant yet. Retain the
+// wire value here so this conversion supports it as soon as Kugo can decode
+// a "plutus:v4" response.
+const kupoScriptLanguagePlutusV4 kugo.ScriptLanguage = 4
 
 func matchToUtxo(ctx context.Context, match kugo.Match, address common.Address, datums datumFetcher) (common.Utxo, error) {
 	hashBytes, err := hex.DecodeString(match.TransactionID)
@@ -785,6 +792,8 @@ func kupoScriptToScriptRef(script kugo.Script, expectedHashHex string) (*common.
 		scriptType = common.ScriptRefTypePlutusV2
 	case kugo.ScriptLanguagePlutusV3:
 		scriptType = common.ScriptRefTypePlutusV3
+	case kupoScriptLanguagePlutusV4:
+		scriptType = common.ScriptRefTypePlutusV4
 	default:
 		return nil, fmt.Errorf("unsupported kupo script language: %d", script.Language)
 	}
@@ -793,7 +802,7 @@ func kupoScriptToScriptRef(script kugo.Script, expectedHashHex string) (*common.
 }
 
 // ogmiosScriptToScriptRef converts an Ogmios script JSON to a common.ScriptRef.
-// Ogmios v6 uses: {"language": "plutus:v1"|"plutus:v2"|"plutus:v3"|"native", "cbor": "hex"}
+// Ogmios v6 uses: {"language": "plutus:v1" through "plutus:v4"|"native", "cbor": "hex"}
 // Ogmios does not include the script hash in UTxO responses, so no hash
 // verification is possible here.
 func ogmiosScriptToScriptRef(scriptJSON json.RawMessage) (*common.ScriptRef, error) {
@@ -824,6 +833,8 @@ func ogmiosScriptToScriptRef(scriptJSON json.RawMessage) (*common.ScriptRef, err
 		scriptType = common.ScriptRefTypePlutusV2
 	case "plutus:v3":
 		scriptType = common.ScriptRefTypePlutusV3
+	case "plutus:v4":
+		scriptType = common.ScriptRefTypePlutusV4
 	default:
 		return nil, fmt.Errorf("unsupported ogmios script language %q", raw.Language)
 	}

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -185,6 +185,43 @@ func TestKupoScriptToScriptRefVerifiesHash(t *testing.T) {
 	}
 }
 
+func TestKupoScriptToScriptRefPlutusV4(t *testing.T) {
+	scriptBytes := []byte{0x01, 0x02, 0x03}
+	script := kugo.Script{
+		Language: kupoScriptLanguagePlutusV4,
+		Script:   hex.EncodeToString(scriptBytes),
+	}
+	correctHash := hex.EncodeToString(common.PlutusV4Script(scriptBytes).Hash().Bytes())
+
+	ref, err := kupoScriptToScriptRef(script, correctHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
+		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
+	}
+}
+
+func TestOgmiosScriptToScriptRefPlutusV4(t *testing.T) {
+	scriptBytes := []byte{0x01, 0x02, 0x03}
+	ref, err := ogmiosScriptToScriptRef(json.RawMessage(`{"language":"plutus:v4","cbor":"010203"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
+		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
+	}
+	if got := ref.Script.RawScriptBytes(); !bytes.Equal(got, scriptBytes) {
+		t.Fatalf("script bytes = %x, want %x", got, scriptBytes)
+	}
+}
+
+func TestOgmiosCostModelKeyPlutusV4(t *testing.T) {
+	if got := ogmiosCostModelKey("plutus:v4"); got != "PlutusV4" {
+		t.Fatalf("cost model key = %q, want PlutusV4", got)
+	}
+}
+
 func TestEvaluateResponseToExUnitsRejectsZeroResults(t *testing.T) {
 	if _, err := evaluateResponseToExUnits(nil); err == nil {
 		t.Fatal("expected error for nil response")

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -198,22 +198,31 @@ func (u *UtxoRpcChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 		pp.MinFeeRefScriptCostPerByte = float64(refCost.GetNumerator()) / float64(refCost.GetDenominator())
 	}
 
-	// Parse cost models from UTxO RPC protobuf response.
-	// Keys match ComputeScriptDataHash expectations: "PlutusV1", "PlutusV2", "PlutusV3".
-	if cm := params.GetCostModels(); cm != nil {
-		pp.CostModels = make(map[string][]int64)
-		if v1 := cm.GetPlutusV1(); v1 != nil {
-			pp.CostModels["PlutusV1"] = append([]int64(nil), v1.GetValues()...)
-		}
-		if v2 := cm.GetPlutusV2(); v2 != nil {
-			pp.CostModels["PlutusV2"] = append([]int64(nil), v2.GetValues()...)
-		}
-		if v3 := cm.GetPlutusV3(); v3 != nil {
-			pp.CostModels["PlutusV3"] = append([]int64(nil), v3.GetValues()...)
-		}
-	}
+	pp.CostModels = costModelsFromRpc(params.GetCostModels())
 
 	return pp, nil
+}
+
+// costModelsFromRpc translates UTxO RPC cost models to the canonical names
+// expected by ComputeScriptDataHash.
+func costModelsFromRpc(cm *cardano.CostModels) map[string][]int64 {
+	if cm == nil {
+		return nil
+	}
+	models := make(map[string][]int64)
+	if v1 := cm.GetPlutusV1(); v1 != nil {
+		models["PlutusV1"] = append([]int64(nil), v1.GetValues()...)
+	}
+	if v2 := cm.GetPlutusV2(); v2 != nil {
+		models["PlutusV2"] = append([]int64(nil), v2.GetValues()...)
+	}
+	if v3 := cm.GetPlutusV3(); v3 != nil {
+		models["PlutusV3"] = append([]int64(nil), v3.GetValues()...)
+	}
+	if v4 := cm.GetPlutusV4(); v4 != nil {
+		models["PlutusV4"] = append([]int64(nil), v4.GetValues()...)
+	}
+	return models
 }
 
 func (u *UtxoRpcChainContext) GenesisParams() (backend.GenesisParameters, error) {

--- a/backend/utxorpc/utxorpc_test.go
+++ b/backend/utxorpc/utxorpc_test.go
@@ -28,6 +28,16 @@ func evalTxResponse(errors []*cardano.EvalError, redeemers []*cardano.Redeemer) 
 	}
 }
 
+func TestCostModelsFromRpcIncludesPlutusV4(t *testing.T) {
+	models := costModelsFromRpc(&cardano.CostModels{
+		PlutusV4: &cardano.CostModel{Values: []int64{1, 2, 3}},
+	})
+	got := models["PlutusV4"]
+	if !reflect.DeepEqual(got, []int64{1, 2, 3}) {
+		t.Fatalf("PlutusV4 cost model = %v, want [1 2 3]", got)
+	}
+}
+
 func TestEvalTxResponseRejectsSingleEvaluationError(t *testing.T) {
 	msg := evalTxResponse([]*cardano.EvalError{
 		{Msg: "PreservationOfValue"},

--- a/helpers.go
+++ b/helpers.go
@@ -540,6 +540,8 @@ func ComputeScriptDataHash(
 			version = 1
 		case "PlutusV3":
 			version = 2
+		case "PlutusV4":
+			version = 3
 		default:
 			return nil, fmt.Errorf("unsupported cost model language: %q", lang)
 		}
@@ -593,22 +595,55 @@ func MinLovelacePostAlonzo(output *babbage.BabbageTransactionOutput, coinsPerUtx
 // --- ScriptRef Constructors ---
 
 // NewScriptRef creates a ScriptRef by detecting the script type automatically.
-// Accepts NativeScript, PlutusV1Script, PlutusV2Script, or PlutusV3Script.
+// Accepts NativeScript and PlutusV1Script through PlutusV4Script.
 func NewScriptRef(script common.Script) (*common.ScriptRef, error) {
-	var scriptType uint
-	switch script.(type) {
-	case common.NativeScript:
-		scriptType = 0
-	case common.PlutusV1Script:
-		scriptType = 1
-	case common.PlutusV2Script:
-		scriptType = 2
-	case common.PlutusV3Script:
-		scriptType = 3
-	default:
-		return nil, fmt.Errorf("unsupported script type: %T", script)
+	scriptType, err := scriptRefType(script)
+	if err != nil {
+		return nil, err
 	}
 	return &common.ScriptRef{Type: scriptType, Script: script}, nil
+}
+
+func scriptRefType(script common.Script) (uint, error) {
+	switch s := script.(type) {
+	case common.NativeScript:
+		return common.ScriptRefTypeNativeScript, nil
+	case *common.NativeScript:
+		if s == nil {
+			return 0, errors.New("script must not be nil")
+		}
+		return common.ScriptRefTypeNativeScript, nil
+	case common.PlutusV1Script:
+		return common.ScriptRefTypePlutusV1, nil
+	case *common.PlutusV1Script:
+		if s == nil {
+			return 0, errors.New("script must not be nil")
+		}
+		return common.ScriptRefTypePlutusV1, nil
+	case common.PlutusV2Script:
+		return common.ScriptRefTypePlutusV2, nil
+	case *common.PlutusV2Script:
+		if s == nil {
+			return 0, errors.New("script must not be nil")
+		}
+		return common.ScriptRefTypePlutusV2, nil
+	case common.PlutusV3Script:
+		return common.ScriptRefTypePlutusV3, nil
+	case *common.PlutusV3Script:
+		if s == nil {
+			return 0, errors.New("script must not be nil")
+		}
+		return common.ScriptRefTypePlutusV3, nil
+	case common.PlutusV4Script:
+		return common.ScriptRefTypePlutusV4, nil
+	case *common.PlutusV4Script:
+		if s == nil {
+			return 0, errors.New("script must not be nil")
+		}
+		return common.ScriptRefTypePlutusV4, nil
+	default:
+		return 0, fmt.Errorf("unsupported script type: %T", script)
+	}
 }
 
 // GetStakeCredentialFromAddress extracts the staking credential from an address.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -677,6 +677,32 @@ func TestComputeScriptDataHashPlutusV1LanguageView(t *testing.T) {
 	}
 }
 
+func TestComputeScriptDataHashPlutusV4LanguageView(t *testing.T) {
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: common.RedeemerTagSpend, Index: 0}: {ExUnits: common.ExUnits{Memory: 1, Steps: 1}},
+	}
+	costs := map[string][]int64{"PlutusV4": {100, 200, 300}}
+	got, err := ComputeScriptDataHash(redeemers, nil, costs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redeemerBytes, err := cbor.Encode(redeemers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{3: {}},
+		map[uint][]int64{3: costs["PlutusV4"]},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := common.Blake2b256Hash(append(append([]byte{}, redeemerBytes...), langViews...))
+	if *got != want {
+		t.Fatalf("PlutusV4 language-view hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+}
+
 func TestComputeScriptDataHashMultipleLanguagesDeterministic(t *testing.T) {
 	redeemers := map[common.RedeemerKey]common.RedeemerValue{
 		{Tag: common.RedeemerTagMint, Index: 0}: {ExUnits: common.ExUnits{Memory: 1, Steps: 1}},


### PR DESCRIPTION
## Summary
- Decode and hydrate Plutus V4 reference scripts across shared, Blockfrost, Maestro, and Ogmios paths.
- Normalize Plutus V4 cost models and compute V4 script-data language views.
- Reject V4 witness/reference-script construction clearly until Apollo adds Dijkstra transaction support.

## Tests
- go test -race ./...
- go test -race ./backend/...