### PR TITLE
chore: update v2 release toolchain and ledger dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/Salvionied/apollo/v2
 
-go 1.25.10
+go 1.25.12
 
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/SundaeSwap-finance/kugo v1.3.1
 	github.com/SundaeSwap-finance/ogmigo/v6 v6.2.1
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.188.1
+	github.com/blinklabs-io/gouroboros v0.189.1
 	github.com/blinklabs-io/plutigo v0.1.17
 	github.com/maestro-org/go-sdk v1.2.1
 	github.com/utxorpc/go-codegen v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.188.1 h1:ElF4glMKqrXw3hJThz+Dt1kqv5RvThQoN15EP5Lr0h0=
-github.com/blinklabs-io/gouroboros v0.188.1/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
+github.com/blinklabs-io/gouroboros v0.189.1 h1:JIPi37b45LQL3e0Kvit5s/OSWjcB/V7WEI9bZ/T27Tc=
+github.com/blinklabs-io/gouroboros v0.189.1/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
 github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=


### PR DESCRIPTION
## Summary

- raise the minimum Go patch release from 1.25.10 to 1.25.12
- update blinklabs-io/gouroboros from 0.188.1 to 0.189.1
- tidy obsolete dependency checksums

The Go baseline change removes the reachable standard-library vulnerabilities reported when building with Go 1.25.10.

## Validation

- Go 1.25.12: go test -race ./...
- govulncheck ./...: zero reachable vulnerabilities
- go mod tidy -diff

This PR is file-disjoint from the core-hardening and documentation PRs.