### PR TITLE
ci: enforce Linux 386 compilation

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -37,7 +37,7 @@ jobs:
       - run: go test -race ./...
 
   quality:
-    name: format, tidy, and vet
+    name: format, tidy, vet, and 386 build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,6 +50,11 @@ jobs:
         run: go mod tidy -diff
       - name: Vet
         run: go vet ./...
+      - name: Compile Linux 386
+        env:
+          GOOS: linux
+          GOARCH: "386"
+        run: go build ./...
 
   vulnerability:
     name: vulnerability scan


### PR DESCRIPTION
## Summary

Restore Linux/386 compilation as a required quality check now that the 32-bit portability fixes from #268 are on master.

## Validation

- actionlint
- GOOS=linux GOARCH=386 go build ./...
- git diff --check

This is intentionally a standalone CI-only follow-up so the earlier documentation PR remained independently mergeable.