### PR TITLE
docs: prepare Apollo v2 release guidance and validation

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,11 +2,10 @@ name: go-test
 
 on:
   push:
-    tags:
-      - v*
     branches:
       - master
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -26,3 +25,45 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: go-test
         run: go test ./...
+
+  race:
+    name: race
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.25.x
+      - run: go test -race ./...
+
+  quality:
+    name: format, tidy, vet, and 386 build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.25.x
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+      - name: Check module files
+        run: go mod tidy -diff
+      - name: Vet
+        run: go vet ./...
+      - name: Compile Linux 386
+        env:
+          GOOS: linux
+          GOARCH: "386"
+        run: go build ./...
+
+  vulnerability:
+    name: vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.25.x
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+      - run: govulncheck ./...

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -37,7 +37,7 @@ jobs:
       - run: go test -race ./...
 
   quality:
-    name: format, tidy, vet, and 386 build
+    name: format, tidy, and vet
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,11 +50,6 @@ jobs:
         run: go mod tidy -diff
       - name: Vet
         run: go vet ./...
-      - name: Compile Linux 386
-        env:
-          GOOS: linux
-          GOARCH: "386"
-        run: go build ./...
 
   vulnerability:
     name: vulnerability scan

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,11 +4,10 @@
 name: golangci-lint
 on:
   push:
-    tags:
-      - v*
     branches:
       - master
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,14 @@ jobs:
           result-encoding: string
           script: |
             try {
-              const prerelease = process.env.RELEASE_TAG.includes("-");
+              const semverPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+              const parsedTag = semverPattern.exec(process.env.RELEASE_TAG);
+              if (!parsedTag) {
+                throw new Error(
+                  `release tag ${process.env.RELEASE_TAG} is not valid SemVer (expected vMAJOR.MINOR.PATCH)`,
+                );
+              }
+              const prerelease = parsedTag[4] !== undefined;
               const response = await github.rest.repos.createRelease({
                 generate_release_notes: true,
                 name: process.env.RELEASE_TAG,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,26 +8,39 @@ on:
 concurrency: ${{ github.ref }}
 
 jobs:
+  validate:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/go-test.yml
+
+  lint:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/golangci-lint.yml
+
   create-release:
+    needs: [validate, lint]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: create-release
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
           script: |
             try {
+              const prerelease = process.env.RELEASE_TAG.includes("-");
               const response = await github.rest.repos.createRelease({
                 generate_release_notes: true,
                 name: process.env.RELEASE_TAG,
                 owner: context.repo.owner,
-                prerelease: false,
+                prerelease,
                 repo: context.repo.repo,
                 tag_name: process.env.RELEASE_TAG,
               });

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # Gather all .go files for use in dependencies below
 GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
 
-.PHONY: mod-tidy clean test
+.PHONY: mod-tidy clean format golines test
 
 mod-tidy:
 	# Needed to fetch new dependencies and add them to go.mod

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -711,12 +711,16 @@ func TestFromAddressMatchesUnified(t *testing.T) {
 		},
 		{
 			"RegisterAndDelegateStake",
-			func(a *Apollo) (*Apollo, error) { return a.RegisterAndDelegateStakeFromAddress(addr, poolHash, StakeDeposit) },
+			func(a *Apollo) (*Apollo, error) {
+				return a.RegisterAndDelegateStakeFromAddress(addr, poolHash, StakeDeposit)
+			},
 			func(a *Apollo) (*Apollo, error) { return a.RegisterAndDelegateStake(addr, poolHash, StakeDeposit) },
 		},
 		{
 			"RegisterAndDelegateVote",
-			func(a *Apollo) (*Apollo, error) { return a.RegisterAndDelegateVoteFromAddress(addr, drep, StakeDeposit) },
+			func(a *Apollo) (*Apollo, error) {
+				return a.RegisterAndDelegateVoteFromAddress(addr, drep, StakeDeposit)
+			},
 			func(a *Apollo) (*Apollo, error) { return a.RegisterAndDelegateVote(addr, drep, StakeDeposit) },
 		},
 		{

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,13 @@ Documentation for the Apollo transaction building library for Cardano.
 - **[Data Attachment](data_attachment/README.md)** — Attaching Plutus datums (hash and inline) and reference scripts to transaction outputs; CLI parity for datum and reference script flags.
 - **[Staking Functionalities](staking_functionalities/README.md)** — Stake key registration and deregistration, pool and vote (DRep) delegation, combined certificates, and reward withdrawals; CLI parity for stake-address and withdrawal flags.
 - **[Conway Governance](conway_governance/README.md)** — DRep registration/retirement/update, constitutional committee key authorization and resignation, casting votes, submitting governance action proposals, and treasury donations; CLI parity for `conway governance` commands and CIP-1694.
+- **[v1 to v2 migration](v2_migration/MIGRATION.md)** — Import, type, and builder API changes for users upgrading from Apollo v1.
+- **[SundaeSwap fork migration](sundaeswap-fork-migration.md)** — A focused checklist for applications moving from the SundaeSwap fork.
 
-All sections reference **cardano-cli** 10.14.0.0 where applicable. API details and examples are based on the Apollo codebase (see [AGENTS.md](../AGENTS.md) for build and test commands).
+The command comparisons were written against **cardano-cli 10.14.0.0**. During
+the Apollo v2 release review, the latest
+[upstream release](https://github.com/IntersectMBO/cardano-cli/releases) was
+11.0.0.0. The examples have not yet been fully revalidated against that
+release, so treat parity statements as historical until that review is
+complete. API details and examples are based on the Apollo codebase (see
+[AGENTS.md](../AGENTS.md) for build and test commands).

--- a/docs/data_attachment/pay_to_contract_and_datums.md
+++ b/docs/data_attachment/pay_to_contract_and_datums.md
@@ -68,7 +68,10 @@ func (a *Apollo) AttachDatum(datum *common.Datum) *Apollo
 
 ## Inputs and constraints
 
-- Apollo works with `*common.Datum` (alias for `*common.PlutusData` from gouroboros). For CLI-style file or JSON value input, you must read and parse/decode in your application, then pass the resulting datum into the builder.
+- Apollo works with `*common.Datum`. Its Plutus data value is provided by
+  `github.com/blinklabs-io/plutigo/data`; gouroboros does not export a
+  `common.PlutusData` type. For CLI-style file or JSON value input, read and
+  decode it in your application, then pass the resulting datum to the builder.
 - `PayToContractAsHash`: you supply the hash bytes; the ledger may need the full datum elsewhere (e.g. another output or previous tx) if the contract expects it.
 
 ## Behavior details

--- a/docs/plutus_v3_support/data_structures.md
+++ b/docs/plutus_v3_support/data_structures.md
@@ -73,7 +73,9 @@ Redeemer tags: `RedeemerTagSpend`, `RedeemerTagMint`, `RedeemerTagCert`, `Redeem
 
 ## Datum Types
 
-Datums use `common.Datum` (alias for `common.PlutusData`). They can be attached inline to outputs or as hashes:
+Datums use `common.Datum`, whose Plutus data value comes from
+`github.com/blinklabs-io/plutigo/data`. They can be attached inline to outputs
+or as hashes:
 
 ```go
 // Inline datum on output

--- a/docs/sundaeswap-fork-migration.md
+++ b/docs/sundaeswap-fork-migration.md
@@ -1,277 +1,97 @@
-# Migration Guide: SundaeSwap-finance/apollo Fork to Salvionied/apollo Master
+# Migrating from the SundaeSwap Apollo Fork
 
-This guide covers the changes needed when switching from
-`github.com/SundaeSwap-finance/apollo` back to
-`github.com/Salvionied/apollo/v2`.
+This page is a focused checklist for applications moving from
+`github.com/SundaeSwap-finance/apollo` to Apollo v2. The forks have diverged,
+so do not assume that types or method signatures are interchangeable.
 
-Both codebases share the same lineage. The upstream master has incorporated
-most of the SundaeSwap fork's improvements (error returns, PlutusV3, cost
-model rework, etc.) and added further refinements. The migration is mostly
-mechanical: update import paths and adjust to minor API differences.
+## Change the module path
 
----
-
-## 1. Module / Import Path
-
-**Every import must change:**
+Replace Apollo imports with the v2 module path:
 
 ```go
-// Before (fork)
-import "github.com/SundaeSwap-finance/apollo"
-import "github.com/SundaeSwap-finance/apollo/serialization/PlutusData"
-
-// After (upstream)
-import "github.com/Salvionied/apollo/v2"
-import "github.com/Salvionied/apollo/v2/serialization/PlutusData"
+import apollo "github.com/Salvionied/apollo/v2"
 ```
 
-A global find-and-replace handles this:
+Apollo v2 does not contain the old `serialization/*` package tree. Replace
+those imports with ledger types from gouroboros, primarily:
+
+```go
+import "github.com/blinklabs-io/gouroboros/ledger/common"
+```
+
+Then run:
 
 ```bash
-find . -name '*.go' -exec sed -i \
-  's|github.com/SundaeSwap-finance/apollo|github.com/Salvionied/apollo/v2|g' {} +
 go mod tidy
+go test ./...
 ```
 
-Run `go mod tidy` after the import rewrite to refresh module requirements.
+## Builder differences to check
 
-The fork depended on `github.com/SundaeSwap-finance/kugo` and
-`github.com/SundaeSwap-finance/ogmigo/v6`. Upstream uses
-`github.com/blinklabs-io/kugo` and `github.com/blinklabs-io/ogmigo/v6`
-(or other equivalents). You do not need to worry about these transitive
-dependencies unless you imported them directly.
-
----
-
-## 2. APIs That Are Identical
-
-The following SundaeSwap fork APIs exist in upstream master with the
-**same signature** -- no changes needed beyond the import path swap:
-
-| API | Notes |
-|-----|-------|
-| `Complete() (*Apollo, []byte, error)` | 3-return-value form |
-| `MintAssetsWithRedeemer(Unit, PlutusData)` | Takes `PlutusData` not `Redeemer` |
-| `ForceFee(int64) *Apollo` | |
-| `GetMints() Value.Value` | |
-| `GetBurns() Value.Value` | |
-| `GetEstimatedFee() (int64, error)` | |
-| `SetAdditionalUTxOs([]UTxO.UTxO) *Apollo` | |
-| `PayToContractAsHash(...)` | |
-| `AttachV3Script(PlutusV3Script)` | |
-| `GetUsedUTxOs() map[string]bool` | Was `[]string` in old upstream |
-| `RedeemerTagNames` | Was `RdeemerTagNames` in old upstream |
-| `Address.AddressFromBytes(payment, paymentIsScript, staking, stakingIsScript, network)` | Script credential support |
-| `Address.IsPublicKeyAddress() bool` | |
-| `ChainContext.Utxos() ([]UTxO.UTxO, error)` | Error return |
-| `ChainContext.EvaluateTx() (map[...]..., error)` | Error return |
-| `ChainContext.EvaluateTxWithAdditionalUtxos(...)` | |
-| `ChainContext.CostModelsV1/V2/V3()` | |
-| `PlutusData.CostModel` type | |
-| `Transaction.Bytes()` uses `CanonicalEncOptions` | |
-| `TransactionOutput.GetScriptRef()` returns `nil` for pre-Alonzo | |
-
----
-
-## 3. APIs That Differ
-
-### 3.1 `AddReferenceScriptV1/V2/V3`
-
-The fork combines reference input registration with script version tagging:
+Apollo v2 uses these current signatures:
 
 ```go
-// Fork -- takes txHash and index, implicitly calls AddReferenceInput
-b.AddReferenceScriptV2(txHash, index)
+builder := apollo.New(chainContext)
+
+builder, err := builder.Complete()
+txCbor, err := builder.GetTxCbor()
+
+builder = builder.AddLoadedUTxOs(utxos...)
+builder = builder.PayToAddress(address, lovelace, units...)
+builder = builder.CollectFrom(utxo, redeemer, exUnits)
+
+builder, err = builder.AddReferenceInput(txHash, index)
+used := builder.GetUsedUTxOs() // map[string]bool
 ```
 
-Upstream separates the two concerns:
+Reference scripts are constructed from a `common.Script`; the constructor can
+fail for an unsupported or nil script:
 
 ```go
-// Upstream -- call AddReferenceInput yourself, then tag the version
-b.AddReferenceInput(txHash, index).AddReferenceScriptV2()
-```
-
-**Migration:** Split the single call into two chained calls.
-
-### 3.2 `UtxoFromRef` Return Type
-
-The fork returns a value type:
-
-```go
-// Fork
-func (b *Apollo) UtxoFromRef(txHash string, txIndex int) (UTxO.UTxO, error)
-```
-
-Upstream returns a pointer:
-
-```go
-// Upstream
-func (b *Apollo) UtxoFromRef(txHash string, txIndex int) (*UTxO.UTxO, error)
-```
-
-**Migration:** Handle the `*UTxO.UTxO` return; check for `nil` in addition
-to checking the error.
-
-### 3.3 `GetUtxoFromRef` (ChainContext Interface)
-
-Same story -- the fork returns `(UTxO.UTxO, error)`, upstream returns
-`(*UTxO.UTxO, error)`:
-
-```go
-// Fork
-GetUtxoFromRef(txHash string, txIndex int) (UTxO.UTxO, error)
-
-// Upstream
-GetUtxoFromRef(txHash string, txIndex int) (*UTxO.UTxO, error)
-```
-
-**Migration:** If you implement `ChainContext`, update your return type
-to `*UTxO.UTxO`.
-
-### 3.4 `ScriptRef` Type
-
-The fork uses a struct with an `InnerScript` field (renamed from `_Script`):
-
-```go
-// Fork
-type ScriptRef struct {
-    Script InnerScript
-}
-type InnerScript struct {
-    _ struct{} `cbor:",toarray"`
-    Script []byte
+scriptRef, err := apollo.NewScriptRef(script)
+if err != nil {
+    return err
 }
 ```
 
-Upstream uses a flat `[]byte` alias with proper CBOR tag-24 handling and
-constructor helpers:
+Datums are `common.Datum` values. The underlying Plutus data representation
+comes from `github.com/blinklabs-io/plutigo/data`; there is no
+`common.PlutusData` type.
+
+## Custom chain contexts
+
+Custom backends must implement `backend.ChainContext` from
+`github.com/Salvionied/apollo/v2/backend`. Use that interface as the source of
+truth rather than copying method lists into application code; compile-time
+conformance catches future signature changes:
 
 ```go
-// Upstream
-type ScriptRef []byte
-
-func NewV1ScriptRef(script PlutusV1Script) (ScriptRef, error)
-func NewV2ScriptRef(script PlutusV2Script) (ScriptRef, error)
-func NewV3ScriptRef(script PlutusV3Script) (ScriptRef, error)
+var _ backend.ChainContext = (*myChainContext)(nil)
 ```
 
-**Migration:** Replace direct `ScriptRef{Script: InnerScript{...}}`
-construction with the `NewV1ScriptRef` / `NewV2ScriptRef` /
-`NewV3ScriptRef` constructors. Access to the raw script bytes changes
-from `scriptRef.Script.Script` to `[]byte(scriptRef)`.
+The repository includes Blockfrost, Maestro, Ogmios/Kupo, UTxO RPC, and a
+deterministic fixed backend for tests.
 
-### 3.5 `WalletAddressFromBytes`
+## Dependency expectations
 
-The fork renamed this to `AddressFromBytes` and removed the old name.
-Upstream has **both**: the new `AddressFromBytes` (with script credential
-flags) and a compatibility wrapper `WalletAddressFromBytes` that delegates
-to it with `paymentIsScript=false, stakingIsScript=false`.
+Apollo v2 currently uses Blink Labs packages for ledger behavior, wallet key
+derivation, and Plutus data:
 
-**Migration:** No action needed. If you were using `AddressFromBytes`,
-it exists. If you were using `WalletAddressFromBytes`, it also still
-exists upstream.
+- `github.com/blinklabs-io/gouroboros`
+- `github.com/blinklabs-io/bursa`
+- `github.com/blinklabs-io/plutigo`
 
-### 3.6 `SetWalletFromKeypair` Signing Key Handling
+Backend implementations may have additional provider-specific dependencies.
+Applications should not import Apollo's transitive dependencies directly.
 
-The fork passes the raw bytes directly to `Key.SigningKey`:
+## Recommended migration process
 
-```go
-// Fork
-signingKey := Key.SigningKey{Payload: signingKey_bytes}
-```
+1. Change the Apollo module path and remove old `serialization/*` imports.
+2. Replace serialization types with the corresponding gouroboros/common types.
+3. Update calls based on compiler errors; pay particular attention to methods
+   returning `(*Apollo, error)`.
+4. Update custom backends to satisfy `backend.ChainContext`.
+5. Run `go mod tidy`, `gofmt`, and `go test -race ./...`.
 
-Upstream uses `ed25519.NewKeyFromSeed()` to derive the full 64-byte
-private key from the 32-byte seed, matching the cardano-cli convention:
-
-```go
-// Upstream
-signingKey := Key.SigningKey{
-    Payload: ed25519.NewKeyFromSeed(signingKey_bytes),
-}
-```
-
-**Migration:** If you were passing raw 32-byte seeds from cardano-cli
-key files, upstream handles the conversion automatically. If you were
-relying on the fork's raw-passthrough behavior with pre-expanded 64-byte
-keys, you may need to adjust.
-
-### 3.7 Additional Error Returns on ChainContext Methods
-
-Apollo v2 uses the `backend.ChainContext` interface from `backend/base.go`.
-Custom implementations must use these method names and signatures:
-
-```go
-ProtocolParams() (backend.ProtocolParameters, error)
-GenesisParams() (backend.GenesisParameters, error)
-NetworkId() uint8
-CurrentEpoch() (uint64, error)
-MaxTxFee() (uint64, error)
-Tip() (uint64, error)
-Utxos(address common.Address) ([]common.Utxo, error)
-SubmitTx(txCbor []byte) (common.Blake2b256, error)
-EvaluateTx(txCbor []byte) (map[common.RedeemerKey]common.ExUnits, error)
-UtxoByRef(txHash common.Blake2b256, index uint32) (*common.Utxo, error)
-ScriptCbor(scriptHash common.Blake2b224) ([]byte, error)
-```
-
-**Migration:** Rename old fork methods such as `GetProtocolParams`,
-`GetGenesisParams`, `Epoch`, `LastBlockSlot`, and `GetContractCbor` to the
-v2 interface above, and update integer return types where needed.
-
-### 3.8 `ProtocolParameters.MinFeeReferenceScripts`
-
-Both have this field, but upstream uses it in the `Fee()` calculation
-identically. No migration needed.
-
-### 3.9 Ogmios Backend
-
-The fork upgraded to `ogmigo/v6` v6.1.0 with major rewrites to the
-Ogmios chain context. Upstream also supports `ogmigo/v6` but through
-its own backend paths. If you were using `OgmiosChainContext` directly,
-verify your constructor calls match the upstream API.
-
----
-
-## 4. Deleted Code
-
-### `txBuilding/TxBuilder/TxBuilder.go`
-
-The fork deleted this file (the old transaction builder). Upstream also
-does not ship this file on master. If you were importing from
-`txBuilding/TxBuilder`, that package no longer exists in either codebase
--- use `apollo.New(cc)` with the builder pattern instead.
-
----
-
-## 5. Dependency Changes
-
-| Fork | Upstream |
-|------|----------|
-| `go 1.23.0` | `go 1.25.8` |
-| `github.com/SundaeSwap-finance/kugo v1.3.0` | Different kugo dependency |
-| `github.com/SundaeSwap-finance/ogmigo/v6 v6.1.0` | Different ogmigo dependency |
-| `golang.org/x/exp` (removed) | Also removed |
-| `github.com/tyler-smith/go-bip39` | `github.com/blinklabs-io/go-bip39` |
-
-Run `go mod tidy` after switching imports.
-
----
-
-## 6. Migration Checklist
-
-1. **Find-and-replace** all `github.com/SundaeSwap-finance/apollo`
-   imports to `github.com/Salvionied/apollo/v2`
-2. **Split** `AddReferenceScriptV1/V2/V3(txHash, index)` calls into
-   `AddReferenceInput(txHash, index).AddReferenceScriptV1/V2/V3()`
-3. **Update** `UtxoFromRef` / `GetUtxoFromRef` callers to expect
-   `*UTxO.UTxO` instead of `UTxO.UTxO`
-4. **Update** any custom `ChainContext` implementations to match the
-   v2 `backend.ChainContext` interface (`ProtocolParams`, `GenesisParams`,
-   `NetworkId`, `CurrentEpoch`, `MaxTxFee`, `Tip`, `Utxos`, `SubmitTx`,
-   `EvaluateTx`, `UtxoByRef`, `ScriptCbor`)
-5. **Replace** `ScriptRef` struct usage with the new `[]byte`-based
-   `ScriptRef` and its `NewV1/V2/V3ScriptRef` constructors
-6. **Run** `go mod tidy` to resolve dependency changes
-7. **Run** `make format && make golines` to match upstream style
-   (80-char lines)
-8. **Run** `go test -race ./...` to verify
+For migration from Salvionied Apollo v1, use the
+[v1-to-v2 migration guide](v2_migration/MIGRATION.md).

--- a/docs/v2_migration/MIGRATION.md
+++ b/docs/v2_migration/MIGRATION.md
@@ -70,7 +70,7 @@ import "github.com/Salvionied/apollo/v2"
 
 ## Dependencies
 
-Apollo v2 uses [bursa](https://github.com/blinklabs-io/bursa) v0.15.0 for HD wallet key derivation and transaction signing. Bursa provides:
+Apollo v2 uses [bursa](https://github.com/blinklabs-io/bursa) v0.16.0 for HD wallet key derivation and transaction signing. Bursa provides:
 
 - **BIP32-Ed25519 key derivation** following CIP-1852 (payment, stake, DRep, committee, and calidus keys)
 - **Native `XPrv.Sign()`** for correct CIP-1852 extended Ed25519 signatures
@@ -115,7 +115,10 @@ ref := apollo.NewV2ScriptRef(v2Script)
 ref := apollo.NewV3ScriptRef(v3Script)
 
 // v2 - auto-detects type
-ref := apollo.NewScriptRef(script)
+ref, err := apollo.NewScriptRef(script)
+if err != nil {
+    return err
+}
 ```
 
 ### 3. Minting (2 methods -> 1)
@@ -291,7 +294,7 @@ This pattern applies to all 8 staking/delegation operations:
 | `serialization.PlutusData` | `common.Datum` |
 | `serialization.Redeemer` | `common.RedeemerKey` + `common.RedeemerValue` |
 | `serialization.NativeScript` | `common.NativeScript` |
-| `PlutusData` (custom) | `common.PlutusData` / `common.Datum` |
+| `PlutusData` (custom) | `common.Datum` (backed by `plutigo/data.PlutusData`) |
 
 ### 12. Backend / Chain Context
 
@@ -312,11 +315,11 @@ Supported backends: `blockfrost`, `ogmios`, `maestro`, `utxorpc`, `fixed` (testi
 v2 introduces an explicit `Value` type replacing various ad-hoc representations:
 
 ```go
-v := apollo.NewSimpleValue(2_000_000)           // ADA only
-v := apollo.NewValue(2_000_000, multiAsset)     // ADA + assets
-result, err := v.Add(other)                     // returns error on overflow
-v, err = v.Sub(other)
-ok := v.GreaterOrEqual(other)
+adaOnly := apollo.NewSimpleValue(2_000_000)
+withAssets := apollo.NewValue(2_000_000, multiAsset)
+result, err := withAssets.Add(other) // returns error on overflow
+result, err = result.Sub(other)
+ok := result.GreaterOrEqual(adaOnly)
 ```
 
 **Note**: `Value.Add` returns `(Value, error)` to detect uint64 overflow.
@@ -359,7 +362,10 @@ a, err = a.SetWalletFromMnemonic(mnemonic)                        // no passphra
 a, err = a.SetWalletFromMnemonicWithPassphrase(mnemonic, "pass")  // with passphrase
 ```
 
-## Complete v2 Public API
+## Selected v2 Public API
+
+This list highlights APIs commonly needed during migration. The Go package
+documentation and exported declarations are the authoritative complete API.
 
 ### Construction & Wallet
 - `New(cc) *Apollo`
@@ -392,7 +398,7 @@ a, err = a.SetWalletFromMnemonicWithPassphrase(mnemonic, "pass")  // with passph
 - `CollectFrom(utxo, redeemer, exUnits) *Apollo`
 - `ConsumeUTxO(utxo, payments...) (*Apollo, error)`
 - `UtxoFromRef(hash, index) (*Utxo, error)`
-- `GetUsedUTxOs() []string`
+- `GetUsedUTxOs() map[string]bool`
 
 ### Scripts & Minting
 - `AttachScript(script) *Apollo`

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,40 @@
+package apollo_test
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	apollo "github.com/Salvionied/apollo/v2"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// Example demonstrates the basic, externally visible builder setup. Transaction
+// completion requires spendable UTxOs and is covered by the package's
+// deterministic backend tests.
+func Example() {
+	rawAddress := make([]byte, 57)
+	rawAddress[1] = 0xaa
+	rawAddress[29] = 0xbb
+	address, err := common.NewAddressFromBytes(rawAddress)
+	if err != nil {
+		panic(err)
+	}
+
+	chainContext := fixed.NewEmptyFixedChainContext()
+	builder := apollo.New(chainContext).
+		SetWallet(apollo.NewExternalWallet(address)).
+		PayToAddress(address, 2_000_000)
+
+	_ = builder
+}
+
+// ExampleNewScriptRef verifies the error-returning reference-script API from an
+// external consumer's perspective.
+func ExampleNewScriptRef() {
+	script := common.PlutusV3Script{0x01}
+	scriptRef, err := apollo.NewScriptRef(script)
+	if err != nil {
+		panic(err)
+	}
+
+	_ = scriptRef
+}

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,27 @@
     <img src="./assets/logo.jpg" alt="apollo logo" width="480">
 </div>
 
-# Apollo: Pure Golang Cardano Building blocks 
-## Pure Golang Cardano Serialization
+# Apollo v2
 
-The Objective of this library is to give Developers Access to each and every needed resource for cardano development.
-The final goal is to be able to have this library interact directly with the node without intermediaries.
+Pure Go building blocks for constructing Cardano transactions.
 
-Little Sample Usage:
+Apollo uses the Blink Labs ledger packages for Cardano types, CBOR, scripts,
+addresses, and transaction bodies.
+
+## Install
+
+Apollo v2 requires Go 1.25 or newer:
+
+```bash
+go get github.com/Salvionied/apollo/v2
+```
+
+See the [documentation index](docs/README.md), the
+[v1-to-v2 migration guide](docs/v2_migration/MIGRATION.md), and the
+[SundaeSwap fork migration notes](docs/sundaeswap-fork-migration.md).
+
+## Sample usage
+
 ```go
 package main
 
@@ -31,6 +45,7 @@ func main() {
 
     mnemonic := "your mnemonic here"
     a := apollo.New(bfc)
+    var err error
     a, err = a.SetWalletFromMnemonic(mnemonic)
     if err != nil {
         panic(err)
@@ -124,7 +139,7 @@ a.AddEvaluationWitnessProvider(remoteEvaluationSigner{})
 These signatures are used only for `EvaluateTx`; they are not retained in the
 final unsigned transaction.
 
-If you have any questions or requests feel free to drop into this discord and ask :) https://discord.gg/MH4CmJcg49
+For questions and requests, join the
+[Apollo Discord](https://discord.gg/MH4CmJcg49).
 
-By:
-    `Edoardo Salvioni - Zhaata` 
+Created by Edoardo Salvioni (Zhaata).


### PR DESCRIPTION
## Summary

- repair the README setup example and add install/documentation navigation
- replace the obsolete SundaeSwap migration guide with a current checklist
- correct v2 migration, datum, and cardano-cli baseline documentation
- add externally compiled examples
- gate tagged releases on tests and lint
- add race, formatting, tidy, vet, and vulnerability CI checks
- validate release tags as strict SemVer and derive prerelease status correctly
- fix Makefile phony targets and existing formatting drift

## Validation

- go test ./...
- actionlint
- gofmt check
- go mod tidy -diff
- local Markdown link checks
- git diff --check

Linux 386 compilation is deliberately left to the core-hardening change that fixes the existing 32-bit build failures; this PR remains independently mergeable.