### PR TITLE
docs: align documentation with current Apollo API

### DIFF
--- a/docs/conway_governance/README.md
+++ b/docs/conway_governance/README.md
@@ -93,18 +93,24 @@ proposal := conway.ConwayProposalProcedure{
     },
 }
 
-builder, err := apollo.New(chainContext).
+builder := apollo.New(chainContext).
     RegisterDRep(drepCred, 500_000_000, &common.GovAnchor{
         Url:      "https://example.com/drep.json",
         DataHash: drepDocHash,
     }).
     AddVote(voter, actionId, procedure).
     AddProposal(proposal).
-    AddTreasuryDonation(5_000_000).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddTreasuryDonation(5_000_000)
+builder, err := builder.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+builder = builder.AddLoadedUTxOs(utxos...)
+builder, err = builder.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+builder, err = builder.Complete()
 ```
 
 `Complete()` accounts for the DRep deposit, the proposal deposit, and the treasury donation when balancing inputs and outputs.

--- a/docs/conway_governance/committee_methods.md
+++ b/docs/conway_governance/committee_methods.md
@@ -57,12 +57,18 @@ hot := common.Credential{
     Credential: ccHotKeyHash,
 }
 
-apollob, err = apollob.
+apollob = apollob.
     AuthorizeCommitteeHotKey(cold, hot).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 **Cardano CLI:**
@@ -79,26 +85,38 @@ cardano-cli conway governance committee create-hot-key-authorization-certificate
 **Apollo:**
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     ResignCommitteeColdKey(cold, &common.GovAnchor{
         Url:      "https://example.com/resignation.json",
         DataHash: resignDocHash,
     }).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 ### Resign without an anchor
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     ResignCommitteeColdKey(cold, nil).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 **Cardano CLI:**

--- a/docs/conway_governance/drep_methods.md
+++ b/docs/conway_governance/drep_methods.md
@@ -1,6 +1,6 @@
 # DRep Methods
 
-This page documents the **DRep lifecycle** certificates: `RegisterDRep`, `RetireDRep`, `UpdateDRep`. Implementation: [`apollo.go`](../../apollo.go), `github.com/blinklabs-io/gouroboros/ledger/common` (`RegDRepCert`, `UnregDRepCert`, `UpdateDRepCert`). Certificate CBOR: [`governance_test.go`](../../governance_test.go).
+This page documents the **DRep lifecycle** certificates: `RegisterDRep`, `RetireDRep`, `UpdateDRep`. Implementation: [`apollo.go`](../../apollo.go), `github.com/blinklabs-io/gouroboros/ledger/common` (`RegistrationDrepCertificate`, `DeregistrationDrepCertificate`, `UpdateDrepCertificate`). Certificate CBOR: [`governance_test.go`](../../governance_test.go).
 
 A **DRep** (Delegated Representative) is an on-chain identity that other stakers can delegate their voting power to. DReps vote on governance actions on behalf of their delegators. The lifecycle is managed explicitly through three certificates: registration (kind 16), retirement (kind 17), and update (kind 18).
 
@@ -52,7 +52,7 @@ All three methods append a certificate to the builder's certificate list and ret
 
 ## Behavior details
 
-- **Deposit handling**: `RegisterDRep` requires the DRep deposit defined by current Conway protocol parameters (`drepDeposit`, typically 500 ADA). `Complete()` adds `RegDRepCert.Coin` to the required input amount automatically. `RetireDRep` refunds `UnregDRepCert.Coin` — pass the same amount that was originally deposited.
+- **Deposit handling**: `RegisterDRep` takes the DRep deposit defined by the current Conway protocol parameters (`drepDeposit`, typically 500 ADA). `Complete()` adds `RegistrationDrepCertificate.Amount` to the required input amount automatically. `RetireDRep` refunds `DeregistrationDrepCertificate.Amount` — pass the same amount that was originally deposited.
 - **Anchor optionality**: Pass `nil` for `anchor` to register or update a DRep without metadata. CBOR encodes the absent anchor as `null`.
 - **No replay protection in builder**: Apollo does not check whether a DRep is already registered or retired. The node will reject the transaction if the certificate is invalid in the current ledger state.
 
@@ -61,7 +61,7 @@ All three methods append a certificate to the builder's certificate list and ret
 - `credential.Credential` must be exactly 28 bytes.
 - `coin` for `RegisterDRep` must match the protocol-parameter `drepDeposit`. `coin` for `RetireDRep` must match the deposit originally paid at registration.
 - `anchor.DataHash` must be 32 bytes (Blake2b-256).
-- The transaction must include witnesses for the DRep credential (key witness for `Code: 0`, script witness for `Code: 1`).
+- The transaction must include witnesses for the DRep credential (key witness for `CredType: 0`, script witness for `CredType: 1`).
 
 ## Cardano CLI equivalence (10.14.0.0)
 
@@ -85,15 +85,21 @@ drepCred := common.Credential{
     Credential: drepKeyHash,
 }
 
-apollob, err = apollob.
+apollob = apollob.
     RegisterDRep(drepCred, 500_000_000, &common.GovAnchor{
         Url:      "https://example.com/drep.json",
         DataHash: drepDocHash,
     }).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 **Cardano CLI:**
@@ -112,12 +118,18 @@ cardano-cli conway transaction build --certificate-file drep-reg.cert ...
 ### Register without metadata
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     RegisterDRep(drepCred, 500_000_000, nil).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 ### Update a DRep's anchor
@@ -125,26 +137,38 @@ apollob, err = apollob.
 **Apollo:**
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     UpdateDRep(drepCred, &common.GovAnchor{
         Url:      "https://example.com/drep-v2.json",
         DataHash: newDocHash,
     }).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 To **remove** the anchor entirely, pass `nil`:
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     UpdateDRep(drepCred, nil).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 ### Retire a DRep
@@ -152,12 +176,18 @@ apollob, err = apollob.
 **Apollo:**
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     RetireDRep(drepCred, 500_000_000).  // Refund the original deposit
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 **Cardano CLI:**
@@ -183,7 +213,7 @@ cardano-cli conway governance drep retirement-certificate \
 
 ## Caveats and validation
 
-- **Deposit must equal the protocol parameter** at the time of registration. Submitting a `RegDRepCert` with the wrong `Coin` will be rejected by the node.
+- **Deposit must equal the protocol parameter** at the time of registration. Submitting a `RegistrationDrepCertificate` with the wrong `Amount` will be rejected by the node.
 - **Anchor URL is *not* dereferenced** by Apollo or the node. The node only verifies that the on-chain hash matches what was supplied — it never fetches the URL. Hosting and content integrity are your responsibility.
 - The DRep credential must sign the transaction (or its script must be witnessed for script DReps).
 - Validate on preview/preprod first — Conway parameters and deposit amounts vary across networks.

--- a/docs/conway_governance/proposal_methods.md
+++ b/docs/conway_governance/proposal_methods.md
@@ -171,12 +171,18 @@ proposal := conway.ConwayProposalProcedure{
     },
 }
 
-apollob, err = apollob.
+apollob = apollob.
     AddProposal(proposal).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 **Cardano CLI:**
@@ -376,13 +382,19 @@ apollob, err = apollob.AddProposal(proposal). /* ... */ Complete()
 ### Multiple proposals in one transaction
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     AddProposal(infoProposal).
     AddProposal(parameterChangeProposal).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 `Complete()` adds the **sum** of both deposits to the required input balance.

--- a/docs/conway_governance/treasury_methods.md
+++ b/docs/conway_governance/treasury_methods.md
@@ -45,13 +45,19 @@ Cardano CLI requires both flags together when donating; Apollo allows either ind
 **Apollo:**
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     SetCurrentTreasuryValue(currentEpochTreasuryValue).
     AddTreasuryDonation(5_000_000).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 `currentEpochTreasuryValue` should come from a fresh ledger query (e.g. `cardano-cli query ledger-state`).
@@ -84,12 +90,18 @@ This is convenient when constructing a transaction in stages — e.g. a fundrais
 If you don't care about racing with epoch boundaries, omit `SetCurrentTreasuryValue`:
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     AddTreasuryDonation(5_000_000).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 The node accepts the transaction as long as inputs cover outputs + fee + donation.

--- a/docs/conway_governance/voting_methods.md
+++ b/docs/conway_governance/voting_methods.md
@@ -112,12 +112,18 @@ procedure := common.VotingProcedure{
     Anchor: nil,
 }
 
-apollob, err = apollob.
+apollob = apollob.
     AddVote(voter, actionId, procedure).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 **Cardano CLI:**
@@ -138,14 +144,20 @@ cardano-cli conway transaction build --vote-file vote.cert ...
 The same voter can vote on several different actions:
 
 ```go
-apollob, err = apollob.
+apollob = apollob.
     AddVote(voter, action1, common.VotingProcedure{Vote: common.GovVoteYes}).
     AddVote(voter, action2, common.VotingProcedure{Vote: common.GovVoteNo}).
     AddVote(voter, action3, common.VotingProcedure{Vote: common.GovVoteAbstain}).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 All three votes are stored under the single voter entry in the transaction's voting procedures map.
@@ -163,12 +175,18 @@ procedure := common.VotingProcedure{
     },
 }
 
-apollob, err = apollob.
+apollob = apollob.
     AddVote(voter, actionId, procedure).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 ### Constitutional committee member voting with hot key
@@ -179,14 +197,20 @@ voter := common.Voter{
     Hash: ccHotKeyHash,
 }
 
-apollob, err = apollob.
+apollob = apollob.
     AddVote(voter, actionId, common.VotingProcedure{
         Vote: common.GovVoteYes,
     }).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 Use the **hot** key hash here — the cold key authorized this hot key via `AuthorizeCommitteeHotKey`.
@@ -201,14 +225,20 @@ voter := common.Voter{
     Hash: poolColdKeyHash,
 }
 
-apollob, err = apollob.
+apollob = apollob.
     AddVote(voter, actionId, common.VotingProcedure{
         Vote: common.GovVoteYes,
     }).
-    AddInputAddressFromBech32(myAddr).
-    AddLoadedUTxOs(utxos...).
-    PayToAddressBech32(myAddr, 10_000_000).
-    Complete()
+    AddLoadedUTxOs(utxos...)
+apollob, err = apollob.AddInputAddressFromBech32(myAddr)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.PayToAddressBech32(myAddr, 10_000_000)
+if err != nil {
+    panic(err)
+}
+apollob, err = apollob.Complete()
 ```
 
 ### Changing your vote before sending

--- a/docs/data_attachment/README.md
+++ b/docs/data_attachment/README.md
@@ -25,6 +25,8 @@ This section documents how to attach **Plutus datums** (hash or inline) and **re
 
 Each functionality page above includes method signatures, behavior, side-by-side Apollo + CLI examples, evidence labels, and caveats.
 
+Plutus V4 reference scripts are recognized by the underlying types, but the current Conway transaction builder rejects V4 reference-script payments with `ErrPlutusV4RequiresDijkstra`; V4 requires Dijkstra-era transaction support.
+
 ## See also
 
 - [Staking Functionalities](../staking_functionalities/README.md) — Stake certificates and withdrawals
@@ -33,4 +35,3 @@ Each functionality page above includes method signatures, behavior, side-by-side
 ## Reference
 
 - [Cardano CLI repository](https://github.com/IntersectMBO/cardano-cli) — CLI command reference (10.14.0.0)
-

--- a/docs/data_attachment/pay_to_contract_and_datums.md
+++ b/docs/data_attachment/pay_to_contract_and_datums.md
@@ -101,7 +101,10 @@ func (a *Apollo) AttachDatum(datum *common.Datum) *Apollo
 ```go
 import "github.com/blinklabs-io/gouroboros/ledger/common"
 
-contractAddr, _ := common.NewAddress("addr1qy99jvml...")
+contractAddr, err := common.NewAddress("addr1qy99jvml...")
+if err != nil {
+    panic(err)
+}
 datum := common.Datum{} // your Plutus data
 apollob = apollob.
     SetChangeAddress(changeAddr).

--- a/docs/data_attachment/reference_script_output_attachments.md
+++ b/docs/data_attachment/reference_script_output_attachments.md
@@ -1,6 +1,6 @@
 # Reference Script Output Attachments
 
-This page documents attaching **reference scripts** (Plutus V1, V2, V3, or Native) to transaction outputs. Apollo v2 provides both a **unified** method that auto-detects the script version and **version-specific** convenience methods. Implementation: [`apollo.go`](../../apollo.go), [`convenience.go`](../../convenience.go), [`helpers.go`](../../helpers.go).
+This page documents attaching **reference scripts** (Plutus V1, V2, V3, or Native) to transaction outputs. Apollo v2 provides both a **unified** method that auto-detects the script version and **version-specific** convenience methods. `common.PlutusV4Script` is recognized by `NewScriptRef`, but V4 reference-script payments are rejected for the current Conway transaction format with `ErrPlutusV4RequiresDijkstra`. Implementation: [`apollo.go`](../../apollo.go), [`convenience.go`](../../convenience.go), [`helpers.go`](../../helpers.go).
 
 ## Purpose and method signatures
 
@@ -10,7 +10,7 @@ This page documents attaching **reference scripts** (Plutus V1, V2, V3, or Nativ
 func (a *Apollo) PayToAddressWithReferenceScript(addr common.Address, lovelace int64, script common.Script, units ...Unit) (*Apollo, error)
 ```
 
-Auto-detects the script type (V1, V2, V3, Native) and creates the appropriate `ScriptRef`.
+Auto-detects the script type (V1, V2, V3, V4, Native) and creates the appropriate `ScriptRef`. Only V1-V3 and Native scripts can currently be used by Apollo's Conway transaction builder.
 
 ### Version-specific: PayToAddressWithV1/V2/V3ReferenceScript
 
@@ -42,12 +42,12 @@ Type-safe wrappers with inline datum. These delegate to the unified `PayToContra
 
 ## Inputs and constraints
 
-- Script is passed as `common.PlutusV1Script`, `common.PlutusV2Script`, `common.PlutusV3Script`, or `common.NativeScript` (all from gouroboros). Loading from a file and optional CBOR decode is the application's responsibility.
+- Script is passed as `common.PlutusV1Script`, `common.PlutusV2Script`, `common.PlutusV3Script`, `common.PlutusV4Script`, or `common.NativeScript` (all from gouroboros). Loading from a file and optional CBOR decode is the application's responsibility. V4 is recognized but rejected by the current Conway payment methods; use a Dijkstra-capable transaction builder for V4.
 - Outputs with a reference script are always built as post-Alonzo so that `ScriptRef` is present.
 
 ## Behavior details
 
-- Reference scripts are stored in the output's `ScriptRef` field (post-Alonzo). `NewScriptRef(script)` wraps the script into a `common.ScriptRef` with the appropriate type code (0=Native, 1=V1, 2=V2, 3=V3).
+- Reference scripts are stored in the output's `ScriptRef` field (post-Alonzo). `NewScriptRef(script)` wraps the script into a `common.ScriptRef` with the appropriate type code (0=Native, 1=V1, 2=V2, 3=V3, 4=V4).
 - The unified method auto-detects the script version via Go type assertion.
 - Duplicate scripts attached via `AttachScript` are automatically deduplicated by hash.
 

--- a/docs/plutus_v3_support/README.md
+++ b/docs/plutus_v3_support/README.md
@@ -4,7 +4,7 @@ This documentation provides a comprehensive overview of Plutus V3 support within
 
 ## Key Changes in v2
 
-- **Unified script API**: A single `AttachScript` method handles all script types (V1, V2, V3, and NativeScript) with automatic type detection
+- **Unified script API**: A single `AttachScript` method handles the Conway-supported script types (V1, V2, V3, and NativeScript) with automatic type detection. Plutus V4 is recognized by script-reference helpers but requires Dijkstra-era transaction support.
 - **Unified reference inputs**: A single `AddReferenceInput` method works for all script versions
 - **gouroboros types**: All Plutus types come from `github.com/blinklabs-io/gouroboros/ledger/common`
 
@@ -18,5 +18,5 @@ This documentation provides a comprehensive overview of Plutus V3 support within
 
 ## See also
 
-- [Data Attachment](../data_attachment/README.md) — Datums and reference scripts on outputs (including V1/V2/V3 reference scripts)
+- [Data Attachment](../data_attachment/README.md) — Datums and reference scripts on outputs (including V1/V2/V3 reference scripts; V4 requires Dijkstra)
 - [Staking Functionalities](../staking_functionalities/README.md) — Stake certificates and withdrawals

--- a/docs/plutus_v3_support/cost_models.md
+++ b/docs/plutus_v3_support/cost_models.md
@@ -1,10 +1,10 @@
-# Plutus Cost Models (V1, V2, V3)
+# Plutus Cost Models (V1, V2, V3, V4)
 
 This document describes how Plutus cost models are handled in Apollo v2.
 
 ## Cost Model Overview
 
-Cost models define the execution costs for each primitive operation in Plutus scripts. Each Plutus version (V1, V2, V3) has its own cost model with different parameters. These are part of the Cardano protocol parameters.
+Cost models define the execution costs for each primitive operation in Plutus scripts. Each Plutus version has its own cost model with different parameters. These are part of the Cardano protocol parameters. Apollo can represent and hash V4 cost models, but the current Conway transaction builder only creates V1-V3 witnesses; V4 transaction support requires the Dijkstra-era ledger format.
 
 ## Cost Model Retrieval
 
@@ -18,7 +18,7 @@ if err != nil {
 costModels := pp.CostModels // map[string][]int64
 ```
 
-The `CostModels` map uses string keys: `"PlutusV1"`, `"PlutusV2"`, `"PlutusV3"`.
+The `CostModels` map uses string keys: `"PlutusV1"`, `"PlutusV2"`, `"PlutusV3"`, and, when supplied by the backend, `"PlutusV4"`.
 
 ## Backend Integration
 
@@ -40,6 +40,9 @@ costModels := map[string][]int64{
     "PlutusV2": ppCardano.GetCostModels().GetPlutusV2().GetValues(),
     "PlutusV3": ppCardano.GetCostModels().GetPlutusV3().GetValues(),
 }
+if v4 := ppCardano.GetCostModels().GetPlutusV4(); v4 != nil {
+    costModels["PlutusV4"] = v4.GetValues()
+}
 ```
 
 ### Maestro
@@ -57,8 +60,8 @@ hash, err := apollo.ComputeScriptDataHash(redeemerMap, datums, pp.CostModels)
 The `ComputeScriptDataHash` function:
 1. CBOR-encodes the redeemers
 2. CBOR-encodes the datums
-3. CBOR-encodes the cost models as language views (keyed by language ID: 0=V1, 1=V2, 2=V3)
+3. CBOR-encodes the cost models as language views (keyed by language ID: 0=V1, 1=V2, 2=V3, 3=V4)
 4. Concatenates all three byte arrays
 5. Computes a Blake2b-256 hash of the concatenated bytes
 
-This ensures that transactions using V3 scripts include the correct V3 cost model in the script data hash.
+This ensures that transactions include the correct cost model for each script language represented in the script data hash. A V4 cost model may be present in protocol parameters, but V4 scripts cannot currently be attached to Conway transactions through Apollo.

--- a/docs/plutus_v3_support/data_structures.md
+++ b/docs/plutus_v3_support/data_structures.md
@@ -4,7 +4,7 @@ This document details how Plutus V3 scripts are represented in the transaction w
 
 ## Transaction Witness Set
 
-The `ConwayTransactionWitnessSet` (from `gouroboros/ledger/conway`) contains fields for all Plutus script versions:
+The `ConwayTransactionWitnessSet` (from `gouroboros/ledger/conway`) contains witness fields for Plutus V1, V2, and V3. Plutus V4 witness fields belong to the Dijkstra-era transaction format and are not available in Apollo's current Conway builder:
 
 ```go
 // From gouroboros/ledger/conway
@@ -51,6 +51,7 @@ All script types implement `common.Script`:
 | Plutus V1 | `common.PlutusV1Script` | 1 |
 | Plutus V2 | `common.PlutusV2Script` | 2 |
 | Plutus V3 | `common.PlutusV3Script` | 3 |
+| Plutus V4 | `common.PlutusV4Script` | 4 (Dijkstra only; not available in the Conway builder) |
 
 ## Redeemers
 
@@ -82,7 +83,10 @@ or as hashes:
 a.PayToContract(scriptAddr, &datum, 5_000_000)
 
 // Datum hash on output (datum added to witness set)
-a.PayToContractWithDatumHash(scriptAddr, &datum, 5_000_000)
+a, err := a.PayToContractWithDatumHash(scriptAddr, &datum, 5_000_000)
+if err != nil {
+    // handle error
+}
 
 // Add datum directly to witness set
 a.AddDatum(&datum)

--- a/docs/plutus_v3_support/reference_inputs.md
+++ b/docs/plutus_v3_support/reference_inputs.md
@@ -30,7 +30,7 @@ func main() {
     )
     a := apollo.New(cc)
 
-    // Add a reference input (works for V1, V2, and V3 script references)
+    // Add a reference input (reference inputs are version-agnostic, including V4)
     txHash := "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
     a, err := a.AddReferenceInput(txHash, 0)
     if err != nil {

--- a/docs/plutus_v3_support/script_management.md
+++ b/docs/plutus_v3_support/script_management.md
@@ -11,7 +11,7 @@ The `PlutusV3Script` type is defined in gouroboros and implements the `common.Sc
 type PlutusV3Script []byte
 ```
 
-All Plutus script types (`PlutusV1Script`, `PlutusV2Script`, `PlutusV3Script`) implement the `common.Script` interface:
+All Plutus script types (`PlutusV1Script`, `PlutusV2Script`, `PlutusV3Script`, and `PlutusV4Script`) implement the `common.Script` interface:
 
 ```go
 type Script interface {
@@ -45,7 +45,10 @@ func main() {
     cc := blockfrost.NewBlockFrostChainContext(
         constants.BlockfrostBaseUrlPreview, 0, "your-project-id",
     )
-    scriptBytes, _ := hex.DecodeString("58...") // Compiled Plutus V3 script
+    scriptBytes, err := hex.DecodeString("58...") // Compiled Plutus V3 script
+    if err != nil {
+        panic(err)
+    }
     v3Script := common.PlutusV3Script(scriptBytes)
 
     a := apollo.New(cc)
@@ -62,7 +65,10 @@ func main() {
 The `Hash()` method on any script type returns a `ScriptHash` (alias for `Blake2b224`):
 
 ```go
-scriptBytes, _ := hex.DecodeString("58...")
+scriptBytes, err := hex.DecodeString("58...")
+if err != nil {
+    panic(err)
+}
 v3Script := common.PlutusV3Script(scriptBytes)
 
 hash := v3Script.Hash() // returns common.ScriptHash (common.Blake2b224)
@@ -80,8 +86,9 @@ if err != nil {
 }
 ```
 
-This works for all script types - the reference script type is determined automatically:
+This recognizes all script types - the reference script type is determined automatically:
 - `PlutusV1Script` -> type 1
 - `PlutusV2Script` -> type 2
 - `PlutusV3Script` -> type 3
+- `PlutusV4Script` -> type 4 (Dijkstra only; Conway payment methods return `ErrPlutusV4RequiresDijkstra`)
 - `NativeScript` -> type 0

--- a/docs/plutus_v3_support/transaction_building.md
+++ b/docs/plutus_v3_support/transaction_building.md
@@ -1,6 +1,6 @@
 # Transaction Building with Plutus V3
 
-Apollo v2 provides comprehensive support for building transactions with Plutus V3 scripts. This document details the key methods and patterns for working with V3 scripts.
+Apollo v2 provides comprehensive support for building transactions with Plutus V3 scripts. This document details the key methods and patterns for working with V3 scripts. Plutus V4 is recognized by some underlying types, but requires Dijkstra-era transaction support and cannot currently be attached to Apollo's Conway transactions.
 
 ## Plutus V3 Fields in `Apollo`
 

--- a/docs/staking_functionalities/README.md
+++ b/docs/staking_functionalities/README.md
@@ -26,7 +26,7 @@ Each page includes method signatures, behavior, side-by-side Apollo + CLI exampl
 | Vote (DRep) delegation | Yes | `DelegateVote`, `RegisterAndDelegateVote`, etc. |
 | Stake + vote combined | Yes | `DelegateStakeAndVote`, `RegisterAndDelegateStakeAndVote`, etc. |
 | Withdrawals | Yes | `AddWithdrawal(address, amount, redeemer, exUnits)` |
-| Deposit handling | Yes | `STAKE_DEPOSIT` (2 ADA) applied/refunded in `Complete()` |
+| Deposit handling | Yes | Current network `key_deposit` applied/refunded in `Complete()` (2 ADA fallback) |
 
 ## CLI-to-Apollo Mapping Index
 

--- a/docs/staking_functionalities/credential_helpers.md
+++ b/docs/staking_functionalities/credential_helpers.md
@@ -60,7 +60,10 @@ a, err = a.RegisterStake(&cred)
 **Apollo (credential from address):**
 
 ```go
-addr, _ := common.NewAddress("stake1u...")
+addr, err := common.NewAddress("stake1u...")
+if err != nil {
+    panic(err)
+}
 cred, err := apollo.GetStakeCredentialFromAddress(addr)
 ```
 

--- a/docs/staking_functionalities/delegate_stake_methods.md
+++ b/docs/staking_functionalities/delegate_stake_methods.md
@@ -39,7 +39,7 @@ func (a *Apollo) DelegateStakeAndVoteFromBech32(bech32 string, poolHash common.B
 ## Inputs and constraints
 
 - `poolHash`: 28-byte cold key hash (`common.Blake2b224`) of the target stake pool.
-- `drep`: `common.Drep` with Code (0 = key hash, 1 = script hash, or special values) and optional Credential.
+- `drep`: `common.Drep` with Type (0 = key hash, 1 = script hash, or special values) and optional Credential.
 
 ## Cardano CLI equivalence (10.14.0.0)
 
@@ -86,7 +86,7 @@ cardano-cli transaction build --certificate-file deleg.cert ...
 ### Stake and vote delegation (one cert)
 
 ```go
-drep := common.Drep{Type: 0, Hash: drepKeyHash}
+drep := common.Drep{Type: 0, Credential: drepKeyHash}
 a, err = a.DelegateStakeAndVote(nil, poolHash, drep)
 ```
 

--- a/docs/staking_functionalities/delegate_vote_methods.md
+++ b/docs/staking_functionalities/delegate_vote_methods.md
@@ -7,7 +7,7 @@ This page documents **vote (DRep) delegation**: `DelegateVote*`. Implementation:
 `common.Drep` (from gouroboros):
 
 - `Type`: 0 = key hash, 1 = script hash, or special values for "always abstain" / "no confidence."
-- `Hash`: optional key or script hash (zero for abstain/no-confidence).
+- `Credential`: optional key or script hash (zero for abstain/no-confidence).
 
 Build a `Drep` and pass it into the delegation methods.
 
@@ -53,7 +53,7 @@ import (
 
 drep := common.Drep{
     Type: 0,
-    Hash: drepKeyHash,
+    Credential: drepKeyHash,
 }
 a := apollo.New(cc)
 a.SetWallet(wallet)
@@ -76,5 +76,5 @@ a, err = a.DelegateVoteFromBech32("stake1u...", drep)
 
 ## Caveats and validation
 
-- No ApolloBuilder-level integration tests for vote delegation. Validate on preprod/mainnet with small amounts.
+- No end-to-end integration tests for vote delegation are documented here. Validate on preprod/mainnet with small amounts.
 - All types come from `github.com/blinklabs-io/gouroboros/ledger/common`.

--- a/docs/staking_functionalities/deregister_methods.md
+++ b/docs/staking_functionalities/deregister_methods.md
@@ -1,6 +1,6 @@
 # Deregister Methods
 
-This page documents **stake deregistration**: `DeregisterStake`, `DeregisterStakeFromAddress`, `DeregisterStakeFromBech32`. Deregistering returns the 2 ADA stake key deposit; `Complete()` accounts for the refund. Implementation: [`apollo.go`](../../apollo.go), [`convenience.go`](../../convenience.go).
+This page documents **stake deregistration**: `DeregisterStake`, `DeregisterStakeFromAddress`, `DeregisterStakeFromBech32`. Deregistering refunds the current network's stake key deposit (2 ADA on networks using the default); `Complete()` accounts for the refund. Implementation: [`apollo.go`](../../apollo.go), [`convenience.go`](../../convenience.go).
 
 ## Purpose and method signatures
 

--- a/docs/staking_functionalities/register_methods.md
+++ b/docs/staking_functionalities/register_methods.md
@@ -4,7 +4,7 @@ This page documents **stake registration** and **register+delegate** certificate
 
 ## Constants
 
-- **Stake key deposit**: 2 ADA (`2_000_000` lovelace), `StakeDeposit` in `apollo.go`. `Complete()` adds it to the required balance when registration certificates are present.
+- **Stake key deposit**: `StakeDeposit` in `apollo.go` is the 2 ADA (`2_000_000` lovelace) fallback. When registration certificates are present, `Complete()` uses the current network's `key_deposit` protocol parameter when available.
 
 ## Purpose and method signatures
 
@@ -72,7 +72,7 @@ func (a *Apollo) RegisterAndDelegateStakeAndVoteFromBech32(bech32 string, poolHa
 
 ## Inputs and constraints
 
-- Ensure inputs cover at least 2 ADA deposit when registering. `Complete()` adds the deposit automatically.
+- Ensure inputs cover the current network's key deposit when registering (2 ADA by default). `Complete()` adds the protocol-parameter amount automatically when it is available.
 - Pool key hash must be the correct 28-byte cold key hash for the target pool. DRep must be built as `common.Drep`.
 - The unified methods accept any of the listed types; the `FromAddress`/`FromBech32` variants provide compile-time type safety.
 
@@ -119,7 +119,10 @@ a, err = a.RegisterStakeFromBech32("stake1u...")
 ### Register and delegate in one transaction
 
 ```go
-cred, _ := a.GetStakeCredentialFromWallet()
+cred, err := a.GetStakeCredentialFromWallet()
+if err != nil {
+    panic(err)
+}
 a, err = a.RegisterAndDelegateStake(&cred, poolKeyHash, apollo.StakeDeposit)
 if err != nil {
     panic(err)
@@ -131,6 +134,6 @@ tx, err := a.Complete()
 
 ## Caveats and validation
 
-- Ensure enough inputs for the 2 ADA deposit. Pool key hash and DRep must match node expectations.
+- Ensure enough inputs for the current network's key deposit (2 ADA by default). Pool key hash and DRep must match node expectations.
 - All types come from `github.com/blinklabs-io/gouroboros/ledger/common`.
 - Validate on preprod/mainnet with small amounts before production use.

--- a/docs/v2_migration/MIGRATION.md
+++ b/docs/v2_migration/MIGRATION.md
@@ -43,7 +43,7 @@ import "github.com/Salvionied/apollo/v2"
 | `PayToContractWithV3ReferenceScript(...)` | `PayToContractWithV3ReferenceScript(...)` or `PayToContractWithReferenceScript(addr, datum, lovelace, script, units...)` |
 | `CompleteExact(fee)` | `SetFee(fee)` then `Complete()` |
 | `SetEstimateRequired()` | Automatic — set by `CollectFrom` and `Mint` with redeemers |
-| `ConsumeAssetsFromUtxo(utxo, payments...)` | `AddInput(utxo)` then `AddPayment(payments...)` |
+| `ConsumeAssetsFromUtxo(utxo, payments...)` | `ConsumeUTxO(utxo, payments...)` |
 | `GetPaymentsLength()` | Removed — internal detail |
 | `GetRedeemers()` | Removed — leaked private type |
 | `UpdateRedeemers(r)` | Removed — leaked private type |
@@ -82,7 +82,7 @@ Wallet creation uses bursa internally — see `SetWalletFromMnemonic` and `NewBu
 
 ### 1. Script Attachment (12+ methods -> 1 unified + convenience)
 
-v2 uses a single `AttachScript` method that handles all script types — PlutusV1, PlutusV2, PlutusV3, and NativeScript. Duplicate scripts are ignored automatically.
+v2 uses a single `AttachScript` method that handles the Conway-supported script types — PlutusV1, PlutusV2, PlutusV3, and NativeScript. PlutusV4 requires Dijkstra-era transaction support and is rejected by the current builder. Duplicate scripts are ignored automatically.
 
 ```go
 // v1
@@ -155,7 +155,10 @@ a.PayToContract(addr, datum, lovelace, units...)
 a.PayToContract(addr, datum, lovelace, false, units...)
 
 // v2 - datum hash
-a.PayToContractWithDatumHash(addr, datum, lovelace, units...)
+a, err := a.PayToContractWithDatumHash(addr, datum, lovelace, units...)
+if err != nil {
+    return err
+}
 
 // v1 - pre-computed hash
 a.PayToContractAsHash(addr, hashBytes, lovelace, false)
@@ -175,20 +178,44 @@ a.PayToAddressWithV2ReferenceScript(addr, lovelace, v2Script, units...)
 a.PayToAddressWithV3ReferenceScript(addr, lovelace, v3Script, units...)
 
 // v2 - unified (auto-detects type)
-a.PayToAddressWithReferenceScript(addr, lovelace, script, units...)
+a, err := a.PayToAddressWithReferenceScript(addr, lovelace, script, units...)
+if err != nil {
+    return err
+}
 
 // v2 - version-specific (still available as convenience)
-a.PayToAddressWithV1ReferenceScript(addr, lovelace, v1Script, units...)
-a.PayToAddressWithV2ReferenceScript(addr, lovelace, v2Script, units...)
-a.PayToAddressWithV3ReferenceScript(addr, lovelace, v3Script, units...)
+a, err = a.PayToAddressWithV1ReferenceScript(addr, lovelace, v1Script, units...)
+if err != nil {
+    return err
+}
+a, err = a.PayToAddressWithV2ReferenceScript(addr, lovelace, v2Script, units...)
+if err != nil {
+    return err
+}
+a, err = a.PayToAddressWithV3ReferenceScript(addr, lovelace, v3Script, units...)
+if err != nil {
+    return err
+}
 
 // v2 - contract + reference script (new unified method)
-a.PayToContractWithReferenceScript(addr, datum, lovelace, script, units...)
+a, err = a.PayToContractWithReferenceScript(addr, datum, lovelace, script, units...)
+if err != nil {
+    return err
+}
 
 // v2 - version-specific contract + reference script (convenience)
-a.PayToContractWithV1ReferenceScript(addr, datum, lovelace, v1Script, units...)
-a.PayToContractWithV2ReferenceScript(addr, datum, lovelace, v2Script, units...)
-a.PayToContractWithV3ReferenceScript(addr, datum, lovelace, v3Script, units...)
+a, err = a.PayToContractWithV1ReferenceScript(addr, datum, lovelace, v1Script, units...)
+if err != nil {
+    return err
+}
+a, err = a.PayToContractWithV2ReferenceScript(addr, datum, lovelace, v2Script, units...)
+if err != nil {
+    return err
+}
+a, err = a.PayToContractWithV3ReferenceScript(addr, datum, lovelace, v3Script, units...)
+if err != nil {
+    return err
+}
 ```
 
 ### 6. Bech32 Convenience Methods
@@ -198,11 +225,23 @@ Bech32 convenience methods are available. You can also parse the address yoursel
 ```go
 // v2 - convenience methods (parse bech32 for you)
 a, err = a.PayToAddressBech32("addr1...", 2_000_000)
+if err != nil {
+    return err
+}
 a, err = a.AddInputAddressFromBech32("addr1...")
+if err != nil {
+    return err
+}
 a, err = a.SetChangeAddressBech32("addr1...")
+if err != nil {
+    return err
+}
 
 // v2 - explicit parsing (recommended for reuse)
 addr, err := common.NewAddress("addr1...")
+if err != nil {
+    return err
+}
 a.PayToAddress(addr, 2_000_000)
 a.AddInputAddress(addr)
 a.SetChangeAddress(addr)
@@ -211,6 +250,9 @@ a.SetChangeAddress(addr)
 **Note**: The `SetWalletFromBech32` method is not available in v2. Parse the address and use `NewExternalWallet`:
 ```go
 addr, err := common.NewAddress("addr1...")
+if err != nil {
+    return err
+}
 a.SetWallet(apollo.NewExternalWallet(addr))
 ```
 
@@ -239,6 +281,9 @@ a.AddReferenceInputV3(txHash, idx)  // for V3
 
 // v2
 a, err = a.AddReferenceInput(txHash, idx)    // for all script versions
+if err != nil {
+    return err
+}
 ```
 
 ### 9. Staking & Delegation (unified + convenience)
@@ -247,14 +292,32 @@ v2 provides unified methods that accept flexible input types via `any`, plus `Fr
 
 ```go
 // v2 - unified method, multiple input types
-a.RegisterStake(&cred)       // credential pointer
-a.RegisterStake(addr)        // common.Address
-a.RegisterStake("addr1...")  // bech32 string
-a.RegisterStake(nil)         // wallet fallback
+a, err = a.RegisterStake(&cred)       // credential pointer
+if err != nil {
+    return err
+}
+a, err = a.RegisterStake(addr)        // common.Address
+if err != nil {
+    return err
+}
+a, err = a.RegisterStake("addr1...")  // bech32 string
+if err != nil {
+    return err
+}
+a, err = a.RegisterStake(nil)         // wallet fallback
+if err != nil {
+    return err
+}
 
 // v2 - type-safe convenience wrappers (still available)
-a.RegisterStakeFromAddress(addr)
-a.RegisterStakeFromBech32("stake1u...")
+a, err = a.RegisterStakeFromAddress(addr)
+if err != nil {
+    return err
+}
+a, err = a.RegisterStakeFromBech32("stake1u...")
+if err != nil {
+    return err
+}
 ```
 
 This pattern applies to all 8 staking/delegation operations:
@@ -274,10 +337,10 @@ This pattern applies to all 8 staking/delegation operations:
 | Method | Reason |
 |--------|--------|
 | `CompleteExact(fee)` | Use `SetFee(fee)` then `Complete()` |
-| `SetWalletAsChangeAddress()` | Default behavior — wallet is always the change address |
+| `SetWalletAsChangeAddress()` | The wallet is the default change address unless `SetChangeAddress` is used |
 | `SetWalletFromKeypair(...)` | Incomplete implementation — build address manually |
 | `SetEstimateRequired()` | Internal — automatically set by `CollectFrom`/`Mint` |
-| `ConsumeAssetsFromUtxo(...)` | Use `AddInput(utxo)` then `AddPayment(...)` |
+| `ConsumeAssetsFromUtxo(...)` | Use `ConsumeUTxO(utxo, payments...)` |
 | `GetPaymentsLength()` | Internal detail |
 | `GetRedeemers()` | Leaked private type |
 | `UpdateRedeemers(r)` | Leaked private type |
@@ -359,7 +422,13 @@ w, err := apollo.NewBursaWalletWithPassphrase(mnemonic, "my-secret")
 
 // Via Apollo builder
 a, err = a.SetWalletFromMnemonic(mnemonic)                        // no passphrase
+if err != nil {
+    return err
+}
 a, err = a.SetWalletFromMnemonicWithPassphrase(mnemonic, "pass")  // with passphrase
+if err != nil {
+    return err
+}
 ```
 
 ## Selected v2 Public API
@@ -397,7 +466,7 @@ documentation and exported declarations are the authoritative complete API.
 - `AddInputAddressFromBech32(bech32) (*Apollo, error)`
 - `CollectFrom(utxo, redeemer, exUnits) *Apollo`
 - `ConsumeUTxO(utxo, payments...) (*Apollo, error)`
-- `UtxoFromRef(hash, index) (*Utxo, error)`
+- `UtxoFromRef(hash, index) (*common.Utxo, error)`
 - `GetUsedUTxOs() map[string]bool`
 
 ### Scripts & Minting


### PR DESCRIPTION
## Summary

- Fix fallible Bech32, reference-script, staking, governance, and migration examples so returned errors are assigned and handled.
- Correct current Apollo/gouroboros API names and signatures, including DRep fields and UtxoFromRef.
- Align staking deposit and change-address documentation with current protocol-parameter behavior.
- Document Plutus V4 recognition and the current Conway/Dijkstra support boundary.
- Remove stale claims and ignored parsing errors from related examples and guides.

## Validation

- go test ./...
- git diff --check
- Audited documentation examples against the current exported Apollo API.