### PR TITLE
fix: harden v2 transaction building and backend operations

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"math"
 	"math/big"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -109,7 +110,7 @@ type auxData struct {
 
 // New creates a new Apollo transaction builder with the given chain context.
 func New(cc backend.ChainContext) *Apollo {
-	return &Apollo{
+	a := &Apollo{
 		Context:         cc,
 		redeemers:       make(map[string]redeemerEntry),
 		stakeRedeemers:  make(map[string]redeemerEntry),
@@ -117,6 +118,10 @@ func New(cc backend.ChainContext) *Apollo {
 		withdrawals:     make(map[string]withdrawalEntry),
 		estimateExUnits: true,
 	}
+	if isNilChainContext(cc) {
+		a.setErrOnce(errors.New("chain context must not be nil"))
+	}
+	return a
 }
 
 // SetWallet sets the wallet for the transaction builder.
@@ -197,6 +202,19 @@ func (a *Apollo) AddRequiredSigner(pkh common.Blake2b224) *Apollo {
 
 // AddRequiredSignerPaymentKey adds the payment key hash from an address as a required signer.
 func (a *Apollo) AddRequiredSignerPaymentKey(addr common.Address) *Apollo {
+	switch addr.Type() {
+	case common.AddressTypeKeyKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeKeyPointer,
+		common.AddressTypeKeyNone:
+		// These address forms have a payment key credential.
+	default:
+		a.setErrOnce(fmt.Errorf(
+			"AddRequiredSignerPaymentKey: address type %d does not have a payment key credential",
+			addr.Type(),
+		))
+		return a
+	}
 	a.requiredSigners = append(a.requiredSigners, addr.PaymentKeyHash())
 	return a
 }
@@ -212,24 +230,40 @@ func (a *Apollo) AddRequiredSignerStakeKey(addr common.Address) *Apollo {
 
 // SetTtl sets the transaction time-to-live.
 func (a *Apollo) SetTtl(ttl int64) *Apollo {
+	if ttl < 0 {
+		a.setErrOnce(errors.New("SetTtl: ttl must be non-negative"))
+		return a
+	}
 	a.Ttl = ttl
 	return a
 }
 
 // SetValidityStart sets the validity start slot.
 func (a *Apollo) SetValidityStart(start int64) *Apollo {
+	if start < 0 {
+		a.setErrOnce(errors.New("SetValidityStart: start must be non-negative"))
+		return a
+	}
 	a.ValidityStart = start
 	return a
 }
 
 // SetFee sets a specific fee (disables fee estimation).
 func (a *Apollo) SetFee(fee int64) *Apollo {
+	if fee < 0 {
+		a.setErrOnce(errors.New("SetFee: fee must be non-negative"))
+		return a
+	}
 	a.Fee = fee
 	return a
 }
 
 // SetFeePadding adds additional fee padding.
 func (a *Apollo) SetFeePadding(padding int64) *Apollo {
+	if padding < 0 {
+		a.setErrOnce(errors.New("SetFeePadding: padding must be non-negative"))
+		return a
+	}
 	a.FeePadding = padding
 	return a
 }
@@ -243,6 +277,10 @@ func (a *Apollo) SetCoinSelector(selector CoinSelector) *Apollo {
 
 // ForceFee sets a fixed fee for the transaction, bypassing automatic fee estimation.
 func (a *Apollo) ForceFee(fee int64) *Apollo {
+	if fee < 0 {
+		a.setErrOnce(errors.New("ForceFee: fee must be non-negative"))
+		return a
+	}
 	a.Fee = fee
 	a.forceFee = true
 	return a
@@ -1033,6 +1071,10 @@ func (a *Apollo) SignWithSkey(skey []byte) (*Apollo, error) {
 
 // SetCollateralAmount sets the target collateral amount.
 func (a *Apollo) SetCollateralAmount(amount int64) *Apollo {
+	if amount < 0 {
+		a.setErrOnce(errors.New("SetCollateralAmount: amount must be non-negative"))
+		return a
+	}
 	a.collateralAmount = amount
 	return a
 }
@@ -1053,7 +1095,9 @@ func (a *Apollo) LoadTxCbor(txCbor string) (*Apollo, error) {
 	return a, nil
 }
 
-// Clone returns a deep copy of this Apollo builder.
+// Clone returns a deep copy of builder-owned state. Injected collaborators
+// (the chain context, wallet, coin selector, and evaluation witness providers)
+// are retained so the clone preserves the original builder's behavior.
 func (a *Apollo) Clone() *Apollo {
 	clone := &Apollo{
 		Context:                    a.Context,
@@ -1070,6 +1114,7 @@ func (a *Apollo) Clone() *Apollo {
 		currentTreasury:            a.currentTreasury,
 		treasuryDonation:           a.treasuryDonation,
 		estimateExUnits:            a.estimateExUnits,
+		coinSelector:               a.coinSelector,
 		wallet:                     a.wallet,
 		evaluationWitnessProviders: append([]EvaluationWitnessProvider(nil), a.evaluationWitnessProviders...),
 		err:                        a.err,
@@ -1080,6 +1125,11 @@ func (a *Apollo) Clone() *Apollo {
 	}
 	for _, p := range a.payments {
 		if pp, ok := p.(*Payment); ok {
+			if pp == nil {
+				clone.setErrOnce(errors.New("clone payment: payment must not be nil"))
+				clone.payments = append(clone.payments, p)
+				continue
+			}
 			cp := *pp
 			if len(pp.Units) > 0 {
 				cp.Units = make([]Unit, len(pp.Units))
@@ -1089,62 +1139,280 @@ func (a *Apollo) Clone() *Apollo {
 				cp.DatumHash = make([]byte, len(pp.DatumHash))
 				copy(cp.DatumHash, pp.DatumHash)
 			}
+			if pp.Datum != nil {
+				var datum common.Datum
+				if err := cloneCBORValue(*pp.Datum, &datum); err != nil {
+					clone.setErrOnce(fmt.Errorf("clone payment datum: %w", err))
+				} else {
+					cp.Datum = &datum
+				}
+			}
+			if pp.ScriptRef != nil {
+				var scriptRef common.ScriptRef
+				if err := cloneCBORValue(*pp.ScriptRef, &scriptRef); err != nil {
+					clone.setErrOnce(fmt.Errorf("clone payment script reference: %w", err))
+				} else {
+					cp.ScriptRef = &scriptRef
+				}
+			}
 			clone.payments = append(clone.payments, &cp)
+		} else if cloner, ok := p.(PaymentCloner); ok {
+			clonedPayment, err := cloner.ClonePayment()
+			if err != nil {
+				clone.setErrOnce(fmt.Errorf("clone custom payment: %w", err))
+			}
+			if clonedPayment == nil {
+				clone.setErrOnce(errors.New("clone custom payment: ClonePayment returned nil"))
+			}
+			clone.payments = append(clone.payments, clonedPayment)
 		} else {
+			clone.setErrOnce(fmt.Errorf(
+				"clone custom payment %T: implement PaymentCloner to support deep cloning",
+				p,
+			))
 			clone.payments = append(clone.payments, p)
 		}
 	}
-	clone.utxos = append(clone.utxos, a.utxos...)
-	clone.preselectedUtxos = append(clone.preselectedUtxos, a.preselectedUtxos...)
+	clone.utxos = cloneUtxos(a.utxos, clone, "available")
+	clone.preselectedUtxos = cloneUtxos(a.preselectedUtxos, clone, "preselected")
 	clone.inputAddresses = append(clone.inputAddresses, a.inputAddresses...)
-	clone.datums = append(clone.datums, a.datums...)
+	for _, datum := range a.datums {
+		var datumCopy common.Datum
+		if err := cloneCBORValue(datum, &datumCopy); err != nil {
+			clone.setErrOnce(fmt.Errorf("clone datum: %w", err))
+			continue
+		}
+		clone.datums = append(clone.datums, datumCopy)
+	}
 	clone.requiredSigners = append(clone.requiredSigners, a.requiredSigners...)
-	clone.v1scripts = append(clone.v1scripts, a.v1scripts...)
-	clone.v2scripts = append(clone.v2scripts, a.v2scripts...)
-	clone.v3scripts = append(clone.v3scripts, a.v3scripts...)
+	for _, script := range a.v1scripts {
+		clone.v1scripts = append(clone.v1scripts, slices.Clone(script))
+	}
+	for _, script := range a.v2scripts {
+		clone.v2scripts = append(clone.v2scripts, slices.Clone(script))
+	}
+	for _, script := range a.v3scripts {
+		clone.v3scripts = append(clone.v3scripts, slices.Clone(script))
+	}
 	clone.mint = append(clone.mint, a.mint...)
-	clone.collaterals = append(clone.collaterals, a.collaterals...)
+	clone.collaterals = cloneUtxos(a.collaterals, clone, "collateral")
 	clone.referenceInputs = append(clone.referenceInputs, a.referenceInputs...)
-	clone.nativescripts = append(clone.nativescripts, a.nativescripts...)
+	for _, script := range a.nativescripts {
+		var scriptCopy common.NativeScript
+		if err := cloneCBORValue(script, &scriptCopy); err != nil {
+			clone.setErrOnce(fmt.Errorf("clone native script: %w", err))
+			continue
+		}
+		clone.nativescripts = append(clone.nativescripts, scriptCopy)
+	}
 	clone.usedUtxos = make(map[string]bool, len(a.usedUtxos))
 	maps.Copy(clone.usedUtxos, a.usedUtxos)
-	clone.certificates = append(clone.certificates, a.certificates...)
+	for _, certificate := range a.certificates {
+		var certificateCopy common.CertificateWrapper
+		if err := cloneCBORValue(certificate, &certificateCopy); err != nil {
+			clone.setErrOnce(fmt.Errorf("clone certificate: %w", err))
+			continue
+		}
+		clone.certificates = append(clone.certificates, certificateCopy)
+	}
 	clone.scriptHashes = append(clone.scriptHashes, a.scriptHashes...)
-	clone.proposalProcedures = append(clone.proposalProcedures, a.proposalProcedures...)
+	for _, proposal := range a.proposalProcedures {
+		var proposalCopy conway.ConwayProposalProcedure
+		if err := cloneCBORValue(proposal, &proposalCopy); err != nil {
+			clone.setErrOnce(fmt.Errorf("clone proposal procedure: %w", err))
+			continue
+		}
+		clone.proposalProcedures = append(clone.proposalProcedures, proposalCopy)
+	}
 	clone.votingProcedures = cloneVotingProcedures(a.votingProcedures)
-	maps.Copy(clone.redeemers, a.redeemers)
-	maps.Copy(clone.stakeRedeemers, a.stakeRedeemers)
-	maps.Copy(clone.mintRedeemers, a.mintRedeemers)
+	cloneRedeemerMap(a.redeemers, clone.redeemers, clone)
+	cloneRedeemerMap(a.stakeRedeemers, clone.stakeRedeemers, clone)
+	cloneRedeemerMap(a.mintRedeemers, clone.mintRedeemers, clone)
 	maps.Copy(clone.withdrawals, a.withdrawals)
 	if a.changeAddress != nil {
 		addr := *a.changeAddress
 		clone.changeAddress = &addr
 	}
 	if a.collateralReturn != nil {
-		cr := *a.collateralReturn
-		clone.collateralReturn = &cr
+		var cr babbage.BabbageTransactionOutput
+		if err := cloneCBORValue(*a.collateralReturn, &cr); err != nil {
+			clone.setErrOnce(fmt.Errorf("clone collateral return: %w", err))
+		} else {
+			clone.collateralReturn = &cr
+		}
 	}
 	if a.auxiliaryData != nil {
 		clonedMeta := make(map[uint64]any, len(a.auxiliaryData.metadata))
-		maps.Copy(clonedMeta, a.auxiliaryData.metadata)
+		for key, value := range a.auxiliaryData.metadata {
+			clonedMeta[key] = cloneMetadataValue(value, clone)
+		}
 		clone.auxiliaryData = &auxData{metadata: clonedMeta}
 	}
 	if a.tx != nil {
 		txBytes, err := cbor.Encode(a.tx)
 		if err != nil {
-			// CBOR encode failed; leave clone.tx nil to avoid shallow-copy aliasing
-			clone.tx = nil
+			clone.setErrOnce(fmt.Errorf("clone transaction: encode CBOR: %w", err))
 		} else {
 			var txCopy conway.ConwayTransaction
 			if _, err := cbor.Decode(txBytes, &txCopy); err != nil {
-				// CBOR decode failed; leave clone.tx nil to avoid shallow-copy aliasing
-				clone.tx = nil
+				clone.setErrOnce(fmt.Errorf("clone transaction: decode CBOR: %w", err))
 			} else {
 				clone.tx = &txCopy
 			}
 		}
 	}
 	return clone
+}
+
+func isNilChainContext(ctx backend.ChainContext) bool {
+	if ctx == nil {
+		return true
+	}
+	value := reflect.ValueOf(ctx)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func cloneCBORValue(src, dst any) error {
+	encoded, err := cbor.Encode(src)
+	if err != nil {
+		return fmt.Errorf("encode CBOR: %w", err)
+	}
+	if _, err := cbor.Decode(encoded, dst); err != nil {
+		return fmt.Errorf("decode CBOR: %w", err)
+	}
+	return nil
+}
+
+func cloneCBORInterface[T any](src T) (T, error) {
+	var zero T
+	value := reflect.ValueOf(src)
+	if !value.IsValid() {
+		return zero, errors.New("value is nil")
+	}
+
+	encoded, err := cbor.Encode(src)
+	if err != nil {
+		return zero, fmt.Errorf("encode CBOR: %w", err)
+	}
+
+	valueType := value.Type()
+	var target reflect.Value
+	if valueType.Kind() == reflect.Pointer {
+		target = reflect.New(valueType.Elem())
+	} else {
+		target = reflect.New(valueType)
+	}
+	if _, err := cbor.Decode(encoded, target.Interface()); err != nil {
+		return zero, fmt.Errorf("decode CBOR: %w", err)
+	}
+
+	var candidate any
+	if valueType.Kind() == reflect.Pointer {
+		candidate = target.Interface()
+	} else {
+		candidate = target.Elem().Interface()
+	}
+	cloned, ok := candidate.(T)
+	if !ok {
+		return zero, fmt.Errorf("cloned CBOR value has unexpected type %T", candidate)
+	}
+	return cloned, nil
+}
+
+func cloneUtxos(src []common.Utxo, owner *Apollo, kind string) []common.Utxo {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]common.Utxo, 0, len(src))
+	for _, utxo := range src {
+		id, err := cloneCBORInterface[common.TransactionInput](utxo.Id)
+		if err != nil {
+			owner.setErrOnce(fmt.Errorf("clone %s UTxO input: %w", kind, err))
+			continue
+		}
+		output, err := cloneCBORInterface[common.TransactionOutput](utxo.Output)
+		if err != nil {
+			owner.setErrOnce(fmt.Errorf("clone %s UTxO output: %w", kind, err))
+			continue
+		}
+		dst = append(dst, common.Utxo{Id: id, Output: output})
+	}
+	return dst
+}
+
+func cloneRedeemerMap(src, dst map[string]redeemerEntry, owner *Apollo) {
+	for key, entry := range src {
+		var datum common.Datum
+		if err := cloneCBORValue(entry.Data, &datum); err != nil {
+			owner.setErrOnce(fmt.Errorf("clone redeemer %q datum: %w", key, err))
+			continue
+		}
+		entry.Data = datum
+		dst[key] = entry
+	}
+}
+
+func cloneMetadataValue(value any, owner *Apollo) any {
+	switch typed := value.(type) {
+	case nil, string, int, int64, uint64:
+		return typed
+	case *big.Int:
+		if typed == nil {
+			return (*big.Int)(nil)
+		}
+		return new(big.Int).Set(typed)
+	case big.Int:
+		return *new(big.Int).Set(&typed)
+	case []byte:
+		return slices.Clone(typed)
+	case MetadataMap:
+		cloned := make(MetadataMap, len(typed))
+		for i, entry := range typed {
+			cloned[i] = MetadataMapEntry{
+				Key:   cloneMetadataValue(entry.Key, owner),
+				Value: cloneMetadataValue(entry.Value, owner),
+			}
+		}
+		return cloned
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, item := range typed {
+			cloned[key] = cloneMetadataValue(item, owner)
+		}
+		return cloned
+	case map[uint64]any:
+		cloned := make(map[uint64]any, len(typed))
+		for key, item := range typed {
+			cloned[key] = cloneMetadataValue(item, owner)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneMetadataValue(item, owner)
+		}
+		return cloned
+	case common.TransactionMetadatum:
+		encoded, err := cbor.Encode(typed)
+		if err != nil {
+			owner.setErrOnce(fmt.Errorf("clone transaction metadatum: encode CBOR: %w", err))
+			return typed
+		}
+		cloned, err := common.DecodeMetadatumRaw(encoded)
+		if err != nil {
+			owner.setErrOnce(fmt.Errorf("clone transaction metadatum: decode CBOR: %w", err))
+			return typed
+		}
+		return cloned
+	default:
+		owner.setErrOnce(fmt.Errorf("clone metadata value: unsupported type %T", value))
+		return value
+	}
 }
 
 // UtxoFromRef looks up a UTxO by transaction hash and index.
@@ -1681,15 +1949,40 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 	if err != nil {
 		return nil, err
 	}
+	availableByRef := make(map[string]common.Utxo, len(available))
+	for _, utxo := range available {
+		availableByRef[utxoRef(utxo)] = utxo
+	}
+	canonical := make([]common.Utxo, 0, len(selected))
+	seen := make(map[string]struct{}, len(selected))
+	for _, utxo := range selected {
+		if err := backend.ValidateAdditionalUtxo(utxo); err != nil {
+			return nil, fmt.Errorf("coin selector returned invalid UTxO: %w", err)
+		}
+		ref := utxoRef(utxo)
+		availableUtxo, ok := availableByRef[ref]
+		if !ok {
+			return nil, fmt.Errorf("coin selector returned unavailable UTxO %s", ref)
+		}
+		if _, ok := seen[ref]; ok {
+			return nil, fmt.Errorf("coin selector returned duplicate UTxO %s", ref)
+		}
+		seen[ref] = struct{}{}
+		canonical = append(canonical, availableUtxo)
+	}
+	selectedValue, err := a.sumUtxoValues(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("coin selector returned invalid selection: %w", err)
+	}
+	if !selectedValue.GreaterOrEqual(remaining) {
+		return nil, errors.New("coin selector returned a selection that does not cover the target")
+	}
 
 	// Commit to usedUtxos only on success
-	for i, utxo := range selected {
-		if err := validateUtxo(utxo); err != nil {
-			return nil, fmt.Errorf("coin selector returned invalid UTxO %d: %w", i, err)
-		}
+	for _, utxo := range canonical {
 		a.markUsed(utxoRef(utxo))
 	}
-	return selected, nil
+	return canonical, nil
 }
 
 func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) (int64, error) {

--- a/apollo.go
+++ b/apollo.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -36,6 +37,7 @@ var ErrPlutusV4RequiresDijkstra = errors.New("plutus V4 requires Dijkstra transa
 // Apollo is the main transaction builder.
 type Apollo struct {
 	Context            backend.ChainContext
+	requestContext     context.Context
 	payments           []PaymentI
 	isEstimateRequired bool
 	utxos              []common.Utxo
@@ -112,6 +114,7 @@ type auxData struct {
 func New(cc backend.ChainContext) *Apollo {
 	a := &Apollo{
 		Context:         cc,
+		requestContext:  context.Background(),
 		redeemers:       make(map[string]redeemerEntry),
 		stakeRedeemers:  make(map[string]redeemerEntry),
 		mintRedeemers:   make(map[string]redeemerEntry),
@@ -121,6 +124,18 @@ func New(cc backend.ChainContext) *Apollo {
 	if isNilChainContext(cc) {
 		a.setErrOnce(errors.New("chain context must not be nil"))
 	}
+	return a
+}
+
+// WithContext sets the context used by subsequent chain-context operations.
+// A nil context is treated as context.Background. The context is retained by
+// the builder, so callers should not use a short-lived context for operations
+// they intend to perform later.
+func (a *Apollo) WithContext(ctx context.Context) *Apollo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	a.requestContext = ctx
 	return a
 }
 
@@ -1101,6 +1116,7 @@ func (a *Apollo) LoadTxCbor(txCbor string) (*Apollo, error) {
 func (a *Apollo) Clone() *Apollo {
 	clone := &Apollo{
 		Context:                    a.Context,
+		requestContext:             a.requestContext,
 		isEstimateRequired:         a.isEstimateRequired,
 		Fee:                        a.Fee,
 		FeePadding:                 a.FeePadding,
@@ -1429,7 +1445,7 @@ func (a *Apollo) UtxoFromRef(txHash string, txIndex int) (*common.Utxo, error) {
 	}
 	var hash common.Blake2b256
 	copy(hash[:], hashBytes)
-	return a.Context.UtxoByRef(hash, uint32(txIndex))
+	return backend.UtxoByRefContext(a.requestContext, a.Context, hash, uint32(txIndex))
 }
 
 // GetUsedUTxOs returns a copy of the used UTxO references.
@@ -1488,7 +1504,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	// a silently wrong deposit produces a value-non-conserving transaction.
 	stakeDeposit := int64(StakeDeposit)
 	if len(a.certificates) > 0 {
-		pp, ppErr := a.Context.ProtocolParams()
+		pp, ppErr := backend.ProtocolParamsContext(a.requestContext, a.Context)
 		if ppErr != nil {
 			return a, fmt.Errorf("failed to get protocol params for certificate deposit: %w", ppErr)
 		}
@@ -1556,7 +1572,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	// MaxTxFee covers the size-based fee only; Conway reference-script fees are
 	// charged separately, so reserve the known reference-input / pinned-input
 	// surcharge before coin selection.
-	maxFee, feeErr := a.Context.MaxTxFee()
+	maxFee, feeErr := backend.MaxTxFeeContext(a.requestContext, a.Context)
 	if feeErr != nil {
 		return a, fmt.Errorf("failed to compute max tx fee for coin selection: %w", feeErr)
 	}
@@ -1823,14 +1839,14 @@ func (a *Apollo) Submit() (common.Blake2b256, error) {
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
-	return a.Context.SubmitTx(txCbor)
+	return backend.SubmitTxContext(a.requestContext, a.Context, txCbor)
 }
 
 // --- internal helpers ---
 
 func (a *Apollo) loadUtxos() error {
 	for _, addr := range a.inputAddresses {
-		utxos, err := a.Context.Utxos(addr)
+		utxos, err := backend.UtxosContext(a.requestContext, a.Context, addr)
 		if err != nil {
 			return fmt.Errorf("failed to load UTxOs for %s: %w", addr.String(), err)
 		}
@@ -1841,7 +1857,7 @@ func (a *Apollo) loadUtxos() error {
 	}
 	// If no UTxOs loaded and wallet is set, load from wallet address
 	if len(a.utxos) == 0 && len(a.preselectedUtxos) == 0 && a.wallet != nil {
-		utxos, err := a.Context.Utxos(a.wallet.Address())
+		utxos, err := backend.UtxosContext(a.requestContext, a.Context, a.wallet.Address())
 		if err != nil {
 			return fmt.Errorf("failed to load wallet UTxOs: %w", err)
 		}
@@ -1856,7 +1872,7 @@ func (a *Apollo) loadUtxos() error {
 func (a *Apollo) buildOutputs() ([]babbage.BabbageTransactionOutput, error) {
 	outputs := make([]babbage.BabbageTransactionOutput, 0, len(a.payments))
 	for _, payment := range a.payments {
-		if err := payment.EnsureMinUTXO(a.Context); err != nil {
+		if err := payment.EnsureMinUTXO(backend.BindContext(a.requestContext, a.Context)); err != nil {
 			return nil, fmt.Errorf("failed to ensure min UTxO: %w", err)
 		}
 		txOut, err := payment.ToTxOut()
@@ -1986,7 +2002,7 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 }
 
 func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) (int64, error) {
-	pp, err := a.Context.ProtocolParams()
+	pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context)
 	if err != nil {
 		return 0, err
 	}
@@ -1998,7 +2014,7 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 	// producing a fee that is a few hundred lovelace short and a FeeTooSmallUTxO
 	// rejection. Use a placeholder fee whose CBOR width matches (or exceeds) the
 	// final fee so the size — and thus the fee — is not underestimated.
-	placeholderFee, feeErr := a.Context.MaxTxFee()
+	placeholderFee, feeErr := backend.MaxTxFeeContext(a.requestContext, a.Context)
 	if feeErr != nil || placeholderFee == 0 {
 		placeholderFee = 2_000_000
 	}
@@ -2083,7 +2099,7 @@ func (a *Apollo) referenceScriptFee(inputs []common.Utxo) (int64, error) {
 	if refScriptSize == 0 {
 		return 0, nil
 	}
-	pp, err := a.Context.ProtocolParams()
+	pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context)
 	if err != nil {
 		return 0, err
 	}
@@ -2174,7 +2190,7 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 			continue
 		}
 		seen[ref] = struct{}{}
-		utxo, err := a.Context.UtxoByRef(refInput.TxId, refInput.OutputIndex)
+		utxo, err := backend.UtxoByRefContext(a.requestContext, a.Context, refInput.TxId, refInput.OutputIndex)
 		if err != nil {
 			return 0, fmt.Errorf(
 				"failed to resolve reference input %s for reference-script fee: %w",
@@ -2240,7 +2256,7 @@ func (a *Apollo) estimateExecutionUnits(
 		return nil, fmt.Errorf("failed to encode preliminary tx: %w", err)
 	}
 
-	evalResult, err := a.Context.EvaluateTx(txBytes, inputs)
+	evalResult, err := backend.EvaluateTxContext(a.requestContext, a.Context, txBytes, inputs)
 	if err != nil {
 		return nil, fmt.Errorf("EvaluateTx failed: %w", err)
 	}
@@ -2477,7 +2493,7 @@ func (a *Apollo) buildBody(
 
 	// Script data hash
 	if len(a.redeemers) > 0 || len(a.mintRedeemers) > 0 || len(a.stakeRedeemers) > 0 || len(a.datums) > 0 {
-		pp, err := a.Context.ProtocolParams()
+		pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context)
 		if err != nil {
 			return body, err
 		}
@@ -2617,7 +2633,7 @@ func (a *Apollo) usedScriptCostModels(
 		}
 	}
 	for _, refInput := range a.referenceInputs {
-		utxo, err := a.Context.UtxoByRef(refInput.TxId, refInput.OutputIndex)
+		utxo, err := backend.UtxoByRefContext(a.requestContext, a.Context, refInput.TxId, refInput.OutputIndex)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to resolve reference input %s#%d for script data hash: %w",
@@ -2906,8 +2922,8 @@ func (a *Apollo) setCollateral() error {
 	minCollateral := int64(5_000_000) // conservative fallback
 	if a.collateralAmount > 0 {
 		minCollateral = a.collateralAmount
-	} else if pp, err := a.Context.ProtocolParams(); err == nil {
-		if maxFee, err := a.Context.MaxTxFee(); err == nil && pp.CollateralPercent > 0 &&
+	} else if pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context); err == nil {
+		if maxFee, err := backend.MaxTxFeeContext(a.requestContext, a.Context); err == nil && pp.CollateralPercent > 0 &&
 			maxFee <= math.MaxInt64/uint64(pp.CollateralPercent) {
 			computed := int64(maxFee) * int64(pp.CollateralPercent) / 100 //nolint:gosec // bounded above
 			if computed > 0 {
@@ -2918,7 +2934,7 @@ func (a *Apollo) setCollateral() error {
 
 	candidates := a.utxos
 	if len(candidates) == 0 && a.wallet != nil {
-		loaded, err := a.Context.Utxos(a.wallet.Address())
+		loaded, err := backend.UtxosContext(a.requestContext, a.Context, a.wallet.Address())
 		if err != nil {
 			return fmt.Errorf("failed to load UTxOs for collateral selection: %w", err)
 		}
@@ -3065,7 +3081,7 @@ func (a *Apollo) finalizeCollateral(fee int64) error {
 	if len(a.collaterals) == 0 {
 		return nil
 	}
-	pp, err := a.Context.ProtocolParams()
+	pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context)
 	if err != nil {
 		return fmt.Errorf("failed to get protocol params for collateral sizing: %w", err)
 	}
@@ -3248,7 +3264,7 @@ func (a *Apollo) validateCollateral() error {
 		}
 	}
 	// Enforce the protocol max on collateral inputs when known.
-	if pp, err := a.Context.ProtocolParams(); err == nil && pp.MaxCollateralInputs > 0 &&
+	if pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context); err == nil && pp.MaxCollateralInputs > 0 &&
 		len(a.collaterals) > pp.MaxCollateralInputs {
 		return fmt.Errorf(
 			"too many collateral inputs: %d exceeds protocol maximum of %d",

--- a/apollo.go
+++ b/apollo.go
@@ -163,12 +163,22 @@ func (a *Apollo) AddPayment(payment PaymentI) *Apollo {
 
 // AddLoadedUTxOs adds UTxOs to the available pool for coin selection.
 func (a *Apollo) AddLoadedUTxOs(utxos ...common.Utxo) *Apollo {
+	for i, utxo := range utxos {
+		if err := validateUtxo(utxo); err != nil {
+			a.setErrOnce(fmt.Errorf("loaded UTxO %d is invalid: %w", i, err))
+			return a
+		}
+	}
 	a.utxos = append(a.utxos, utxos...)
 	return a
 }
 
 // AddInput adds a specific UTxO as a transaction input.
 func (a *Apollo) AddInput(utxo common.Utxo) *Apollo {
+	if err := validateUtxo(utxo); err != nil {
+		a.setErrOnce(fmt.Errorf("input UTxO is invalid: %w", err))
+		return a
+	}
 	a.preselectedUtxos = append(a.preselectedUtxos, utxo)
 	return a
 }
@@ -246,6 +256,10 @@ func (a *Apollo) SetChangeAddress(addr common.Address) *Apollo {
 
 // AddCollateral adds a UTxO as collateral for script transactions.
 func (a *Apollo) AddCollateral(utxo common.Utxo) *Apollo {
+	if err := validateUtxo(utxo); err != nil {
+		a.setErrOnce(fmt.Errorf("collateral UTxO is invalid: %w", err))
+		return a
+	}
 	a.collaterals = append(a.collaterals, utxo)
 	return a
 }
@@ -267,8 +281,8 @@ func (a *Apollo) AddReferenceInput(txHash string, index int) (*Apollo, error) {
 	if len(hashBytes) != common.Blake2b256Size {
 		return a, fmt.Errorf("invalid tx hash length: expected %d bytes, got %d", common.Blake2b256Size, len(hashBytes))
 	}
-	if index < 0 || index > math.MaxUint32 {
-		return a, fmt.Errorf("index must be 0-%d, got %d", math.MaxUint32, index)
+	if index < 0 || uint64(index) > uint64(math.MaxUint32) {
+		return a, fmt.Errorf("index must be 0-%d, got %d", uint64(math.MaxUint32), index)
 	}
 	var hash common.Blake2b256
 	copy(hash[:], hashBytes)
@@ -352,6 +366,10 @@ func (a *Apollo) DisableExecutionUnitsEstimation() *Apollo {
 
 // CollectFrom adds a script UTxO as input with a spending redeemer.
 func (a *Apollo) CollectFrom(utxo common.Utxo, redeemer common.Datum, exUnits common.ExUnits) *Apollo {
+	if err := validateUtxo(utxo); err != nil {
+		a.setErrOnce(fmt.Errorf("script input UTxO is invalid: %w", err))
+		return a
+	}
 	a.isEstimateRequired = true
 	a.preselectedUtxos = append(a.preselectedUtxos, utxo)
 	ref := utxoRef(utxo)
@@ -501,6 +519,9 @@ func (a *Apollo) ConsumeUTxO(utxo common.Utxo, payments ...PaymentI) (*Apollo, e
 }
 
 func (a *Apollo) utxoValue(utxo common.Utxo) (Value, error) {
+	if err := validateUtxo(utxo); err != nil {
+		return Value{}, err
+	}
 	v := Value{}
 	amt := utxo.Output.Amount()
 	if amt != nil {
@@ -802,7 +823,12 @@ func (a *Apollo) DeregisterPool(poolHash common.Blake2b224, epoch uint64) *Apoll
 // AddWithdrawal adds a staking reward withdrawal to the transaction.
 // For script-based withdrawals, provide a redeemer and execution units.
 func (a *Apollo) AddWithdrawal(address common.Address, amount uint64, redeemerData *common.Datum, exUnits *common.ExUnits) *Apollo {
-	wdKey := address.String()
+	rewardAddress, err := withdrawalRewardAddress(address)
+	if err != nil {
+		a.setErrOnce(err)
+		return a
+	}
+	wdKey := rewardAddress.String()
 	if existing, ok := a.withdrawals[wdKey]; ok {
 		if math.MaxUint64-existing.Amount < amount {
 			a.setErrOnce(fmt.Errorf("withdrawal amount overflow for %s", wdKey))
@@ -810,9 +836,9 @@ func (a *Apollo) AddWithdrawal(address common.Address, amount uint64, redeemerDa
 		}
 		amount += existing.Amount
 	}
-	a.withdrawals[wdKey] = withdrawalEntry{Address: address, Amount: amount}
+	a.withdrawals[wdKey] = withdrawalEntry{Address: rewardAddress, Amount: amount}
 	if redeemerData != nil {
-		skh := address.StakeKeyHash()
+		skh := rewardAddress.StakeKeyHash()
 		if skh == (common.Blake2b224{}) {
 			a.setErrOnce(fmt.Errorf("withdrawal redeemer requires stake credential for %s", wdKey))
 			return a
@@ -833,6 +859,56 @@ func (a *Apollo) AddWithdrawal(address common.Address, amount uint64, redeemerDa
 		a.isEstimateRequired = true
 	}
 	return a
+}
+
+// withdrawalRewardAddress returns the canonical reward account represented by
+// address. Reward addresses are preserved; base addresses are reduced to their
+// staking credential. Enterprise, pointer, and Byron addresses have no staking
+// credential suitable for a withdrawal.
+func withdrawalRewardAddress(address common.Address) (common.Address, error) {
+	switch address.Type() {
+	case common.AddressTypeNoneKey, common.AddressTypeNoneScript:
+		return address, nil
+	}
+
+	credential, ok := address.StakeCredential()
+	if !ok {
+		return common.Address{}, fmt.Errorf(
+			"withdrawal address %q does not contain a staking credential",
+			address.String(),
+		)
+	}
+
+	var addressType uint8
+	switch credential.CredType {
+	case common.CredentialTypeAddrKeyHash:
+		addressType = common.AddressTypeNoneKey
+	case common.CredentialTypeScriptHash:
+		addressType = common.AddressTypeNoneScript
+	default:
+		return common.Address{}, fmt.Errorf(
+			"withdrawal address %q has an unsupported staking credential",
+			address.String(),
+		)
+	}
+	networkID := address.NetworkId()
+	if networkID > math.MaxUint8 {
+		return common.Address{}, fmt.Errorf(
+			"withdrawal address %q has an invalid network ID %d",
+			address.String(),
+			networkID,
+		)
+	}
+	rewardAddress, err := common.NewAddressFromParts(
+		addressType,
+		uint8(networkID),
+		nil,
+		credential.Credential.Bytes(),
+	)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to build withdrawal reward address: %w", err)
+	}
+	return rewardAddress, nil
 }
 
 // --- Metadata ---
@@ -1080,8 +1156,8 @@ func (a *Apollo) UtxoFromRef(txHash string, txIndex int) (*common.Utxo, error) {
 	if len(hashBytes) != common.Blake2b256Size {
 		return nil, fmt.Errorf("invalid tx hash length: expected %d bytes, got %d", common.Blake2b256Size, len(hashBytes))
 	}
-	if txIndex < 0 || txIndex > math.MaxUint32 {
-		return nil, fmt.Errorf("tx index must be 0-%d, got %d", math.MaxUint32, txIndex)
+	if txIndex < 0 || uint64(txIndex) > uint64(math.MaxUint32) {
+		return nil, fmt.Errorf("tx index must be 0-%d, got %d", uint64(math.MaxUint32), txIndex)
 	}
 	var hash common.Blake2b256
 	copy(hash[:], hashBytes)
@@ -1490,12 +1566,18 @@ func (a *Apollo) loadUtxos() error {
 		if err != nil {
 			return fmt.Errorf("failed to load UTxOs for %s: %w", addr.String(), err)
 		}
+		if err := validateUtxos(utxos); err != nil {
+			return fmt.Errorf("failed to load UTxOs for %s: %w", addr.String(), err)
+		}
 		a.utxos = append(a.utxos, utxos...)
 	}
 	// If no UTxOs loaded and wallet is set, load from wallet address
 	if len(a.utxos) == 0 && len(a.preselectedUtxos) == 0 && a.wallet != nil {
 		utxos, err := a.Context.Utxos(a.wallet.Address())
 		if err != nil {
+			return fmt.Errorf("failed to load wallet UTxOs: %w", err)
+		}
+		if err := validateUtxos(utxos); err != nil {
 			return fmt.Errorf("failed to load wallet UTxOs: %w", err)
 		}
 		a.utxos = utxos
@@ -1537,6 +1619,9 @@ func (a *Apollo) totalPreselectedValue() (Value, error) {
 func (a *Apollo) sumUtxoValues(utxos []common.Utxo) (Value, error) {
 	total := Value{}
 	for _, utxo := range utxos {
+		if err := validateUtxo(utxo); err != nil {
+			return Value{}, err
+		}
 		amt := utxo.Output.Amount()
 		// Amounts come from a remote backend; reject anything outside the
 		// uint64 lovelace range instead of silently treating it as zero.
@@ -1580,6 +1665,9 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 
 	available := make([]common.Utxo, 0, len(a.utxos))
 	for _, utxo := range a.utxos {
+		if err := validateUtxo(utxo); err != nil {
+			return nil, fmt.Errorf("available UTxO is invalid: %w", err)
+		}
 		if !a.isUsed(utxoRef(utxo)) {
 			available = append(available, utxo)
 		}
@@ -1595,7 +1683,10 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 	}
 
 	// Commit to usedUtxos only on success
-	for _, utxo := range selected {
+	for i, utxo := range selected {
+		if err := validateUtxo(utxo); err != nil {
+			return nil, fmt.Errorf("coin selector returned invalid UTxO %d: %w", i, err)
+		}
 		a.markUsed(utxoRef(utxo))
 	}
 	return selected, nil
@@ -1785,7 +1876,7 @@ func (a *Apollo) totalReferenceScriptSize(inputs []common.Utxo) (int, error) {
 
 	// Reference inputs must be resolved against the chain context.
 	for _, refInput := range a.referenceInputs {
-		ref := hex.EncodeToString(refInput.TxId.Bytes()) + "#" + strconv.Itoa(int(refInput.OutputIndex))
+		ref := hex.EncodeToString(refInput.TxId.Bytes()) + "#" + strconv.FormatUint(uint64(refInput.OutputIndex), 10)
 		if _, ok := seen[ref]; ok {
 			continue
 		}
@@ -2465,7 +2556,23 @@ func (a *Apollo) markUsed(ref string) {
 }
 
 func utxoRef(utxo common.Utxo) string {
-	return hex.EncodeToString(utxo.Id.Id().Bytes()) + "#" + strconv.Itoa(int(utxo.Id.Index()))
+	return hex.EncodeToString(utxo.Id.Id().Bytes()) + "#" + strconv.FormatUint(uint64(utxo.Id.Index()), 10)
+}
+
+func validateUtxo(utxo common.Utxo) error {
+	if err := backend.ValidateAdditionalUtxo(utxo); err != nil {
+		return fmt.Errorf("UTxO is malformed: %w", err)
+	}
+	return nil
+}
+
+func validateUtxos(utxos []common.Utxo) error {
+	for i, utxo := range utxos {
+		if err := validateUtxo(utxo); err != nil {
+			return fmt.Errorf("UTxO %d is invalid: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // getChangeAddress returns the change address (explicit or wallet).

--- a/apollo_context_test.go
+++ b/apollo_context_test.go
@@ -1,0 +1,120 @@
+package apollo
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+
+	"github.com/Salvionied/apollo/v2/backend"
+)
+
+type contextTrackingChain struct {
+	backend.ChainContext
+	received context.Context
+}
+
+func (c *contextTrackingChain) ProtocolParamsContext(context.Context) (backend.ProtocolParameters, error) {
+	return backend.ProtocolParameters{}, nil
+}
+
+func (c *contextTrackingChain) GenesisParamsContext(context.Context) (backend.GenesisParameters, error) {
+	return backend.GenesisParameters{}, nil
+}
+
+func (c *contextTrackingChain) CurrentEpochContext(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (c *contextTrackingChain) MaxTxFeeContext(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (c *contextTrackingChain) TipContext(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (c *contextTrackingChain) UtxosContext(context.Context, common.Address) ([]common.Utxo, error) {
+	return nil, nil
+}
+
+func (c *contextTrackingChain) SubmitTxContext(context.Context, []byte) (common.Blake2b256, error) {
+	return common.Blake2b256{}, nil
+}
+
+func (c *contextTrackingChain) EvaluateTxContext(
+	context.Context,
+	[]byte,
+	[]common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	return nil, nil
+}
+
+func (c *contextTrackingChain) UtxoByRefContext(
+	ctx context.Context,
+	_ common.Blake2b256,
+	_ uint32,
+) (*common.Utxo, error) {
+	c.received = ctx
+	return nil, ctx.Err()
+}
+
+func (c *contextTrackingChain) ScriptCborContext(context.Context, common.Blake2b224) ([]byte, error) {
+	return nil, nil
+}
+
+func TestApolloWithContextPropagatesCancellation(t *testing.T) {
+	chainContext := &contextTrackingChain{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := New(chainContext).
+		WithContext(ctx).
+		UtxoFromRef(hex.EncodeToString(make([]byte, common.Blake2b256Size)), 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("UtxoFromRef() error = %v, want context.Canceled", err)
+	}
+	if chainContext.received != ctx {
+		t.Fatal("context-aware backend did not receive the Apollo context")
+	}
+}
+
+func TestApolloWithContextNormalizesNil(t *testing.T) {
+	chainContext := &contextTrackingChain{}
+
+	if _, err := New(chainContext).
+		WithContext(nil).
+		UtxoFromRef(hex.EncodeToString(make([]byte, common.Blake2b256Size)), 0); err != nil {
+		t.Fatalf("UtxoFromRef() error = %v", err)
+	}
+	if chainContext.received == nil {
+		t.Fatal("context-aware backend received a nil context")
+	}
+}
+
+func TestApolloLookupRejectsNilChainContext(t *testing.T) {
+	txHash := hex.EncodeToString(make([]byte, common.Blake2b256Size))
+	if _, err := New(nil).UtxoFromRef(txHash, 0); err == nil {
+		t.Fatal("UtxoFromRef() with nil chain context returned nil error")
+	}
+
+	var typedNil *contextTrackingChain
+	if _, err := New(typedNil).UtxoFromRef(txHash, 0); err == nil {
+		t.Fatal("UtxoFromRef() with typed nil chain context returned nil error")
+	}
+}
+
+func TestApolloSubmitRejectsNilChainContext(t *testing.T) {
+	builder := New(nil)
+	builder.tx = &conway.ConwayTransaction{}
+
+	if _, err := builder.Submit(); err == nil || !strings.Contains(err.Error(), "chain context is nil") {
+		t.Fatalf("Submit() error = %v, want nil chain context error", err)
+	}
+}
+
+var _ backend.ContextChainContext = (*contextTrackingChain)(nil)

--- a/apollo_context_test.go
+++ b/apollo_context_test.go
@@ -85,10 +85,13 @@ func TestApolloWithContextPropagatesCancellation(t *testing.T) {
 
 func TestApolloWithContextNormalizesNil(t *testing.T) {
 	chainContext := &contextTrackingChain{}
+	builder := New(chainContext)
+	builder.WithContext(nil) //nolint:staticcheck // Verify Apollo's documented nil-context normalization contract.
 
-	if _, err := New(chainContext).
-		WithContext(nil).
-		UtxoFromRef(hex.EncodeToString(make([]byte, common.Blake2b256Size)), 0); err != nil {
+	if _, err := builder.UtxoFromRef(
+		hex.EncodeToString(make([]byte, common.Blake2b256Size)),
+		0,
+	); err != nil {
 		t.Fatalf("UtxoFromRef() error = %v", err)
 	}
 	if chainContext.received == nil {

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -172,6 +172,22 @@ func TestAddLoadedUTxOs(t *testing.T) {
 	}
 }
 
+func TestAddLoadedUTxOsRejectsMalformedUTxOsAtomically(t *testing.T) {
+	a := New(setupFixedContext())
+	valid := makeTestUtxo(t, common.Blake2b256{1}, 0, 5_000_000)
+	var nilInput *shelley.ShelleyTransactionInput
+	malformed := common.Utxo{Id: nilInput, Output: valid.Output}
+
+	a.AddLoadedUTxOs(valid, malformed)
+
+	if a.err == nil {
+		t.Fatal("expected builder error")
+	}
+	if len(a.utxos) != 0 {
+		t.Fatalf("expected no partially-added UTxOs, got %d", len(a.utxos))
+	}
+}
+
 func TestAddInput(t *testing.T) {
 	cc := setupFixedContext()
 	a := New(cc)
@@ -181,6 +197,21 @@ func TestAddInput(t *testing.T) {
 	a.AddInput(utxo)
 	if len(a.preselectedUtxos) != 1 {
 		t.Errorf("expected 1 preselected utxo, got %d", len(a.preselectedUtxos))
+	}
+}
+
+func TestAddInputRejectsTypedNilOutput(t *testing.T) {
+	a := New(setupFixedContext())
+	valid := makeTestUtxo(t, common.Blake2b256{1}, 0, 5_000_000)
+	var nilOutput *babbage.BabbageTransactionOutput
+
+	a.AddInput(common.Utxo{Id: valid.Id, Output: nilOutput})
+
+	if a.err == nil {
+		t.Fatal("expected builder error")
+	}
+	if len(a.preselectedUtxos) != 0 {
+		t.Fatalf("expected no malformed input, got %d", len(a.preselectedUtxos))
 	}
 }
 
@@ -488,6 +519,21 @@ func TestCollectFrom(t *testing.T) {
 	}
 }
 
+func TestCollectFromRejectsMalformedUTxOWithoutMutatingRedeemers(t *testing.T) {
+	a := New(setupFixedContext())
+	var nilInput *shelley.ShelleyTransactionInput
+	utxo := common.Utxo{Id: nilInput}
+
+	a.CollectFrom(utxo, common.Datum{}, common.ExUnits{})
+
+	if a.err == nil {
+		t.Fatal("expected builder error")
+	}
+	if len(a.preselectedUtxos) != 0 || len(a.redeemers) != 0 || a.isEstimateRequired {
+		t.Fatal("malformed script input mutated builder state")
+	}
+}
+
 func TestPayToContract(t *testing.T) {
 	cc := setupFixedContext()
 	a := New(cc)
@@ -707,6 +753,132 @@ func TestAddWithdrawal(t *testing.T) {
 	if len(a.withdrawals) != 1 {
 		t.Errorf("expected 1 withdrawal, got %d", len(a.withdrawals))
 	}
+	reward := addr.StakeAddress()
+	if reward == nil {
+		t.Fatal("expected test base address to have a reward address")
+	}
+	entry, ok := a.withdrawals[reward.String()]
+	if !ok {
+		t.Fatalf("expected canonical reward account %s", reward.String())
+	}
+	got, err := entry.Address.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := reward.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("withdrawal address bytes = %x, want %x", got, want)
+	}
+}
+
+func TestAddWithdrawalPreservesRewardAddress(t *testing.T) {
+	a := New(setupFixedContext())
+	base := testAddress(t)
+	reward := base.StakeAddress()
+	if reward == nil {
+		t.Fatal("expected reward address")
+	}
+
+	a.AddWithdrawal(*reward, 1_000_000, nil, nil)
+
+	entry, ok := a.withdrawals[reward.String()]
+	if !ok {
+		t.Fatalf("expected reward account %s", reward.String())
+	}
+	got, err := entry.Address.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := reward.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("withdrawal address bytes = %x, want %x", got, want)
+	}
+}
+
+func TestAddWithdrawalConvertsScriptStakeCredential(t *testing.T) {
+	var paymentHash, stakeScriptHash common.Blake2b224
+	paymentHash[0] = 0xaa
+	stakeScriptHash[0] = 0xbb
+	base, err := common.NewAddressFromParts(
+		common.AddressTypeKeyScript,
+		common.AddressNetworkTestnet,
+		paymentHash.Bytes(),
+		stakeScriptHash.Bytes(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(setupFixedContext())
+
+	a.AddWithdrawal(base, 1_000_000, nil, nil)
+
+	if a.err != nil {
+		t.Fatal(a.err)
+	}
+	reward, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkTestnet,
+		nil,
+		stakeScriptHash.Bytes(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := a.withdrawals[reward.String()]
+	if !ok {
+		t.Fatalf("expected script reward account %s", reward.String())
+	}
+	got, err := entry.Address.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := reward.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("withdrawal address bytes = %x, want %x", got, want)
+	}
+}
+
+func TestAddWithdrawalRejectsAddressesWithoutStakeCredential(t *testing.T) {
+	var paymentHash common.Blake2b224
+	paymentHash[0] = 0xaa
+	enterprise, err := common.NewAddressFromParts(
+		common.AddressTypeKeyNone,
+		common.AddressNetworkTestnet,
+		paymentHash.Bytes(),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pointer, err := common.NewAddressFromParts(
+		common.AddressTypeKeyPointer,
+		common.AddressNetworkTestnet,
+		paymentHash.Bytes(),
+		[]byte{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, address := range []common.Address{enterprise, pointer, common.Address{}} {
+		a := New(setupFixedContext())
+		a.AddWithdrawal(address, 1_000_000, nil, nil)
+		if a.err == nil {
+			t.Fatalf("expected builder error for address type %d", address.Type())
+		}
+		if len(a.withdrawals) != 0 {
+			t.Fatal("invalid withdrawal mutated builder state")
+		}
+	}
 }
 
 func TestAddWithdrawalWithRedeemer(t *testing.T) {
@@ -735,7 +907,11 @@ func TestAddWithdrawalAggregatesAmounts(t *testing.T) {
 	a.AddWithdrawal(addr, 1_000_000, nil, nil)
 	a.AddWithdrawal(addr, 2_000_000, nil, nil)
 
-	if got := a.withdrawals[addr.String()].Amount; got != 3_000_000 {
+	reward := addr.StakeAddress()
+	if reward == nil {
+		t.Fatal("expected reward address")
+	}
+	if got := a.withdrawals[reward.String()].Amount; got != 3_000_000 {
 		t.Fatalf("expected aggregated withdrawal amount, got %d", got)
 	}
 }
@@ -1159,6 +1335,23 @@ func TestCompleteWithWithdrawal(t *testing.T) {
 	}
 	if len(tx.Body.TxWithdrawals) != 1 {
 		t.Errorf("expected 1 withdrawal, got %d", len(tx.Body.TxWithdrawals))
+	}
+	reward := addr.StakeAddress()
+	if reward == nil {
+		t.Fatal("expected reward address")
+	}
+	want, err := reward.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for withdrawalAddress := range tx.Body.TxWithdrawals {
+		got, err := withdrawalAddress.Bytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("transaction withdrawal address bytes = %x, want reward account %x", got, want)
+		}
 	}
 }
 

--- a/backend/base.go
+++ b/backend/base.go
@@ -69,6 +69,9 @@ type CapabilityReporter interface {
 // not implement CapabilityReporter are treated as supporting the historic
 // complete ChainContext contract.
 func CapabilitiesOf(ctx ChainContext) CapabilitySet {
+	if isNilInterface(ctx) {
+		return 0
+	}
 	if reporter, ok := ctx.(CapabilityReporter); ok {
 		return reporter.Capabilities()
 	}

--- a/backend/base_test.go
+++ b/backend/base_test.go
@@ -8,6 +8,24 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+type nilChainContext struct {
+	ChainContext
+}
+
+func TestCapabilitiesOfNilContext(t *testing.T) {
+	if got := CapabilitiesOf(nil); got != 0 {
+		t.Fatalf("CapabilitiesOf(nil) = %d, want 0", got)
+	}
+
+	var ctx *nilChainContext
+	if got := CapabilitiesOf(ctx); got != 0 {
+		t.Fatalf("CapabilitiesOf(typed nil) = %d, want 0", got)
+	}
+	if Supports(ctx, CapabilityProtocolParams) {
+		t.Fatal("Supports reports a capability for a typed nil context")
+	}
+}
+
 func TestCoinsPerUtxoByteValueDefault(t *testing.T) {
 	pp := ProtocolParameters{}
 	val := pp.CoinsPerUtxoByteValue()

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -1005,7 +1005,7 @@ func (raw *bfAddressUTxO) toUtxo(address common.Address) (common.Utxo, error) {
 	if raw.OutputIndex < 0 {
 		return common.Utxo{}, fmt.Errorf("negative output index: %d", raw.OutputIndex)
 	}
-	if raw.OutputIndex > math.MaxUint32 {
+	if uint64(raw.OutputIndex) > uint64(math.MaxUint32) {
 		return common.Utxo{}, fmt.Errorf("output index %d exceeds uint32 range", raw.OutputIndex)
 	}
 	input := shelley.ShelleyTransactionInput{

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -71,10 +71,6 @@ func NewBlockFrostChainContext(baseUrl string, networkId uint8, projectId string
 	}
 }
 
-func (b *BlockFrostChainContext) request(method, path string, body io.Reader, contentType string) ([]byte, error) {
-	return b.requestContext(context.Background(), method, path, body, contentType)
-}
-
 func (b *BlockFrostChainContext) requestContext(
 	ctx context.Context,
 	method, path string,
@@ -421,10 +417,6 @@ func additionalUtxosContainNativeAssets(utxos []common.Utxo) bool {
 // evaluateTxSimple POSTs hex-encoded transaction CBOR to /utils/txs/evaluate.
 // BlockFrost expects the hex string in the body with Content-Type
 // application/cbor (not raw CBOR bytes).
-func (b *BlockFrostChainContext) evaluateTxSimple(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
-	return b.evaluateTxSimpleContext(context.Background(), txCbor)
-}
-
 func (b *BlockFrostChainContext) evaluateTxSimpleContext(
 	ctx context.Context,
 	txCbor []byte,
@@ -439,13 +431,6 @@ func (b *BlockFrostChainContext) evaluateTxSimpleContext(
 
 // evaluateTxWithAdditionalUtxos POSTs to /utils/txs/evaluate/utxos with a JSON
 // body carrying the transaction CBOR hex and a resolved additional UTxO set.
-func (b *BlockFrostChainContext) evaluateTxWithAdditionalUtxos(
-	txCbor []byte,
-	additionalUtxos []common.Utxo,
-) (map[common.RedeemerKey]common.ExUnits, error) {
-	return b.evaluateTxWithAdditionalUtxosContext(context.Background(), txCbor, additionalUtxos)
-}
-
 func (b *BlockFrostChainContext) evaluateTxWithAdditionalUtxosContext(
 	ctx context.Context,
 	txCbor []byte,

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -2,6 +2,7 @@ package blockfrost
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -71,8 +72,17 @@ func NewBlockFrostChainContext(baseUrl string, networkId uint8, projectId string
 }
 
 func (b *BlockFrostChainContext) request(method, path string, body io.Reader, contentType string) ([]byte, error) {
+	return b.requestContext(context.Background(), method, path, body, contentType)
+}
+
+func (b *BlockFrostChainContext) requestContext(
+	ctx context.Context,
+	method, path string,
+	body io.Reader,
+	contentType string,
+) ([]byte, error) {
 	url := b.baseUrl + path
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -108,6 +118,10 @@ func (b *BlockFrostChainContext) request(method, path string, body io.Reader, co
 }
 
 func (b *BlockFrostChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+	return b.ProtocolParamsContext(context.Background())
+}
+
+func (b *BlockFrostChainContext) ProtocolParamsContext(ctx context.Context) (backend.ProtocolParameters, error) {
 	b.mu.Lock()
 	if b.cachedParams != nil && time.Since(b.paramsCacheAt) < cacheExpiry {
 		pp := *b.cachedParams
@@ -126,7 +140,7 @@ func (b *BlockFrostChainContext) ProtocolParams() (backend.ProtocolParameters, e
 	}
 	b.mu.Unlock()
 
-	data, err := b.request("GET", "/epochs/latest/parameters", nil, "")
+	data, err := b.requestContext(ctx, "GET", "/epochs/latest/parameters", nil, "")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -162,6 +176,10 @@ func (b *BlockFrostChainContext) ProtocolParams() (backend.ProtocolParameters, e
 }
 
 func (b *BlockFrostChainContext) GenesisParams() (backend.GenesisParameters, error) {
+	return b.GenesisParamsContext(context.Background())
+}
+
+func (b *BlockFrostChainContext) GenesisParamsContext(ctx context.Context) (backend.GenesisParameters, error) {
 	b.mu.Lock()
 	if b.cachedGenesis != nil && time.Since(b.genesisCacheAt) < cacheExpiry {
 		gp := *b.cachedGenesis
@@ -170,7 +188,7 @@ func (b *BlockFrostChainContext) GenesisParams() (backend.GenesisParameters, err
 	}
 	b.mu.Unlock()
 
-	data, err := b.request("GET", "/genesis", nil, "")
+	data, err := b.requestContext(ctx, "GET", "/genesis", nil, "")
 	if err != nil {
 		return backend.GenesisParameters{}, err
 	}
@@ -205,7 +223,11 @@ func (b *BlockFrostChainContext) NetworkId() uint8 {
 }
 
 func (b *BlockFrostChainContext) CurrentEpoch() (uint64, error) {
-	data, err := b.request("GET", "/epochs/latest", nil, "")
+	return b.CurrentEpochContext(context.Background())
+}
+
+func (b *BlockFrostChainContext) CurrentEpochContext(ctx context.Context) (uint64, error) {
+	data, err := b.requestContext(ctx, "GET", "/epochs/latest", nil, "")
 	if err != nil {
 		return 0, err
 	}
@@ -222,7 +244,11 @@ func (b *BlockFrostChainContext) CurrentEpoch() (uint64, error) {
 }
 
 func (b *BlockFrostChainContext) MaxTxFee() (uint64, error) {
-	pp, err := b.ProtocolParams()
+	return b.MaxTxFeeContext(context.Background())
+}
+
+func (b *BlockFrostChainContext) MaxTxFeeContext(ctx context.Context) (uint64, error) {
+	pp, err := b.ProtocolParamsContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -230,7 +256,11 @@ func (b *BlockFrostChainContext) MaxTxFee() (uint64, error) {
 }
 
 func (b *BlockFrostChainContext) Tip() (uint64, error) {
-	data, err := b.request("GET", "/blocks/latest", nil, "")
+	return b.TipContext(context.Background())
+}
+
+func (b *BlockFrostChainContext) TipContext(ctx context.Context) (uint64, error) {
+	data, err := b.requestContext(ctx, "GET", "/blocks/latest", nil, "")
 	if err != nil {
 		return 0, err
 	}
@@ -247,13 +277,17 @@ func (b *BlockFrostChainContext) Tip() (uint64, error) {
 }
 
 func (b *BlockFrostChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+	return b.UtxosContext(context.Background(), address)
+}
+
+func (b *BlockFrostChainContext) UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error) {
 	const maxPages = 1000
 	var allUtxos []common.Utxo
-	resolver := newScriptRefResolver(b)
+	resolver := newScriptRefResolver(ctx, b)
 
 	for page := 1; page <= maxPages+1; page++ {
 		path := fmt.Sprintf("/addresses/%s/utxos?page=%d", address.String(), page)
-		data, err := b.request("GET", path, nil, "")
+		data, err := b.requestContext(ctx, "GET", path, nil, "")
 		if err != nil {
 			return nil, err
 		}
@@ -279,8 +313,12 @@ func (b *BlockFrostChainContext) Utxos(address common.Address) ([]common.Utxo, e
 }
 
 func (b *BlockFrostChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+	return b.SubmitTxContext(context.Background(), txCbor)
+}
+
+func (b *BlockFrostChainContext) SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
 	body := bytes.NewReader(txCbor)
-	data, err := b.request("POST", "/tx/submit", body, "application/cbor")
+	data, err := b.requestContext(ctx, "POST", "/tx/submit", body, "application/cbor")
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
@@ -314,6 +352,14 @@ var (
 )
 
 func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	return b.EvaluateTxContext(context.Background(), txCbor, additionalUtxos)
+}
+
+func (b *BlockFrostChainContext) EvaluateTxContext(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
 	for i, utxo := range additionalUtxos {
 		if err := backend.ValidateAdditionalUtxo(utxo); err != nil {
 			return nil, fmt.Errorf("invalid additional UTxO at index %d: %w", i, err)
@@ -333,7 +379,7 @@ func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []com
 	// additional set has no native assets.
 	var lastErr error
 	for attempt := 1; attempt <= evaluateSimpleRetries; attempt++ {
-		result, err := b.evaluateTxSimple(txCbor)
+		result, err := b.evaluateTxSimpleContext(ctx, txCbor)
 		if err == nil {
 			return result, nil
 		}
@@ -342,13 +388,19 @@ func (b *BlockFrostChainContext) EvaluateTx(txCbor []byte, additionalUtxos []com
 			return nil, err
 		}
 		if attempt < evaluateSimpleRetries {
-			time.Sleep(evaluateSimpleRetryWait)
+			timer := time.NewTimer(evaluateSimpleRetryWait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 	if len(additionalUtxos) == 0 || additionalUtxosContainNativeAssets(additionalUtxos) {
 		return nil, lastErr
 	}
-	return b.evaluateTxWithAdditionalUtxos(txCbor, additionalUtxos)
+	return b.evaluateTxWithAdditionalUtxosContext(ctx, txCbor, additionalUtxos)
 }
 
 // additionalUtxosContainNativeAssets reports whether any resolved UTxO carries
@@ -370,8 +422,15 @@ func additionalUtxosContainNativeAssets(utxos []common.Utxo) bool {
 // BlockFrost expects the hex string in the body with Content-Type
 // application/cbor (not raw CBOR bytes).
 func (b *BlockFrostChainContext) evaluateTxSimple(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error) {
+	return b.evaluateTxSimpleContext(context.Background(), txCbor)
+}
+
+func (b *BlockFrostChainContext) evaluateTxSimpleContext(
+	ctx context.Context,
+	txCbor []byte,
+) (map[common.RedeemerKey]common.ExUnits, error) {
 	body := strings.NewReader(hex.EncodeToString(txCbor))
-	data, err := b.request("POST", "/utils/txs/evaluate", body, "application/cbor")
+	data, err := b.requestContext(ctx, "POST", "/utils/txs/evaluate", body, "application/cbor")
 	if err != nil {
 		return nil, err
 	}
@@ -384,11 +443,19 @@ func (b *BlockFrostChainContext) evaluateTxWithAdditionalUtxos(
 	txCbor []byte,
 	additionalUtxos []common.Utxo,
 ) (map[common.RedeemerKey]common.ExUnits, error) {
+	return b.evaluateTxWithAdditionalUtxosContext(context.Background(), txCbor, additionalUtxos)
+}
+
+func (b *BlockFrostChainContext) evaluateTxWithAdditionalUtxosContext(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
 	reqBody, err := buildEvalUtxosRequest(txCbor, additionalUtxos)
 	if err != nil {
 		return nil, err
 	}
-	data, err := b.request("POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
+	data, err := b.requestContext(ctx, "POST", "/utils/txs/evaluate/utxos", bytes.NewReader(reqBody), "application/json")
 	if err != nil {
 		return nil, err
 	}
@@ -722,9 +789,17 @@ func evalErrorSnippet(data []byte) string {
 }
 
 func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	return b.UtxoByRefContext(context.Background(), txHash, index)
+}
+
+func (b *BlockFrostChainContext) UtxoByRefContext(
+	ctx context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
 	hashHex := hex.EncodeToString(txHash.Bytes())
 	path := fmt.Sprintf("/txs/%s/utxos", hashHex)
-	data, err := b.request("GET", path, nil, "")
+	data, err := b.requestContext(ctx, "GET", path, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -754,7 +829,7 @@ func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint3
 			if err != nil {
 				return nil, err
 			}
-			utxo, err := b.hydrateUtxo(raw, addr)
+			utxo, err := b.hydrateUtxoContext(ctx, raw, addr)
 			if err != nil {
 				return nil, err
 			}
@@ -765,9 +840,16 @@ func (b *BlockFrostChainContext) UtxoByRef(txHash common.Blake2b256, index uint3
 }
 
 func (b *BlockFrostChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+	return b.ScriptCborContext(context.Background(), scriptHash)
+}
+
+func (b *BlockFrostChainContext) ScriptCborContext(
+	ctx context.Context,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
 	path := fmt.Sprintf("/scripts/%s/cbor", hashHex)
-	data, err := b.request("GET", path, nil, "")
+	data, err := b.requestContext(ctx, "GET", path, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1095,6 +1177,20 @@ func (b *BlockFrostChainContext) hydrateUtxo(raw bfAddressUTxO, address common.A
 	return b.hydrateUtxoWithScriptResolver(raw, address, b.scriptRefByHash)
 }
 
+func (b *BlockFrostChainContext) hydrateUtxoContext(
+	ctx context.Context,
+	raw bfAddressUTxO,
+	address common.Address,
+) (common.Utxo, error) {
+	return b.hydrateUtxoWithScriptResolver(
+		raw,
+		address,
+		func(hashHex string) (*common.ScriptRef, error) {
+			return b.scriptRefByHashContext(ctx, hashHex)
+		},
+	)
+}
+
 func (b *BlockFrostChainContext) hydrateUtxoPage(
 	rawUtxos []bfAddressUTxO,
 	address common.Address,
@@ -1170,7 +1266,8 @@ func (b *BlockFrostChainContext) hydrateUtxoWithScriptResolver(
 }
 
 type scriptRefResolver struct {
-	context *BlockFrostChainContext
+	requestContext context.Context
+	chainContext   *BlockFrostChainContext
 
 	mu      sync.Mutex
 	entries map[string]*scriptRefResolveResult
@@ -1182,10 +1279,11 @@ type scriptRefResolveResult struct {
 	err       error
 }
 
-func newScriptRefResolver(context *BlockFrostChainContext) *scriptRefResolver {
+func newScriptRefResolver(ctx context.Context, chainContext *BlockFrostChainContext) *scriptRefResolver {
 	return &scriptRefResolver{
-		context: context,
-		entries: make(map[string]*scriptRefResolveResult),
+		requestContext: ctx,
+		chainContext:   chainContext,
+		entries:        make(map[string]*scriptRefResolveResult),
 	}
 }
 
@@ -1203,11 +1301,15 @@ func (r *scriptRefResolver) resolve(hashHex string) (*common.ScriptRef, error) {
 	r.mu.Unlock()
 
 	if ok {
-		<-entry.done
-		return entry.scriptRef, entry.err
+		select {
+		case <-r.requestContext.Done():
+			return nil, r.requestContext.Err()
+		case <-entry.done:
+			return entry.scriptRef, entry.err
+		}
 	}
 
-	entry.scriptRef, entry.err = r.context.scriptRefByHash(key)
+	entry.scriptRef, entry.err = r.chainContext.scriptRefByHashContext(r.requestContext, key)
 	close(entry.done)
 	return entry.scriptRef, entry.err
 }
@@ -1238,6 +1340,13 @@ func inlineDatumOptionFromBlockfrost(raw json.RawMessage) (*babbage.BabbageTrans
 }
 
 func (b *BlockFrostChainContext) scriptRefByHash(hashHex string) (*common.ScriptRef, error) {
+	return b.scriptRefByHashContext(context.Background(), hashHex)
+}
+
+func (b *BlockFrostChainContext) scriptRefByHashContext(
+	ctx context.Context,
+	hashHex string,
+) (*common.ScriptRef, error) {
 	hashBytes, err := hex.DecodeString(hashHex)
 	if err != nil {
 		return nil, fmt.Errorf("invalid script hash hex %q: %w", hashHex, err)
@@ -1247,7 +1356,7 @@ func (b *BlockFrostChainContext) scriptRefByHash(hashHex string) (*common.Script
 	}
 	var scriptHash common.Blake2b224
 	copy(scriptHash[:], hashBytes)
-	scriptCbor, err := b.ScriptCbor(scriptHash)
+	scriptCbor, err := b.ScriptCborContext(ctx, scriptHash)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -2,6 +2,7 @@ package blockfrost
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -24,6 +25,29 @@ import (
 
 	"github.com/Salvionied/apollo/v2/backend"
 )
+
+type contextRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f contextRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+var _ backend.ContextChainContext = (*BlockFrostChainContext)(nil)
+
+func TestRequestContextPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	chainContext := NewBlockFrostChainContext("https://example.invalid", 0, "")
+	chainContext.client.Transport = contextRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, req.Context().Err()
+	})
+
+	_, err := chainContext.TipContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("TipContext() error = %v, want context.Canceled", err)
+	}
+}
 
 func TestBlockfrostCapabilities(t *testing.T) {
 	ctx := NewBlockFrostChainContext("http://localhost", 0, "")

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -21,6 +22,8 @@ type CachedChainContext struct {
 	genesisCacheAt time.Time
 }
 
+var _ backend.ContextChainContext = (*CachedChainContext)(nil)
+
 // NewCachedChainContext creates a new cached wrapper around the given ChainContext.
 func NewCachedChainContext(inner backend.ChainContext, ttl time.Duration) *CachedChainContext {
 	return &CachedChainContext{
@@ -35,6 +38,10 @@ func (c *CachedChainContext) Capabilities() backend.CapabilitySet {
 }
 
 func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+	return c.ProtocolParamsContext(context.Background())
+}
+
+func (c *CachedChainContext) ProtocolParamsContext(ctx context.Context) (backend.ProtocolParameters, error) {
 	c.mu.Lock()
 	if c.cachedParams != nil && time.Since(c.paramsCacheAt) < c.ttl {
 		pp := *c.cachedParams
@@ -53,7 +60,7 @@ func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error
 	}
 	c.mu.Unlock()
 
-	pp, err := c.inner.ProtocolParams()
+	pp, err := backend.ProtocolParamsContext(ctx, c.inner)
 	if err != nil {
 		return pp, err
 	}
@@ -79,6 +86,10 @@ func (c *CachedChainContext) ProtocolParams() (backend.ProtocolParameters, error
 }
 
 func (c *CachedChainContext) GenesisParams() (backend.GenesisParameters, error) {
+	return c.GenesisParamsContext(context.Background())
+}
+
+func (c *CachedChainContext) GenesisParamsContext(ctx context.Context) (backend.GenesisParameters, error) {
 	c.mu.Lock()
 	if c.cachedGenesis != nil && time.Since(c.genesisCacheAt) < c.ttl {
 		gp := *c.cachedGenesis
@@ -87,7 +98,7 @@ func (c *CachedChainContext) GenesisParams() (backend.GenesisParameters, error) 
 	}
 	c.mu.Unlock()
 
-	gp, err := c.inner.GenesisParams()
+	gp, err := backend.GenesisParamsContext(ctx, c.inner)
 	if err != nil {
 		return gp, err
 	}
@@ -105,33 +116,76 @@ func (c *CachedChainContext) NetworkId() uint8 {
 }
 
 func (c *CachedChainContext) CurrentEpoch() (uint64, error) {
-	return c.inner.CurrentEpoch()
+	return c.CurrentEpochContext(context.Background())
+}
+
+func (c *CachedChainContext) CurrentEpochContext(ctx context.Context) (uint64, error) {
+	return backend.CurrentEpochContext(ctx, c.inner)
 }
 
 func (c *CachedChainContext) MaxTxFee() (uint64, error) {
-	return c.inner.MaxTxFee()
+	return c.MaxTxFeeContext(context.Background())
+}
+
+func (c *CachedChainContext) MaxTxFeeContext(ctx context.Context) (uint64, error) {
+	return backend.MaxTxFeeContext(ctx, c.inner)
 }
 
 func (c *CachedChainContext) Tip() (uint64, error) {
-	return c.inner.Tip()
+	return c.TipContext(context.Background())
+}
+
+func (c *CachedChainContext) TipContext(ctx context.Context) (uint64, error) {
+	return backend.TipContext(ctx, c.inner)
 }
 
 func (c *CachedChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
-	return c.inner.Utxos(address)
+	return c.UtxosContext(context.Background(), address)
+}
+
+func (c *CachedChainContext) UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error) {
+	return backend.UtxosContext(ctx, c.inner, address)
 }
 
 func (c *CachedChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
-	return c.inner.SubmitTx(txCbor)
+	return c.SubmitTxContext(context.Background(), txCbor)
+}
+
+func (c *CachedChainContext) SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
+	return backend.SubmitTxContext(ctx, c.inner, txCbor)
 }
 
 func (c *CachedChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-	return c.inner.EvaluateTx(txCbor, additionalUtxos)
+	return c.EvaluateTxContext(context.Background(), txCbor, additionalUtxos)
+}
+
+func (c *CachedChainContext) EvaluateTxContext(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	return backend.EvaluateTxContext(ctx, c.inner, txCbor, additionalUtxos)
 }
 
 func (c *CachedChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
-	return c.inner.UtxoByRef(txHash, index)
+	return c.UtxoByRefContext(context.Background(), txHash, index)
+}
+
+func (c *CachedChainContext) UtxoByRefContext(
+	ctx context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
+	return backend.UtxoByRefContext(ctx, c.inner, txHash, index)
 }
 
 func (c *CachedChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
-	return c.inner.ScriptCbor(scriptHash)
+	return c.ScriptCborContext(context.Background(), scriptHash)
+}
+
+func (c *CachedChainContext) ScriptCborContext(
+	ctx context.Context,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
+	return backend.ScriptCborContext(ctx, c.inner, scriptHash)
 }

--- a/backend/context.go
+++ b/backend/context.go
@@ -1,0 +1,230 @@
+package backend
+
+import (
+	"context"
+	"errors"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+var errNilChainContext = errors.New("chain context is nil")
+
+// ContextChainContext is an optional extension to ChainContext for operations
+// that can block. Implementations should stop work promptly when ctx is
+// canceled. It is separate from ChainContext so existing third-party backends
+// remain source compatible.
+type ContextChainContext interface {
+	ProtocolParamsContext(ctx context.Context) (ProtocolParameters, error)
+	GenesisParamsContext(ctx context.Context) (GenesisParameters, error)
+	CurrentEpochContext(ctx context.Context) (uint64, error)
+	MaxTxFeeContext(ctx context.Context) (uint64, error)
+	TipContext(ctx context.Context) (uint64, error)
+	UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error)
+	SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error)
+	EvaluateTxContext(ctx context.Context, txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
+	UtxoByRefContext(ctx context.Context, txHash common.Blake2b256, index uint32) (*common.Utxo, error)
+	ScriptCborContext(ctx context.Context, scriptHash common.Blake2b224) ([]byte, error)
+}
+
+func normalizeContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+// ProtocolParamsContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func ProtocolParamsContext(ctx context.Context, chainContext ChainContext) (ProtocolParameters, error) {
+	if isNilInterface(chainContext) {
+		return ProtocolParameters{}, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.ProtocolParamsContext(normalizeContext(ctx))
+	}
+	return chainContext.ProtocolParams()
+}
+
+// GenesisParamsContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func GenesisParamsContext(ctx context.Context, chainContext ChainContext) (GenesisParameters, error) {
+	if isNilInterface(chainContext) {
+		return GenesisParameters{}, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.GenesisParamsContext(normalizeContext(ctx))
+	}
+	return chainContext.GenesisParams()
+}
+
+// CurrentEpochContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func CurrentEpochContext(ctx context.Context, chainContext ChainContext) (uint64, error) {
+	if isNilInterface(chainContext) {
+		return 0, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.CurrentEpochContext(normalizeContext(ctx))
+	}
+	return chainContext.CurrentEpoch()
+}
+
+// MaxTxFeeContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func MaxTxFeeContext(ctx context.Context, chainContext ChainContext) (uint64, error) {
+	if isNilInterface(chainContext) {
+		return 0, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.MaxTxFeeContext(normalizeContext(ctx))
+	}
+	return chainContext.MaxTxFee()
+}
+
+// TipContext calls the context-aware implementation when available, otherwise
+// it falls back to the historic ChainContext method.
+func TipContext(ctx context.Context, chainContext ChainContext) (uint64, error) {
+	if isNilInterface(chainContext) {
+		return 0, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.TipContext(normalizeContext(ctx))
+	}
+	return chainContext.Tip()
+}
+
+// UtxosContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func UtxosContext(ctx context.Context, chainContext ChainContext, address common.Address) ([]common.Utxo, error) {
+	if isNilInterface(chainContext) {
+		return nil, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.UtxosContext(normalizeContext(ctx), address)
+	}
+	return chainContext.Utxos(address)
+}
+
+// SubmitTxContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func SubmitTxContext(ctx context.Context, chainContext ChainContext, txCbor []byte) (common.Blake2b256, error) {
+	if isNilInterface(chainContext) {
+		return common.Blake2b256{}, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.SubmitTxContext(normalizeContext(ctx), txCbor)
+	}
+	return chainContext.SubmitTx(txCbor)
+}
+
+// EvaluateTxContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func EvaluateTxContext(
+	ctx context.Context,
+	chainContext ChainContext,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	if isNilInterface(chainContext) {
+		return nil, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.EvaluateTxContext(normalizeContext(ctx), txCbor, additionalUtxos)
+	}
+	return chainContext.EvaluateTx(txCbor, additionalUtxos)
+}
+
+// UtxoByRefContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func UtxoByRefContext(
+	ctx context.Context,
+	chainContext ChainContext,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
+	if isNilInterface(chainContext) {
+		return nil, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.UtxoByRefContext(normalizeContext(ctx), txHash, index)
+	}
+	return chainContext.UtxoByRef(txHash, index)
+}
+
+// ScriptCborContext calls the context-aware implementation when available,
+// otherwise it falls back to the historic ChainContext method.
+func ScriptCborContext(
+	ctx context.Context,
+	chainContext ChainContext,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
+	if isNilInterface(chainContext) {
+		return nil, errNilChainContext
+	}
+	if cc, ok := chainContext.(ContextChainContext); ok {
+		return cc.ScriptCborContext(normalizeContext(ctx), scriptHash)
+	}
+	return chainContext.ScriptCbor(scriptHash)
+}
+
+// BindContext returns a ChainContext whose blocking methods dispatch through
+// ctx. This is useful when passing a context through an API that still accepts
+// only the historic ChainContext interface.
+func BindContext(ctx context.Context, chainContext ChainContext) ChainContext {
+	return boundChainContext{
+		Context:      normalizeContext(ctx),
+		ChainContext: chainContext,
+	}
+}
+
+type boundChainContext struct {
+	context.Context
+	ChainContext
+}
+
+func (b boundChainContext) Capabilities() CapabilitySet {
+	return CapabilitiesOf(b.ChainContext)
+}
+
+func (b boundChainContext) ProtocolParams() (ProtocolParameters, error) {
+	return ProtocolParamsContext(b.Context, b.ChainContext)
+}
+
+func (b boundChainContext) GenesisParams() (GenesisParameters, error) {
+	return GenesisParamsContext(b.Context, b.ChainContext)
+}
+
+func (b boundChainContext) CurrentEpoch() (uint64, error) {
+	return CurrentEpochContext(b.Context, b.ChainContext)
+}
+
+func (b boundChainContext) MaxTxFee() (uint64, error) {
+	return MaxTxFeeContext(b.Context, b.ChainContext)
+}
+
+func (b boundChainContext) Tip() (uint64, error) {
+	return TipContext(b.Context, b.ChainContext)
+}
+
+func (b boundChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+	return UtxosContext(b.Context, b.ChainContext, address)
+}
+
+func (b boundChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+	return SubmitTxContext(b.Context, b.ChainContext, txCbor)
+}
+
+func (b boundChainContext) EvaluateTx(
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	return EvaluateTxContext(b.Context, b.ChainContext, txCbor, additionalUtxos)
+}
+
+func (b boundChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	return UtxoByRefContext(b.Context, b.ChainContext, txHash, index)
+}
+
+func (b boundChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+	return ScriptCborContext(b.Context, b.ChainContext, scriptHash)
+}

--- a/backend/context_test.go
+++ b/backend/context_test.go
@@ -110,6 +110,7 @@ func TestProtocolParamsContextFallsBackToLegacyContext(t *testing.T) {
 func TestProtocolParamsContextNormalizesNilContext(t *testing.T) {
 	chainContext := &trackingContextChain{}
 
+	//nolint:staticcheck // Verify the helper's documented nil-context normalization contract.
 	if _, err := ProtocolParamsContext(nil, chainContext); err != nil {
 		t.Fatalf("ProtocolParamsContext(nil) error = %v", err)
 	}

--- a/backend/context_test.go
+++ b/backend/context_test.go
@@ -1,0 +1,143 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+type trackingLegacyContext struct {
+	legacyChainContext
+	protocolCalls int
+}
+
+func (c *trackingLegacyContext) ProtocolParams() (ProtocolParameters, error) {
+	c.protocolCalls++
+	return ProtocolParameters{MaxTxSize: 1}, nil
+}
+
+type trackingContextChain struct {
+	trackingLegacyContext
+	received context.Context
+}
+
+func (c *trackingContextChain) ProtocolParamsContext(ctx context.Context) (ProtocolParameters, error) {
+	c.received = ctx
+	return ProtocolParameters{MaxTxSize: 2}, ctx.Err()
+}
+
+func (c *trackingContextChain) GenesisParamsContext(context.Context) (GenesisParameters, error) {
+	return GenesisParameters{}, nil
+}
+
+func (c *trackingContextChain) CurrentEpochContext(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (c *trackingContextChain) MaxTxFeeContext(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (c *trackingContextChain) TipContext(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (c *trackingContextChain) UtxosContext(context.Context, common.Address) ([]common.Utxo, error) {
+	return nil, nil
+}
+
+func (c *trackingContextChain) SubmitTxContext(context.Context, []byte) (common.Blake2b256, error) {
+	return common.Blake2b256{}, nil
+}
+
+func (c *trackingContextChain) EvaluateTxContext(
+	context.Context,
+	[]byte,
+	[]common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	return nil, nil
+}
+
+func (c *trackingContextChain) UtxoByRefContext(
+	context.Context,
+	common.Blake2b256,
+	uint32,
+) (*common.Utxo, error) {
+	return nil, nil
+}
+
+func (c *trackingContextChain) ScriptCborContext(
+	context.Context,
+	common.Blake2b224,
+) ([]byte, error) {
+	return nil, nil
+}
+
+func TestProtocolParamsContextDispatchesCancellation(t *testing.T) {
+	chainContext := &trackingContextChain{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ProtocolParamsContext(ctx, chainContext)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ProtocolParamsContext() error = %v, want context.Canceled", err)
+	}
+	if chainContext.received != ctx {
+		t.Fatal("context-aware implementation did not receive the caller context")
+	}
+	if chainContext.protocolCalls != 0 {
+		t.Fatalf("legacy ProtocolParams called %d times, want 0", chainContext.protocolCalls)
+	}
+}
+
+func TestProtocolParamsContextFallsBackToLegacyContext(t *testing.T) {
+	chainContext := &trackingLegacyContext{}
+
+	params, err := ProtocolParamsContext(context.Background(), chainContext)
+	if err != nil {
+		t.Fatalf("ProtocolParamsContext() error = %v", err)
+	}
+	if params.MaxTxSize != 1 {
+		t.Fatalf("ProtocolParamsContext() MaxTxSize = %d, want 1", params.MaxTxSize)
+	}
+	if chainContext.protocolCalls != 1 {
+		t.Fatalf("legacy ProtocolParams called %d times, want 1", chainContext.protocolCalls)
+	}
+}
+
+func TestProtocolParamsContextNormalizesNilContext(t *testing.T) {
+	chainContext := &trackingContextChain{}
+
+	if _, err := ProtocolParamsContext(nil, chainContext); err != nil {
+		t.Fatalf("ProtocolParamsContext(nil) error = %v", err)
+	}
+	if chainContext.received == nil {
+		t.Fatal("context-aware implementation received a nil context")
+	}
+}
+
+func TestContextHelpersRejectNilChainContext(t *testing.T) {
+	if _, err := SubmitTxContext(context.Background(), nil, nil); err == nil {
+		t.Fatal("SubmitTxContext(nil chain context) returned nil error")
+	}
+
+	var typedNil *trackingContextChain
+	if _, err := UtxoByRefContext(context.Background(), typedNil, common.Blake2b256{}, 0); err == nil {
+		t.Fatal("UtxoByRefContext(typed nil chain context) returned nil error")
+	}
+}
+
+func TestBindContextDispatchesThroughHistoricInterface(t *testing.T) {
+	chainContext := &trackingContextChain{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := BindContext(ctx, chainContext).ProtocolParams()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("bound ProtocolParams() error = %v, want context.Canceled", err)
+	}
+}
+
+var _ ContextChainContext = (*trackingContextChain)(nil)

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -2,6 +2,7 @@ package maestro
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -36,7 +38,38 @@ type MaestroChainContext struct {
 	apiKey string
 }
 
-const maxMaestroEvaluateErrorResponseBytes = 64 * 1024
+const (
+	maxMaestroEvaluateErrorResponseBytes = 64 * 1024
+	defaultMaestroHTTPTimeout            = 30 * time.Second
+)
+
+type contextTransport struct {
+	ctx  context.Context
+	base http.RoundTripper
+}
+
+func (t contextTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.base.RoundTrip(req.Clone(t.ctx))
+}
+
+func (m *MaestroChainContext) clientWithContext(ctx context.Context) *maestroClient.Client {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client := *m.client
+	httpClient := client.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultMaestroHTTPTimeout}
+	}
+	contextClient := *httpClient
+	transport := contextClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	contextClient.Transport = contextTransport{ctx: ctx, base: transport}
+	client.HTTPClient = &contextClient
+	return &client
+}
 
 // Capabilities reports the Maestro operations supported by this client.
 func (m *MaestroChainContext) Capabilities() backend.CapabilitySet {
@@ -91,7 +124,11 @@ func NewMaestroChainContextWithNetwork(networkId uint8, projectId string, networ
 }
 
 func (m *MaestroChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
-	resp, err := m.client.ProtocolParameters()
+	return m.ProtocolParamsContext(context.Background())
+}
+
+func (m *MaestroChainContext) ProtocolParamsContext(ctx context.Context) (backend.ProtocolParameters, error) {
+	resp, err := m.clientWithContext(ctx).ProtocolParameters()
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -182,6 +219,15 @@ func (m *MaestroChainContext) ProtocolParams() (backend.ProtocolParameters, erro
 }
 
 func (m *MaestroChainContext) GenesisParams() (backend.GenesisParameters, error) {
+	return m.GenesisParamsContext(context.Background())
+}
+
+func (m *MaestroChainContext) GenesisParamsContext(ctx context.Context) (backend.GenesisParameters, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return backend.GenesisParameters{}, err
+		}
+	}
 	return backend.GenesisParameters{}, backend.NewUnsupportedError("Maestro", backend.CapabilityGenesisParams)
 }
 
@@ -190,7 +236,11 @@ func (m *MaestroChainContext) NetworkId() uint8 {
 }
 
 func (m *MaestroChainContext) CurrentEpoch() (uint64, error) {
-	resp, err := m.client.CurrentEpoch()
+	return m.CurrentEpochContext(context.Background())
+}
+
+func (m *MaestroChainContext) CurrentEpochContext(ctx context.Context) (uint64, error) {
+	resp, err := m.clientWithContext(ctx).CurrentEpoch()
 	if err != nil {
 		return 0, err
 	}
@@ -201,7 +251,11 @@ func (m *MaestroChainContext) CurrentEpoch() (uint64, error) {
 }
 
 func (m *MaestroChainContext) MaxTxFee() (uint64, error) {
-	pp, err := m.ProtocolParams()
+	return m.MaxTxFeeContext(context.Background())
+}
+
+func (m *MaestroChainContext) MaxTxFeeContext(ctx context.Context) (uint64, error) {
+	pp, err := m.ProtocolParamsContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -209,7 +263,11 @@ func (m *MaestroChainContext) MaxTxFee() (uint64, error) {
 }
 
 func (m *MaestroChainContext) Tip() (uint64, error) {
-	resp, err := m.client.ChainTip()
+	return m.TipContext(context.Background())
+}
+
+func (m *MaestroChainContext) TipContext(ctx context.Context) (uint64, error) {
+	resp, err := m.clientWithContext(ctx).ChainTip()
 	if err != nil {
 		return 0, err
 	}
@@ -220,13 +278,18 @@ func (m *MaestroChainContext) Tip() (uint64, error) {
 }
 
 func (m *MaestroChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+	return m.UtxosContext(context.Background(), address)
+}
+
+func (m *MaestroChainContext) UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error) {
 	const maxPages = 1000
 	var allUtxos []common.Utxo
 	params := utils.NewParameters()
 	var lastCursor string
+	client := m.clientWithContext(ctx)
 
 	for range maxPages {
-		resp, err := m.client.UtxosAtAddress(address.String(), params)
+		resp, err := client.UtxosAtAddress(address.String(), params)
 		if err != nil {
 			return nil, err
 		}
@@ -255,12 +318,16 @@ func (m *MaestroChainContext) Utxos(address common.Address) ([]common.Utxo, erro
 }
 
 func (m *MaestroChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+	return m.SubmitTxContext(context.Background(), txCbor)
+}
+
+func (m *MaestroChainContext) SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
 	// The Maestro SDK's Client.SubmitTx posts to a corrupted URL
 	// ("/submitmodels.BasicResponse{}/tx") and can never work. Use
 	// TxManagerSubmit instead, which posts the hex-encoded transaction
 	// CBOR to the documented POST /txmanager submit endpoint.
 	txCborHex := hex.EncodeToString(txCbor)
-	txHash, err := m.client.TxManagerSubmit(txCborHex)
+	txHash, err := m.clientWithContext(ctx).TxManagerSubmit(txCborHex)
 	if err != nil {
 		return common.Blake2b256{}, fmt.Errorf("maestro tx submission failed: %w", err)
 	}
@@ -288,10 +355,18 @@ func (m *MaestroChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 // the required {tx_hash, index, txout_cbor} entries, so the request is built
 // here against the SDK client's base URL and API key.
 func (m *MaestroChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	return m.EvaluateTxContext(context.Background(), txCbor, additionalUtxos)
+}
+
+func (m *MaestroChainContext) EvaluateTxContext(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
 	txHex := hex.EncodeToString(txCbor)
 
 	if len(additionalUtxos) == 0 {
-		evalResp, err := m.client.EvaluateTx(txHex)
+		evalResp, err := m.clientWithContext(ctx).EvaluateTx(txHex)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +377,7 @@ func (m *MaestroChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common
 	if err != nil {
 		return nil, err
 	}
-	evalResp, err := m.postEvaluate(reqBody)
+	evalResp, err := m.postEvaluateContext(ctx, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -371,8 +446,18 @@ func maestroAdditionalUtxoFromUtxo(utxo common.Utxo) (maestroAdditionalUtxo, err
 // client's base URL, API key and HTTP client, and decodes the response with the
 // same shape the SDK uses.
 func (m *MaestroChainContext) postEvaluate(body []byte) (models.EvaluateTxResponse, error) {
+	return m.postEvaluateContext(context.Background(), body)
+}
+
+func (m *MaestroChainContext) postEvaluateContext(
+	ctx context.Context,
+	body []byte,
+) (models.EvaluateTxResponse, error) {
 	url := m.client.BaseUrl + "/transactions/evaluate"
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +467,7 @@ func (m *MaestroChainContext) postEvaluate(body []byte) (models.EvaluateTxRespon
 
 	httpClient := m.client.HTTPClient
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = &http.Client{Timeout: defaultMaestroHTTPTimeout}
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -441,8 +526,16 @@ func evaluationsToExUnits(evals models.EvaluateTxResponse) (map[common.RedeemerK
 }
 
 func (m *MaestroChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	return m.UtxoByRefContext(context.Background(), txHash, index)
+}
+
+func (m *MaestroChainContext) UtxoByRefContext(
+	ctx context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
 	hashHex := hex.EncodeToString(txHash.Bytes())
-	resp, err := m.client.TransactionOutputFromReference(hashHex, int(index), nil)
+	resp, err := m.clientWithContext(ctx).TransactionOutputFromReference(hashHex, int(index), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -459,8 +552,15 @@ func (m *MaestroChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 }
 
 func (m *MaestroChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+	return m.ScriptCborContext(context.Background(), scriptHash)
+}
+
+func (m *MaestroChainContext) ScriptCborContext(
+	ctx context.Context,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
-	resp, err := m.client.ScriptByHash(hashHex)
+	resp, err := m.clientWithContext(ctx).ScriptByHash(hashHex)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -418,7 +418,7 @@ func evaluationsToExUnits(evals models.EvaluateTxResponse) (map[common.RedeemerK
 		if eval.RedeemerIndex < 0 {
 			return nil, fmt.Errorf("negative redeemer index: %d", eval.RedeemerIndex)
 		}
-		if eval.RedeemerIndex > math.MaxUint32 {
+		if uint64(eval.RedeemerIndex) > uint64(math.MaxUint32) {
 			return nil, fmt.Errorf("redeemer index %d exceeds uint32 range", eval.RedeemerIndex)
 		}
 		tag, err := backend.ParseRedeemerTag(eval.RedeemerTag)

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -2,6 +2,7 @@ package maestro
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,69 @@ import (
 
 	"github.com/Salvionied/apollo/v2/backend"
 )
+
+var _ backend.ContextChainContext = (*MaestroChainContext)(nil)
+
+func TestClientWithContextUsesBoundedFallback(t *testing.T) {
+	chainContext, err := NewMaestroChainContext(0, "test-key")
+	if err != nil {
+		t.Fatalf("NewMaestroChainContext() error = %v", err)
+	}
+	chainContext.client.HTTPClient = nil
+
+	client := chainContext.clientWithContext(nil)
+	if client.HTTPClient == nil {
+		t.Fatal("clientWithContext() returned a nil HTTP client")
+	}
+	if client.HTTPClient.Timeout != defaultMaestroHTTPTimeout {
+		t.Fatalf(
+			"clientWithContext() timeout = %s, want %s",
+			client.HTTPClient.Timeout,
+			defaultMaestroHTTPTimeout,
+		)
+	}
+}
+
+func TestClientWithContextPropagatesCallerContext(t *testing.T) {
+	type contextKey struct{}
+	key := contextKey{}
+	ctx := context.WithValue(context.Background(), key, "caller")
+
+	chainContext, err := NewMaestroChainContext(0, "test-key")
+	if err != nil {
+		t.Fatalf("NewMaestroChainContext() error = %v", err)
+	}
+	chainContext.client.HTTPClient.Transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Context().Value(key); got != "caller" {
+			t.Fatalf("request context value = %v, want caller", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"slot":1}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	if _, err := chainContext.TipContext(ctx); err != nil {
+		t.Fatalf("TipContext() error = %v", err)
+	}
+}
+
+func TestPostEvaluateContextCancellationWithNilSDKClient(t *testing.T) {
+	chainContext, err := NewMaestroChainContext(0, "test-key")
+	if err != nil {
+		t.Fatalf("NewMaestroChainContext() error = %v", err)
+	}
+	chainContext.client.BaseUrl = "https://example.invalid"
+	chainContext.client.HTTPClient = nil
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = chainContext.postEvaluateContext(ctx, []byte(`{}`))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("postEvaluateContext() error = %v, want context.Canceled", err)
+	}
+}
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 

--- a/backend/maestro/maestro_test.go
+++ b/backend/maestro/maestro_test.go
@@ -32,6 +32,7 @@ func TestClientWithContextUsesBoundedFallback(t *testing.T) {
 	}
 	chainContext.client.HTTPClient = nil
 
+	//nolint:staticcheck // Verify the Maestro adapter's defensive nil-context fallback.
 	client := chainContext.clientWithContext(nil)
 	if client.HTTPClient == nil {
 		t.Fatal("clientWithContext() returned a nil HTTP client")

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -31,6 +31,8 @@ type OgmiosChainContext struct {
 	networkId uint8
 }
 
+var _ backend.ContextChainContext = (*OgmiosChainContext)(nil)
+
 // Capabilities reports the operations supported by the configured Ogmios
 // client. Address UTxO queries and script lookup require the optional Kupo
 // client; UTxO-by-reference queries are served directly by Ogmios.
@@ -52,7 +54,10 @@ func NewOgmiosChainContext(ogmiosClient *ogmigo.Client, kupoClient *kugo.Client,
 }
 
 func (o *OgmiosChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
-	ctx := context.Background()
+	return o.ProtocolParamsContext(context.Background())
+}
+
+func (o *OgmiosChainContext) ProtocolParamsContext(ctx context.Context) (backend.ProtocolParameters, error) {
 	raw, err := o.ogmios.CurrentProtocolParameters(ctx)
 	if err != nil {
 		return backend.ProtocolParameters{}, err
@@ -67,7 +72,10 @@ func (o *OgmiosChainContext) ProtocolParams() (backend.ProtocolParameters, error
 }
 
 func (o *OgmiosChainContext) GenesisParams() (backend.GenesisParameters, error) {
-	ctx := context.Background()
+	return o.GenesisParamsContext(context.Background())
+}
+
+func (o *OgmiosChainContext) GenesisParamsContext(ctx context.Context) (backend.GenesisParameters, error) {
 	raw, err := o.ogmios.GenesisConfig(ctx, "shelley")
 	if err != nil {
 		return backend.GenesisParameters{}, err
@@ -86,12 +94,19 @@ func (o *OgmiosChainContext) NetworkId() uint8 {
 }
 
 func (o *OgmiosChainContext) CurrentEpoch() (uint64, error) {
-	ctx := context.Background()
+	return o.CurrentEpochContext(context.Background())
+}
+
+func (o *OgmiosChainContext) CurrentEpochContext(ctx context.Context) (uint64, error) {
 	return o.ogmios.CurrentEpoch(ctx)
 }
 
 func (o *OgmiosChainContext) MaxTxFee() (uint64, error) {
-	pp, err := o.ProtocolParams()
+	return o.MaxTxFeeContext(context.Background())
+}
+
+func (o *OgmiosChainContext) MaxTxFeeContext(ctx context.Context) (uint64, error) {
+	pp, err := o.ProtocolParamsContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -99,7 +114,10 @@ func (o *OgmiosChainContext) MaxTxFee() (uint64, error) {
 }
 
 func (o *OgmiosChainContext) Tip() (uint64, error) {
-	ctx := context.Background()
+	return o.TipContext(context.Background())
+}
+
+func (o *OgmiosChainContext) TipContext(ctx context.Context) (uint64, error) {
 	point, err := o.ogmios.ChainTip(ctx)
 	if err != nil {
 		return 0, err
@@ -112,10 +130,13 @@ func (o *OgmiosChainContext) Tip() (uint64, error) {
 }
 
 func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+	return o.UtxosContext(context.Background(), address)
+}
+
+func (o *OgmiosChainContext) UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error) {
 	if o.kupo == nil {
 		return nil, backend.NewUnsupportedError("Ogmios without Kupo", backend.CapabilityUtxos)
 	}
-	ctx := context.Background()
 	matches, err := o.kupo.Matches(ctx, kugo.OnlyUnspent(), kugo.Address(address.String()))
 	if err != nil {
 		return nil, err
@@ -133,7 +154,10 @@ func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error
 }
 
 func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
-	ctx := context.Background()
+	return o.SubmitTxContext(context.Background(), txCbor)
+}
+
+func (o *OgmiosChainContext) SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
 	txHex := hex.EncodeToString(txCbor)
 	resp, err := o.ogmios.SubmitTx(ctx, txHex)
 	if err != nil {
@@ -155,7 +179,14 @@ func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) 
 }
 
 func (o *OgmiosChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
-	ctx := context.Background()
+	return o.EvaluateTxContext(context.Background(), txCbor, additionalUtxos)
+}
+
+func (o *OgmiosChainContext) EvaluateTxContext(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
 	txHex := hex.EncodeToString(txCbor)
 	var resp *ogmigo.EvaluateTxResponse
 	var err error
@@ -332,7 +363,14 @@ func evaluateResponseToExUnits(resp *ogmigo.EvaluateTxResponse) (map[common.Rede
 }
 
 func (o *OgmiosChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
-	ctx := context.Background()
+	return o.UtxoByRefContext(context.Background(), txHash, index)
+}
+
+func (o *OgmiosChainContext) UtxoByRefContext(
+	ctx context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
 	hashHex := hex.EncodeToString(txHash.Bytes())
 	query := chainsync.TxInQuery{
 		Transaction: shared.UtxoTxID{ID: hashHex},
@@ -359,10 +397,16 @@ func (o *OgmiosChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (
 }
 
 func (o *OgmiosChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+	return o.ScriptCborContext(context.Background(), scriptHash)
+}
+
+func (o *OgmiosChainContext) ScriptCborContext(
+	ctx context.Context,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
 	if o.kupo == nil {
 		return nil, backend.NewUnsupportedError("Ogmios without Kupo", backend.CapabilityScriptCbor)
 	}
-	ctx := context.Background()
 	hashHex := hex.EncodeToString(scriptHash.Bytes())
 	script, err := o.kupo.Script(ctx, hashHex)
 	if err != nil {

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -550,7 +550,7 @@ func matchToUtxo(ctx context.Context, match kugo.Match, address common.Address, 
 	if match.OutputIndex < 0 {
 		return common.Utxo{}, fmt.Errorf("negative output index: %d", match.OutputIndex)
 	}
-	if match.OutputIndex > math.MaxUint32 {
+	if uint64(match.OutputIndex) > uint64(math.MaxUint32) {
 		return common.Utxo{}, fmt.Errorf("output index %d exceeds uint32 range", match.OutputIndex)
 	}
 	utxo, err := sharedValueToUtxo(txId, uint32(match.OutputIndex), shared.Value(match.Value), address)

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -1,6 +1,7 @@
 package utxorpc
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -30,6 +31,8 @@ type UtxoRpcChainContext struct {
 	client    *sdk.UtxorpcClient
 	networkId uint8
 }
+
+var _ backend.ContextChainContext = (*UtxoRpcChainContext)(nil)
 
 // Capabilities reports the UTxO RPC operations supported by this client.
 func (u *UtxoRpcChainContext) Capabilities() backend.CapabilitySet {
@@ -133,9 +136,13 @@ func bigIntToString(bi *cardano.BigInt) string {
 }
 
 func (u *UtxoRpcChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
+	return u.ProtocolParamsContext(context.Background())
+}
+
+func (u *UtxoRpcChainContext) ProtocolParamsContext(ctx context.Context) (backend.ProtocolParameters, error) {
 	req := connect.NewRequest(&query.ReadParamsRequest{})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.ReadParams(req)
+	resp, err := u.client.ReadParamsWithContext(ctx, req)
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -243,6 +250,13 @@ func costModelsFromRpc(cm *cardano.CostModels) map[string][]int64 {
 }
 
 func (u *UtxoRpcChainContext) GenesisParams() (backend.GenesisParameters, error) {
+	return u.GenesisParamsContext(context.Background())
+}
+
+func (u *UtxoRpcChainContext) GenesisParamsContext(ctx context.Context) (backend.GenesisParameters, error) {
+	if err := ctx.Err(); err != nil {
+		return backend.GenesisParameters{}, err
+	}
 	return backend.GenesisParameters{}, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityGenesisParams)
 }
 
@@ -251,11 +265,22 @@ func (u *UtxoRpcChainContext) NetworkId() uint8 {
 }
 
 func (u *UtxoRpcChainContext) CurrentEpoch() (uint64, error) {
+	return u.CurrentEpochContext(context.Background())
+}
+
+func (u *UtxoRpcChainContext) CurrentEpochContext(ctx context.Context) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	return 0, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityCurrentEpoch)
 }
 
 func (u *UtxoRpcChainContext) MaxTxFee() (uint64, error) {
-	pp, err := u.ProtocolParams()
+	return u.MaxTxFeeContext(context.Background())
+}
+
+func (u *UtxoRpcChainContext) MaxTxFeeContext(ctx context.Context) (uint64, error) {
+	pp, err := u.ProtocolParamsContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -263,9 +288,13 @@ func (u *UtxoRpcChainContext) MaxTxFee() (uint64, error) {
 }
 
 func (u *UtxoRpcChainContext) Tip() (uint64, error) {
+	return u.TipContext(context.Background())
+}
+
+func (u *UtxoRpcChainContext) TipContext(ctx context.Context) (uint64, error) {
 	req := connect.NewRequest(&syncpb.ReadTipRequest{})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.ReadTip(req)
+	resp, err := u.client.ReadTipWithContext(ctx, req)
 	if err != nil {
 		return 0, err
 	}
@@ -277,6 +306,10 @@ func (u *UtxoRpcChainContext) Tip() (uint64, error) {
 }
 
 func (u *UtxoRpcChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
+	return u.UtxosContext(context.Background(), address)
+}
+
+func (u *UtxoRpcChainContext) UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error) {
 	addrBytes, err := address.Bytes()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address bytes: %w", err)
@@ -296,7 +329,7 @@ func (u *UtxoRpcChainContext) Utxos(address common.Address) ([]common.Utxo, erro
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.SearchUtxos(req)
+	resp, err := u.client.SearchUtxosWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -313,13 +346,17 @@ func (u *UtxoRpcChainContext) Utxos(address common.Address) ([]common.Utxo, erro
 }
 
 func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
+	return u.SubmitTxContext(context.Background(), txCbor)
+}
+
+func (u *UtxoRpcChainContext) SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
 	req := connect.NewRequest(&submit.SubmitTxRequest{
 		Tx: &submit.AnyChainTx{
 			Type: &submit.AnyChainTx_Raw{Raw: txCbor},
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.SubmitTx(req)
+	resp, err := u.client.SubmitTxWithContext(ctx, req)
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
@@ -339,6 +376,17 @@ func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error)
 // field for additional/resolved UTxOs, so off-chain or chained inputs cannot
 // be evaluated by this backend.
 func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
+	return u.EvaluateTxContext(context.Background(), txCbor, additionalUtxos)
+}
+
+func (u *UtxoRpcChainContext) EvaluateTxContext(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(additionalUtxos) > 0 {
 		return nil, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityEvaluateTxAdditionalUtxos)
 	}
@@ -352,7 +400,7 @@ func (u *UtxoRpcChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.EvalTx(req)
+	resp, err := u.client.EvalTxWithContext(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("evaluate transaction: %w", err)
 	}
@@ -516,6 +564,14 @@ func formatRedeemerKeys(keys map[common.RedeemerKey]struct{}) string {
 }
 
 func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error) {
+	return u.UtxoByRefContext(context.Background(), txHash, index)
+}
+
+func (u *UtxoRpcChainContext) UtxoByRefContext(
+	ctx context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
 	req := connect.NewRequest(&query.ReadUtxosRequest{
 		Keys: []*query.TxoRef{
 			{
@@ -525,7 +581,7 @@ func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 		},
 	})
 	u.client.AddHeadersToRequest(req)
-	resp, err := u.client.ReadUtxos(req)
+	resp, err := u.client.ReadUtxosWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +596,14 @@ func (u *UtxoRpcChainContext) UtxoByRef(txHash common.Blake2b256, index uint32) 
 	return &utxo, nil
 }
 
-func (u *UtxoRpcChainContext) ScriptCbor(_ common.Blake2b224) ([]byte, error) {
+func (u *UtxoRpcChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
+	return u.ScriptCborContext(context.Background(), scriptHash)
+}
+
+func (u *UtxoRpcChainContext) ScriptCborContext(ctx context.Context, _ common.Blake2b224) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return nil, backend.NewUnsupportedError("UTxO RPC", backend.CapabilityScriptCbor)
 }
 

--- a/builder_hardening_test.go
+++ b/builder_hardening_test.go
@@ -1,0 +1,216 @@
+package apollo
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+type staticSelector struct {
+	selected []common.Utxo
+	err      error
+}
+
+func (s *staticSelector) Name() string { return "static" }
+
+func (s *staticSelector) Select([]common.Utxo, Value) ([]common.Utxo, error) {
+	return s.selected, s.err
+}
+
+type cloneableTestPayment struct {
+	value int
+}
+
+func (p *cloneableTestPayment) EnsureMinUTXO(backend.ChainContext) error { return nil }
+func (p *cloneableTestPayment) ToTxOut() (*babbage.BabbageTransactionOutput, error) {
+	return nil, errors.New("not used")
+}
+func (p *cloneableTestPayment) ToValue() (Value, error) { return Value{}, nil }
+func (p *cloneableTestPayment) ClonePayment() (PaymentI, error) {
+	copy := *p
+	return &copy, nil
+}
+
+func TestNewRejectsNilChainContext(t *testing.T) {
+	if _, err := New(nil).Complete(); err == nil || !strings.Contains(err.Error(), "chain context must not be nil") {
+		t.Fatalf("New(nil).Complete() error = %v", err)
+	}
+
+	var typedNil *fixed.FixedChainContext
+	if _, err := New(typedNil).Complete(); err == nil || !strings.Contains(err.Error(), "chain context must not be nil") {
+		t.Fatalf("New(typed nil).Complete() error = %v", err)
+	}
+}
+
+func TestNegativeBuilderSettersRecordError(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*Apollo)
+	}{
+		{name: "ttl", set: func(a *Apollo) { a.SetTtl(-1) }},
+		{name: "validity start", set: func(a *Apollo) { a.SetValidityStart(-1) }},
+		{name: "fee", set: func(a *Apollo) { a.SetFee(-1) }},
+		{name: "fee padding", set: func(a *Apollo) { a.SetFeePadding(-1) }},
+		{name: "forced fee", set: func(a *Apollo) { a.ForceFee(-1) }},
+		{name: "collateral amount", set: func(a *Apollo) { a.SetCollateralAmount(-1) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := New(setupFixedContext())
+			tt.set(a)
+			if a.err == nil {
+				t.Fatal("negative value did not record an error")
+			}
+			if _, err := a.Complete(); !errors.Is(err, a.err) {
+				t.Fatalf("Complete() error = %v, want %v", err, a.err)
+			}
+		})
+	}
+}
+
+func TestAddRequiredSignerPaymentKeyRejectsScriptCredential(t *testing.T) {
+	raw := make([]byte, 57)
+	raw[0] = common.AddressTypeScriptKey << 4
+	addr, err := common.NewAddressFromBytes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(setupFixedContext()).AddRequiredSignerPaymentKey(addr)
+	if a.err == nil {
+		t.Fatal("script payment credential was accepted as a required key signer")
+	}
+	if len(a.requiredSigners) != 0 {
+		t.Fatalf("required signers = %d, want 0", len(a.requiredSigners))
+	}
+}
+
+func TestSelectCoinsValidatesCustomSelectorResult(t *testing.T) {
+	first := makeSelectorUtxo(t, 1, 0, 3_000_000, nil)
+	second := makeSelectorUtxo(t, 2, 0, 4_000_000, nil)
+	unavailable := makeSelectorUtxo(t, 3, 0, 10_000_000, nil)
+
+	tests := []struct {
+		name     string
+		selected []common.Utxo
+		want     string
+	}{
+		{name: "malformed", selected: []common.Utxo{{}}, want: "invalid UTxO"},
+		{name: "unavailable", selected: []common.Utxo{unavailable}, want: "unavailable UTxO"},
+		{name: "duplicate", selected: []common.Utxo{first, first}, want: "duplicate UTxO"},
+		{name: "under target", selected: []common.Utxo{first}, want: "does not cover"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := New(setupFixedContext()).
+				AddLoadedUTxOs(first, second).
+				SetCoinSelector(&staticSelector{selected: tt.selected})
+			if _, err := a.selectCoins(NewSimpleValue(5_000_000), Value{}); err == nil ||
+				!strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("selectCoins() error = %v, want containing %q", err, tt.want)
+			}
+			if len(a.usedUtxos) != 0 {
+				t.Fatalf("selector failure marked used UTxOs: %v", a.usedUtxos)
+			}
+		})
+	}
+}
+
+func TestSelectCoinsUsesCanonicalAvailableUtxo(t *testing.T) {
+	available := makeSelectorUtxo(t, 1, 0, 3_000_000, nil)
+	tampered := makeSelectorUtxo(t, 1, 0, 10_000_000, nil)
+	a := New(setupFixedContext()).
+		AddLoadedUTxOs(available).
+		SetCoinSelector(&staticSelector{selected: []common.Utxo{tampered}})
+
+	if _, err := a.selectCoins(NewSimpleValue(5_000_000), Value{}); err == nil ||
+		!strings.Contains(err.Error(), "does not cover") {
+		t.Fatalf("selectCoins() error = %v, want under-coverage error", err)
+	}
+}
+
+func TestCloneCopiesOwnedMutableStateAndSelector(t *testing.T) {
+	selector := &staticSelector{}
+	scriptRef, err := NewScriptRef(common.PlutusV2Script{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	payment := &Payment{
+		Receiver:  testAddress(t),
+		Lovelace:  2_000_000,
+		Units:     []Unit{{Name: "01", Quantity: 1}},
+		Datum:     &datum,
+		DatumHash: []byte{4, 5, 6},
+		ScriptRef: scriptRef,
+	}
+	utxo := makeSelectorUtxo(t, 1, 0, 3_000_000, nil)
+	metadataBytes := []byte{7, 8, 9}
+	customPayment := &cloneableTestPayment{value: 10}
+	a := New(setupFixedContext()).
+		SetCoinSelector(selector).
+		AddPayment(payment).
+		AddPayment(customPayment).
+		AddLoadedUTxOs(utxo).
+		SetShelleyMetadata(map[uint64]any{1: map[string]any{"bytes": metadataBytes}})
+	a.v2scripts = append(a.v2scripts, common.PlutusV2Script{10, 11})
+
+	clone := a.Clone()
+	if clone.err != nil {
+		t.Fatalf("Clone() recorded error: %v", clone.err)
+	}
+	if clone.coinSelector != selector {
+		t.Fatal("Clone() did not preserve the configured coin selector")
+	}
+
+	payment.Units[0].Quantity = 99
+	payment.DatumHash[0] = 99
+	payment.ScriptRef.Script.(common.PlutusV2Script)[0] = 99
+	metadataBytes[0] = 99
+	a.v2scripts[0][0] = 99
+	utxo.Output.(*babbage.BabbageTransactionOutput).OutputAmount.Amount = 99
+	customPayment.value = 99
+
+	clonedPayment := clone.payments[0].(*Payment)
+	if clonedPayment.Units[0].Quantity == 99 ||
+		clonedPayment.DatumHash[0] == 99 ||
+		clonedPayment.ScriptRef.Script.(common.PlutusV2Script)[0] == 99 {
+		t.Fatal("built-in payment state aliases the original")
+	}
+	clonedMetadata := clone.auxiliaryData.metadata[1].(map[string]any)["bytes"].([]byte)
+	if clonedMetadata[0] == 99 {
+		t.Fatal("metadata aliases the original")
+	}
+	if clone.v2scripts[0][0] == 99 {
+		t.Fatal("script bytes alias the original")
+	}
+	if clone.utxos[0].Output.Amount().Uint64() == 99 {
+		t.Fatal("UTxO output aliases the original")
+	}
+	if clone.payments[1].(*cloneableTestPayment).value == 99 {
+		t.Fatal("custom cloneable payment aliases the original")
+	}
+}
+
+func TestNewKeyPairWalletCopiesPrivateKey(t *testing.T) {
+	key := make(bip32.XPrv, 96)
+	key[0] = 1
+	wallet, err := NewKeyPairWallet(testAddress(t), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key[0] = 99
+	if wallet.privateKey[0] != 1 {
+		t.Fatal("wallet private key aliases caller-owned memory")
+	}
+}

--- a/coinselection.go
+++ b/coinselection.go
@@ -39,6 +39,9 @@ func (s *LargestFirstSelector) Select(available []common.Utxo, target Value) ([]
 	if remaining.Coin == 0 && !remaining.HasAssets() {
 		return nil, nil
 	}
+	if err := validateUtxos(available); err != nil {
+		return nil, fmt.Errorf("invalid coin-selection input: %w", err)
+	}
 	sorted := SortUtxos(available)
 	// Stabilize ordering for equal-amount UTxOs to preserve deterministic selection.
 	for i := 0; i < len(sorted); {

--- a/coinselection_test.go
+++ b/coinselection_test.go
@@ -179,6 +179,23 @@ func TestLargestFirstSelectorName(t *testing.T) {
 	}
 }
 
+func TestCoinSelectorsRejectMalformedUTxOs(t *testing.T) {
+	selectors := []CoinSelector{
+		&LargestFirstSelector{},
+		NewMACSSelector(),
+	}
+	for _, selector := range selectors {
+		t.Run(selector.Name(), func(t *testing.T) {
+			if _, err := selector.Select(
+				[]common.Utxo{{}},
+				NewSimpleValue(1),
+			); err == nil {
+				t.Fatal("expected malformed UTxO error")
+			}
+		})
+	}
+}
+
 // TestLargestFirstSelectorOrder pins the exact legacy behavior: ADA-only
 // UTxOs are consumed first in descending lovelace order, before any
 // asset-carrying UTxOs.

--- a/evaluation_balance.go
+++ b/evaluation_balance.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	"github.com/Salvionied/apollo/v2/backend"
 )
 
 // balanceContext contains every value in the Cardano balance equation that is
@@ -60,7 +62,7 @@ func (a *Apollo) buildBalancedOutputs(
 	}
 
 	changeOutput := NewBabbageOutput(ctx.changeAddress, change, nil, nil)
-	pp, err := a.Context.ProtocolParams()
+	pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context)
 	if err != nil {
 		return balancedOutputs{}, fmt.Errorf("failed to get protocol params for change output: %w", err)
 	}

--- a/macs.go
+++ b/macs.go
@@ -102,6 +102,9 @@ func (s *MACSSelector) Select(available []common.Utxo, target Value) ([]common.U
 	// MACS reads every amount to compute pool averages, so the whole pool is
 	// validated up front. Amounts come from a remote backend; reject anything
 	// outside the uint64 lovelace range (big.Int.Uint64 is undefined out of range).
+	if err := validateUtxos(available); err != nil {
+		return nil, fmt.Errorf("invalid coin-selection input: %w", err)
+	}
 	cands := make([]*macsCandidate, 0, len(available))
 	for i := range available {
 		amt := available[i].Output.Amount()

--- a/models.go
+++ b/models.go
@@ -105,6 +105,13 @@ type PaymentI interface {
 	ToValue() (Value, error)
 }
 
+// PaymentCloner is implemented by custom PaymentI implementations that can
+// produce an independent copy for Apollo.Clone. Apollo's built-in Payment
+// implementation is cloned directly.
+type PaymentCloner interface {
+	ClonePayment() (PaymentI, error)
+}
+
 // Payment represents a transaction output with receiver, lovelace, and optional assets.
 type Payment struct {
 	Lovelace  int64

--- a/utils.go
+++ b/utils.go
@@ -12,7 +12,15 @@ import (
 func SortUtxos(utxos []common.Utxo) []common.Utxo {
 	res := make([]common.Utxo, len(utxos))
 	copy(res, utxos)
-	sort.Slice(res, func(i, j int) bool {
+	sort.SliceStable(res, func(i, j int) bool {
+		iValid := validateUtxo(res[i]) == nil
+		jValid := validateUtxo(res[j]) == nil
+		if iValid != jValid {
+			return iValid
+		}
+		if !iValid {
+			return false
+		}
 		iHasAssets := res[i].Output.Assets() != nil
 		jHasAssets := res[j].Output.Assets() != nil
 		if !iHasAssets && !jHasAssets {
@@ -40,7 +48,15 @@ func SortUtxos(utxos []common.Utxo) []common.Utxo {
 func SortInputs(inputs []common.Utxo) []common.Utxo {
 	sorted := make([]common.Utxo, len(inputs))
 	copy(sorted, inputs)
-	sort.Slice(sorted, func(i, j int) bool {
+	sort.SliceStable(sorted, func(i, j int) bool {
+		iValid := validateUtxo(sorted[i]) == nil
+		jValid := validateUtxo(sorted[j]) == nil
+		if iValid != jValid {
+			return iValid
+		}
+		if !iValid {
+			return false
+		}
 		iId := hex.EncodeToString(sorted[i].Id.Id().Bytes())
 		jId := hex.EncodeToString(sorted[j].Id.Id().Bytes())
 		if iId != jId {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,7 +1,9 @@
 package apollo
 
 import (
+	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -51,6 +53,18 @@ func TestSortUtxos(t *testing.T) {
 	amt1 := sorted[1].Output.Amount()
 	if amt0.Cmp(amt1) < 0 {
 		t.Error("expected descending order")
+	}
+}
+
+func TestSortUtxosDoesNotPanicOnMalformedInput(t *testing.T) {
+	valid := makeTestUtxo(t, common.Blake2b256{1}, 0, 1_000_000)
+	var nilOutput *babbage.BabbageTransactionOutput
+	malformed := common.Utxo{Id: valid.Id, Output: nilOutput}
+
+	sorted := SortUtxos([]common.Utxo{malformed, valid})
+
+	if len(sorted) != 2 || validateUtxo(sorted[0]) != nil {
+		t.Fatal("expected valid UTxO to sort before malformed UTxO")
 	}
 }
 
@@ -109,6 +123,25 @@ func TestSortInputs(t *testing.T) {
 	firstAmt := sorted[0].Output.Amount()
 	if firstAmt == nil || firstAmt.Cmp(big.NewInt(2_000_000)) != 0 {
 		t.Error("expected hash2 utxo first (lower tx hash)")
+	}
+}
+
+func TestSortInputsDoesNotPanicOnMalformedInput(t *testing.T) {
+	valid := makeTestUtxo(t, common.Blake2b256{1}, 0, 1_000_000)
+	var nilInput *shelley.ShelleyTransactionInput
+	malformed := common.Utxo{Id: nilInput, Output: valid.Output}
+
+	sorted := SortInputs([]common.Utxo{malformed, valid})
+
+	if len(sorted) != 2 || validateUtxo(sorted[0]) != nil {
+		t.Fatal("expected valid input to sort before malformed input")
+	}
+}
+
+func TestUtxoRefPreservesUint32Index(t *testing.T) {
+	utxo := makeTestUtxo(t, common.Blake2b256{1}, math.MaxUint32, 1_000_000)
+	if got := utxoRef(utxo); !strings.HasSuffix(got, "#4294967295") {
+		t.Fatalf("UTxO ref = %q, want uint32 index preserved", got)
 	}
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -189,9 +189,11 @@ func NewKeyPairWallet(addr common.Address, key bip32.XPrv) (*KeyPairWallet, erro
 	if len(key) != 96 {
 		return nil, fmt.Errorf("invalid BIP32 extended private key length: expected 96 bytes, got %d", len(key))
 	}
+	keyCopy := make(bip32.XPrv, len(key))
+	copy(keyCopy, key)
 	return &KeyPairWallet{
 		address:    addr,
-		privateKey: key,
+		privateKey: keyCopy,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- canonicalize and validate withdrawal reward addresses
- reject malformed and typed-nil UTxOs across public builder and selection paths
- make Clone behavior-preserving and deeply copy builder-owned mutable state
- validate negative setters, required signer credentials, and custom coin-selector output
- add backward-compatible context-aware backend dispatch and Apollo.WithContext
- propagate cancellation through Blockfrost, Maestro, Ogmios/Kupo, UTxO RPC, and cache
- bound Maestro fallback HTTP requests and fix Linux 386 portability

## Validation

- go test -race ./...
- go vet ./...
- golangci-lint run
- GOOS=linux GOARCH=386 go build ./...
- gofmt and git diff checks

This consolidates the necessarily overlapping transaction, builder, and backend changes into one PR so the release-hardening PR set does not overlap.