### PR TITLE
fix(ogmios): decode Value<AdaOnly> protocol params and correct genesis shapes

### DIFF
--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/SundaeSwap-finance/kugo"
 	ogmigo "github.com/SundaeSwap-finance/ogmigo/v6"
@@ -83,10 +85,12 @@ func (o *OgmiosChainContext) GenesisParamsContext(ctx context.Context) (backend.
 
 	var genesis ogmiosGenesisConfig
 	if err := json.Unmarshal(raw, &genesis); err != nil {
-		return backend.GenesisParameters{}, err
+		return backend.GenesisParameters{}, fmt.Errorf(
+			"failed to parse genesis config: %w", err,
+		)
 	}
 
-	return genesis.toGenesisParams(), nil
+	return genesis.toGenesisParams()
 }
 
 func (o *OgmiosChainContext) NetworkId() uint8 {
@@ -418,25 +422,33 @@ func (o *OgmiosChainContext) ScriptCborContext(
 // --- Ogmios response types and conversion ---
 
 type ogmiosProtocolParams struct {
-	MinFeeCoefficient  int64           `json:"minFeeCoefficient"`
-	MinFeeConstant     ogmiosLovelace  `json:"minFeeConstant"`
+	// The fee- and deposit-critical parameters are decoded through pointers so
+	// that a key missing from the response is reported by toProtocolParams
+	// instead of defaulting to zero. Ogmios sends all of them in every era.
+	MinFeeCoefficient  *int64          `json:"minFeeCoefficient"`
+	MinFeeConstant     *ogmiosLovelace `json:"minFeeConstant"`
 	MaxBlockBodySize   ogmiosBytes     `json:"maxBlockBodySize"`
 	MaxBlockHeaderSize ogmiosBytes     `json:"maxBlockHeaderSize"`
 	MaxTxSize          ogmiosBytes     `json:"maxTransactionSize"`
-	StakeKeyDeposit    ogmiosLovelace  `json:"stakeCredentialDeposit"`
-	PoolDeposit        ogmiosLovelace  `json:"stakePoolDeposit"`
-	MinPoolCost        ogmiosLovelace  `json:"minStakePoolCost"`
+	StakeKeyDeposit    *ogmiosLovelace `json:"stakeCredentialDeposit"`
+	PoolDeposit        *ogmiosLovelace `json:"stakePoolDeposit"`
+	MinPoolCost        *ogmiosLovelace `json:"minStakePoolCost"`
 	CollateralPercent  int             `json:"collateralPercentage"`
 	MaxCollateral      int             `json:"maxCollateralInputs"`
 	MaxValSize         ogmiosBytes     `json:"maxValueSize"`
 	ScriptPrices       ogmiosPrices    `json:"scriptExecutionPrices"`
 	MaxTxExUnits       ogmiosExUnits   `json:"maxExecutionUnitsPerTransaction"`
 	MaxBlockExUnits    ogmiosExUnits   `json:"maxExecutionUnitsPerBlock"`
-	MinUtxoDeposit     int64           `json:"minUtxoDepositCoefficient"`
+	MinUtxoDeposit     *int64          `json:"minUtxoDepositCoefficient"`
 	CostModels         json.RawMessage `json:"plutusCostModels"`
 	// Ogmios v6 exposes Conway reference-script pricing as a structured object
 	// {base, range, multiplier}; base is the lovelace-per-byte first-tier price.
 	MinFeeReferenceScripts *ogmiosRefScripts `json:"minFeeReferenceScripts"`
+	// maxReferenceScriptsSize arrived in Ogmios v6.5 and was renamed to
+	// maxReferenceScriptsSizePerTransaction in v7.0. Both spellings are
+	// optional: Ogmios before v6.5 sends neither.
+	MaxRefScriptsSize   *ogmiosBytes `json:"maxReferenceScriptsSize"`
+	MaxRefScriptsSizeTx *ogmiosBytes `json:"maxReferenceScriptsSizePerTransaction"`
 }
 
 type ogmiosRefScripts struct {
@@ -445,8 +457,40 @@ type ogmiosRefScripts struct {
 	Multiplier json.Number `json:"multiplier"`
 }
 
+// ogmiosLovelace decodes a lovelace-valued Ogmios protocol parameter.
+//
+// Ogmios v6.0.x encoded these as a bare {"lovelace": N}. Since v6.1.0 they are
+// Value<AdaOnly>, i.e. {"ada": {"lovelace": N}}. Both shapes are accepted so
+// older deployments keep working, and an amount carrying neither key is an
+// error rather than a zero: decoding an unrecognized shape to 0 in silence is
+// what left every fee short by the whole minFeeConstant.
 type ogmiosLovelace struct {
-	Lovelace int64 `json:"lovelace"`
+	Lovelace int64
+}
+
+func (l *ogmiosLovelace) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Ada *struct {
+			Lovelace *int64 `json:"lovelace"`
+		} `json:"ada"`
+		Lovelace *int64 `json:"lovelace"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	switch {
+	case wire.Ada != nil && wire.Ada.Lovelace != nil:
+		l.Lovelace = *wire.Ada.Lovelace
+	case wire.Lovelace != nil:
+		l.Lovelace = *wire.Lovelace
+	default:
+		return fmt.Errorf(
+			"unrecognized lovelace amount %s: want "+
+				`{"ada":{"lovelace":N}} or {"lovelace":N}`,
+			data,
+		)
+	}
+	return nil
 }
 
 type ogmiosBytes struct {
@@ -463,7 +507,38 @@ type ogmiosExUnits struct {
 	CPU    int64 `json:"cpu"`
 }
 
+// missingRequired lists the protocol parameters Apollo cannot balance a
+// transaction without. Reporting them is what keeps a renamed or restructured
+// Ogmios field from quietly becoming a zero fee, deposit, or min-UTxO cost.
+func (p *ogmiosProtocolParams) missingRequired() []string {
+	required := []struct {
+		name    string
+		present bool
+	}{
+		{"minFeeCoefficient", p.MinFeeCoefficient != nil},
+		{"minFeeConstant", p.MinFeeConstant != nil},
+		{"minUtxoDepositCoefficient", p.MinUtxoDeposit != nil},
+		{"stakeCredentialDeposit", p.StakeKeyDeposit != nil},
+		{"stakePoolDeposit", p.PoolDeposit != nil},
+		{"minStakePoolCost", p.MinPoolCost != nil},
+	}
+	missing := make([]string, 0, len(required))
+	for _, field := range required {
+		if !field.present {
+			missing = append(missing, field.name)
+		}
+	}
+	return missing
+}
+
 func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, error) {
+	if missing := p.missingRequired(); len(missing) > 0 {
+		return backend.ProtocolParameters{}, fmt.Errorf(
+			"ogmios protocol parameters missing required fields: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+
 	priceMem, err := backend.ParseFraction(p.ScriptPrices.Memory)
 	if err != nil {
 		return backend.ProtocolParameters{}, fmt.Errorf("invalid memory price: %w", err)
@@ -475,7 +550,7 @@ func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, e
 
 	pp := backend.ProtocolParameters{
 		MinFeeConstant:      p.MinFeeConstant.Lovelace,
-		MinFeeCoefficient:   p.MinFeeCoefficient,
+		MinFeeCoefficient:   *p.MinFeeCoefficient,
 		MaxBlockSize:        p.MaxBlockBodySize.Bytes,
 		MaxTxSize:           p.MaxTxSize.Bytes,
 		MaxBlockHeaderSize:  p.MaxBlockHeaderSize.Bytes,
@@ -491,7 +566,14 @@ func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, e
 		MaxValSize:          strconv.Itoa(p.MaxValSize.Bytes),
 		CollateralPercent:   p.CollateralPercent,
 		MaxCollateralInputs: p.MaxCollateral,
-		CoinsPerUtxoByte:    strconv.FormatInt(p.MinUtxoDeposit, 10),
+		CoinsPerUtxoByte:    strconv.FormatInt(*p.MinUtxoDeposit, 10),
+	}
+
+	switch {
+	case p.MaxRefScriptsSize != nil:
+		pp.MaximumReferenceScriptsSize = p.MaxRefScriptsSize.Bytes
+	case p.MaxRefScriptsSizeTx != nil:
+		pp.MaximumReferenceScriptsSize = p.MaxRefScriptsSizeTx.Bytes
 	}
 
 	if p.MinFeeReferenceScripts != nil {
@@ -545,29 +627,119 @@ func ogmiosCostModelKey(key string) string {
 }
 
 type ogmiosGenesisConfig struct {
-	NetworkMagic      int     `json:"networkMagic"`
-	EpochLength       int     `json:"epochLength"`
-	SlotLength        int     `json:"slotLength"`
-	SlotsPerKesPeriod int     `json:"slotsPerKesPeriod"`
-	MaxKesEvolutions  int     `json:"maxKESEvolutions"`
-	SecurityParam     int     `json:"securityParameter"`
-	UpdateQuorum      int     `json:"updateQuorum"`
-	ActiveSlots       float64 `json:"activeSlotsCoefficient"`
-	MaxLovelaceSupply int64   `json:"maxLovelaceSupply"`
+	// Ogmios reports the system start as an ISO-8601 timestamp, while
+	// GenesisParameters carries Unix seconds like the other backends.
+	StartTime         string           `json:"startTime"`
+	NetworkMagic      int              `json:"networkMagic"`
+	EpochLength       int              `json:"epochLength"`
+	SlotLength        ogmiosSlotLength `json:"slotLength"`
+	SlotsPerKesPeriod int              `json:"slotsPerKesPeriod"`
+	MaxKesEvolutions  int              `json:"maxKesEvolutions"`
+	SecurityParam     int              `json:"securityParameter"`
+	UpdateQuorum      int              `json:"updateQuorum"`
+	ActiveSlots       ogmiosRatio      `json:"activeSlotsCoefficient"`
+	MaxLovelaceSupply int64            `json:"maxLovelaceSupply"`
 }
 
-func (g *ogmiosGenesisConfig) toGenesisParams() backend.GenesisParameters {
+// ogmiosRatio decodes an Ogmios ratio. Ogmios v6 sends these as exact
+// "numerator/denominator" strings (e.g. "1/20" for the mainnet active-slots
+// coefficient); v5 sent a bare JSON number. Both are accepted, and a value in
+// neither form is an error rather than a zero.
+type ogmiosRatio struct {
+	Value float64
+}
+
+func (r *ogmiosRatio) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err == nil {
+		value, parseErr := backend.ParseFraction(text)
+		if parseErr != nil {
+			return fmt.Errorf("invalid ratio %q: %w", text, parseErr)
+		}
+		r.Value = value
+		return nil
+	}
+	var number float64
+	if err := json.Unmarshal(data, &number); err != nil {
+		return fmt.Errorf(
+			"unrecognized ratio %s: want a \"num/den\" string or a number",
+			data,
+		)
+	}
+	r.Value = number
+	return nil
+}
+
+// ogmiosSlotLength decodes an Ogmios slot length. Ogmios v6 sends
+// {"milliseconds": N}; v5 sent a bare number of seconds. Both are accepted and
+// normalized to the whole seconds that GenesisParameters reports, so the value
+// is never silently zero.
+type ogmiosSlotLength struct {
+	Seconds int
+}
+
+func (s *ogmiosSlotLength) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Milliseconds *int64 `json:"milliseconds"`
+	}
+	if err := json.Unmarshal(data, &wire); err == nil &&
+		wire.Milliseconds != nil {
+		millis := *wire.Milliseconds
+		if millis < 0 || millis/1000 > math.MaxInt32 {
+			return fmt.Errorf("slot length out of range: %d ms", millis)
+		}
+		s.Seconds = int(millis / 1000)
+		return nil
+	}
+	var seconds int
+	if err := json.Unmarshal(data, &seconds); err != nil {
+		return fmt.Errorf(
+			`unrecognized slot length %s: want {"milliseconds":N} or N`,
+			data,
+		)
+	}
+	s.Seconds = seconds
+	return nil
+}
+
+func (g *ogmiosGenesisConfig) toGenesisParams() (
+	backend.GenesisParameters,
+	error,
+) {
+	systemStart, err := parseOgmiosStartTime(g.StartTime)
+	if err != nil {
+		return backend.GenesisParameters{}, err
+	}
+
 	return backend.GenesisParameters{
-		ActiveSlotsCoefficient: g.ActiveSlots,
+		ActiveSlotsCoefficient: g.ActiveSlots.Value,
 		UpdateQuorum:           g.UpdateQuorum,
 		NetworkMagic:           g.NetworkMagic,
 		EpochLength:            g.EpochLength,
 		MaxLovelaceSupply:      strconv.FormatInt(g.MaxLovelaceSupply, 10),
-		SlotLength:             g.SlotLength,
+		SystemStart:            systemStart,
+		SlotLength:             g.SlotLength.Seconds,
 		SlotsPerKesPeriod:      g.SlotsPerKesPeriod,
 		MaxKesEvolutions:       g.MaxKesEvolutions,
 		SecurityParam:          g.SecurityParam,
+	}, nil
+}
+
+// parseOgmiosStartTime converts an Ogmios ISO-8601 genesis start time to the
+// Unix seconds reported by GenesisParameters. The Ogmios schema makes the
+// trailing zone designator optional, so a bare local-style timestamp is
+// accepted as UTC. An empty value yields zero; anything unparseable is an
+// error rather than a zero timestamp.
+func parseOgmiosStartTime(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
 	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.Unix(), nil
+		}
+	}
+	return 0, fmt.Errorf("invalid genesis start time %q", value)
 }
 
 // datumFetcher resolves a datum's CBOR (hex-encoded) by its hash. It is

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -570,6 +572,12 @@ func TestOgmiosScriptRefJSONLanguageDetection(t *testing.T) {
 
 func TestProtocolParamsPreserveReferenceScriptFeeParameters(t *testing.T) {
 	const body = `{
+		"minFeeCoefficient": 44,
+		"minFeeConstant": {"ada": {"lovelace": 155381}},
+		"minUtxoDepositCoefficient": 4310,
+		"stakeCredentialDeposit": {"ada": {"lovelace": 2000000}},
+		"stakePoolDeposit": {"ada": {"lovelace": 500000000}},
+		"minStakePoolCost": {"ada": {"lovelace": 170000000}},
 		"scriptExecutionPrices": {"memory": "1/1", "cpu": "1/1"},
 		"minFeeReferenceScripts": {
 			"base": 15.125,
@@ -599,5 +607,516 @@ func TestProtocolParamsPreserveReferenceScriptFeeParameters(t *testing.T) {
 	want := backend.TierRefScriptFeeRational(53, big.NewRat(121, 8), 7, big.NewRat(2469, 2000))
 	if got := backend.TierRefScriptFeeRational(53, pp.RefScriptFeePerByteRational(), pp.RefScriptSizeIncrement(), pp.RefScriptMultiplierRational()); got != want {
 		t.Fatalf("reference-script fee = %d, want %d", got, want)
+	}
+}
+
+// ogmiosV6ProtocolParamsTemplate is a queryLedgerState/protocolParameters
+// result as Ogmios v6.x serves it on a Conway-era network. Every lovelace
+// parameter is a %s placeholder so the same response can be rendered in both
+// encodings Ogmios has used (see adaLovelace and bareLovelace); the remaining
+// fields are reproduced as sent, except that the Plutus cost model arrays are
+// truncated to keep the fixture readable.
+const ogmiosV6ProtocolParamsTemplate = `{
+	"minFeeCoefficient": 44,
+	"minFeeConstant": %s,
+	"minUtxoDepositCoefficient": 4310,
+	"minUtxoDepositConstant": %s,
+	"maxBlockBodySize": {"bytes": 90112},
+	"maxBlockHeaderSize": {"bytes": 1100},
+	"maxTransactionSize": {"bytes": 16384},
+	"maxValueSize": {"bytes": 5000},
+	"maxReferenceScriptsSize": {"bytes": 204800},
+	"extraEntropy": "neutral",
+	"stakeCredentialDeposit": %s,
+	"stakePoolDeposit": %s,
+	"stakePoolRetirementEpochBound": 18,
+	"stakePoolPledgeInfluence": "3/10",
+	"minStakePoolCost": %s,
+	"desiredNumberOfStakePools": 500,
+	"monetaryExpansion": "3/1000",
+	"treasuryExpansion": "1/5",
+	"collateralPercentage": 150,
+	"maxCollateralInputs": 3,
+	"version": {"major": 10, "minor": 0},
+	"scriptExecutionPrices": {"memory": "577/10000", "cpu": "721/10000000"},
+	"maxExecutionUnitsPerTransaction": {
+		"memory": 14000000,
+		"cpu": 10000000000
+	},
+	"maxExecutionUnitsPerBlock": {"memory": 62000000, "cpu": 20000000000},
+	"minFeeReferenceScripts": {"base": 15, "range": 25600, "multiplier": 1.2},
+	"plutusCostModels": {
+		"plutus:v1": [100788, 420, 1, 1, 1000, 173, 0, 1],
+		"plutus:v2": [100788, 420, 1, 1, 1000, 173, 0, 1],
+		"plutus:v3": [100788, 420, 1, 1, 1000, 173, 0, 1]
+	},
+	"stakePoolVotingThresholds": {
+		"noConfidence": "51/100",
+		"constitutionalCommittee": {
+			"default": "51/100",
+			"stateOfNoConfidence": "51/100"
+		},
+		"hardForkInitiation": "51/100",
+		"protocolParametersUpdate": {"security": "51/100"}
+	},
+	"delegateRepresentativeVotingThresholds": {
+		"noConfidence": "67/100",
+		"constitutionalCommittee": {
+			"default": "67/100",
+			"stateOfNoConfidence": "3/5"
+		},
+		"constitution": "3/4",
+		"hardForkInitiation": "3/5",
+		"protocolParametersUpdate": {
+			"network": "67/100",
+			"economic": "67/100",
+			"technical": "67/100",
+			"governance": "3/4"
+		},
+		"treasuryWithdrawals": "67/100"
+	},
+	"constitutionalCommitteeMinSize": 7,
+	"constitutionalCommitteeMaxTermLength": 146,
+	"governanceActionLifetime": 6,
+	"governanceActionDeposit": %s,
+	"delegateRepresentativeDeposit": %s,
+	"delegateRepresentativeMaxIdleTime": 20
+}`
+
+// adaLovelace renders the Value<AdaOnly> encoding Ogmios has used since v6.1.0.
+func adaLovelace(amount int64) string {
+	return fmt.Sprintf(`{"ada": {"lovelace": %d}}`, amount)
+}
+
+// bareLovelace renders the flat encoding used by Ogmios v6.0.x.
+func bareLovelace(amount int64) string {
+	return fmt.Sprintf(`{"lovelace": %d}`, amount)
+}
+
+// protocolParamsBody renders ogmiosV6ProtocolParamsTemplate with every lovelace
+// amount encoded by the given function. The argument order must match the
+// placeholder order in the template.
+func protocolParamsBody(encode func(int64) string) string {
+	return fmt.Sprintf(
+		ogmiosV6ProtocolParamsTemplate,
+		encode(155381),       // minFeeConstant
+		encode(0),            // minUtxoDepositConstant
+		encode(2000000),      // stakeCredentialDeposit
+		encode(500000000),    // stakePoolDeposit
+		encode(170000000),    // minStakePoolCost
+		encode(100000000000), // governanceActionDeposit
+		encode(500000000),    // delegateRepresentativeDeposit
+	)
+}
+
+func decodeProtocolParams(
+	t *testing.T,
+	body string,
+) backend.ProtocolParameters {
+	t.Helper()
+	var raw ogmiosProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("failed to decode protocol params: %v", err)
+	}
+	pp, err := raw.toProtocolParams()
+	if err != nil {
+		t.Fatalf("failed to convert protocol params: %v", err)
+	}
+	return pp
+}
+
+// assertOgmiosV6ProtocolParams checks every parameter Apollo reads out of an
+// Ogmios protocol-parameters response against the fixture above. The zero
+// checks are the point of the test: a lovelace amount whose wire shape is not
+// understood decodes to 0 without an error, and a zero minFeeConstant leaves
+// every computed fee short by 155381 lovelace.
+func assertOgmiosV6ProtocolParams(t *testing.T, pp backend.ProtocolParameters) {
+	t.Helper()
+
+	intFields := []struct {
+		name string
+		got  int64
+		want int64
+	}{
+		{"MinFeeConstant", pp.MinFeeConstant, 155381},
+		{"MinFeeCoefficient", pp.MinFeeCoefficient, 44},
+		{"CoinsPerUtxoByteValue", pp.CoinsPerUtxoByteValue(), 4310},
+		{"MaxBlockSize", int64(pp.MaxBlockSize), 90112},
+		{"MaxBlockHeaderSize", int64(pp.MaxBlockHeaderSize), 1100},
+		{"MaxTxSize", int64(pp.MaxTxSize), 16384},
+		{"CollateralPercent", int64(pp.CollateralPercent), 150},
+		{"MaxCollateralInputs", int64(pp.MaxCollateralInputs), 3},
+		{
+			"MaximumReferenceScriptsSize",
+			int64(pp.MaximumReferenceScriptsSize),
+			204800,
+		},
+		{
+			"MinFeeReferenceScriptsRange",
+			int64(pp.MinFeeReferenceScriptsRange),
+			25600,
+		},
+	}
+	for _, field := range intFields {
+		if field.got == 0 {
+			t.Errorf("%s is zero: value was silently dropped", field.name)
+			continue
+		}
+		if field.got != field.want {
+			t.Errorf("%s = %d, want %d", field.name, field.got, field.want)
+		}
+	}
+
+	stringFields := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"KeyDeposits", pp.KeyDeposits, "2000000"},
+		{"PoolDeposits", pp.PoolDeposits, "500000000"},
+		{"MinPoolCost", pp.MinPoolCost, "170000000"},
+		{"CoinsPerUtxoByte", pp.CoinsPerUtxoByte, "4310"},
+		{"MaxTxExMem", pp.MaxTxExMem, "14000000"},
+		{"MaxTxExSteps", pp.MaxTxExSteps, "10000000000"},
+		{"MaxBlockExMem", pp.MaxBlockExMem, "62000000"},
+		{"MaxBlockExSteps", pp.MaxBlockExSteps, "20000000000"},
+		{"MaxValSize", pp.MaxValSize, "5000"},
+	}
+	for _, field := range stringFields {
+		if field.got == "" || field.got == "0" {
+			t.Errorf("%s = %q: value was silently dropped", field.name, field.got)
+			continue
+		}
+		if field.got != field.want {
+			t.Errorf("%s = %q, want %q", field.name, field.got, field.want)
+		}
+	}
+
+	if got, want := pp.PriceMem, 577.0/10000.0; got != want {
+		t.Errorf("PriceMem = %v, want %v", got, want)
+	}
+	if got, want := pp.PriceStep, 721.0/10000000.0; got != want {
+		t.Errorf("PriceStep = %v, want %v", got, want)
+	}
+
+	base, wantBase := pp.RefScriptFeePerByteRational(), big.NewRat(15, 1)
+	if base.Cmp(wantBase) != 0 {
+		t.Errorf("RefScriptFeePerByteRational() = %s, want %s", base, wantBase)
+	}
+	mult, wantMult := pp.RefScriptMultiplierRational(), big.NewRat(6, 5)
+	if mult.Cmp(wantMult) != 0 {
+		t.Errorf("RefScriptMultiplierRational() = %s, want %s", mult, wantMult)
+	}
+
+	for _, language := range []string{"PlutusV1", "PlutusV2", "PlutusV3"} {
+		costs, ok := pp.CostModels[language]
+		if !ok {
+			t.Errorf("cost models missing %s", language)
+			continue
+		}
+		if len(costs) == 0 || costs[0] != 100788 {
+			t.Errorf("%s cost model = %v", language, costs)
+		}
+	}
+}
+
+// TestProtocolParamsDecodeLovelaceShapes decodes a realistic Ogmios v6
+// protocol-parameters response in both lovelace encodings. Ogmios v6.0.x sent
+// a bare {"lovelace": N}; v6.1.0 onward sends {"ada": {"lovelace": N}}. Both
+// must yield the real parameter values.
+func TestProtocolParamsDecodeLovelaceShapes(t *testing.T) {
+	shapes := []struct {
+		name   string
+		encode func(int64) string
+	}{
+		{"ada nested (v6.1.0 onward)", adaLovelace},
+		{"bare lovelace (v6.0.x)", bareLovelace},
+	}
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			pp := decodeProtocolParams(t, protocolParamsBody(shape.encode))
+			assertOgmiosV6ProtocolParams(t, pp)
+		})
+	}
+}
+
+// TestProtocolParamsAcceptRenamedReferenceScriptsSize covers the v7.0 rename of
+// maxReferenceScriptsSize to maxReferenceScriptsSizePerTransaction.
+func TestProtocolParamsAcceptRenamedReferenceScriptsSize(t *testing.T) {
+	body := strings.Replace(
+		protocolParamsBody(adaLovelace),
+		`"maxReferenceScriptsSize"`,
+		`"maxReferenceScriptsSizePerTransaction"`,
+		1,
+	)
+	if body == protocolParamsBody(adaLovelace) {
+		t.Fatal("fixture no longer contains maxReferenceScriptsSize")
+	}
+
+	pp := decodeProtocolParams(t, body)
+	if got, want := pp.MaximumReferenceScriptsSize, 204800; got != want {
+		t.Fatalf("MaximumReferenceScriptsSize = %d, want %d", got, want)
+	}
+}
+
+// TestProtocolParamsLovelaceShapesAgree pins the two encodings to identical
+// results, so neither path can drift away from the other.
+func TestProtocolParamsLovelaceShapesAgree(t *testing.T) {
+	nested := decodeProtocolParams(t, protocolParamsBody(adaLovelace))
+	bare := decodeProtocolParams(t, protocolParamsBody(bareLovelace))
+	if !reflect.DeepEqual(nested, bare) {
+		t.Fatalf("encodings disagree:\nnested = %+v\nbare   = %+v", nested, bare)
+	}
+}
+
+// TestProtocolParamsProduceLedgerMinFee mirrors the fee formula Apollo applies
+// in Complete() to prove the decoded parameters produce the fee the ledger
+// expects. With a dropped minFeeConstant this fee is 155381 lovelace short and
+// the node rejects the transaction with FeeTooSmallUTxO.
+func TestProtocolParamsProduceLedgerMinFee(t *testing.T) {
+	pp := decodeProtocolParams(t, protocolParamsBody(adaLovelace))
+
+	const txSize = 1024
+	got := int64(txSize)*pp.MinFeeCoefficient + pp.MinFeeConstant
+	want := int64(txSize*44 + 155381)
+	if got != want {
+		t.Fatalf(
+			"min fee for a %d-byte tx = %d, want %d (short by %d)",
+			txSize, got, want, want-got,
+		)
+	}
+}
+
+// TestOgmiosLovelaceRejectsUnrecognizedShape is the guard against the next
+// wire-format change: an amount Apollo cannot interpret must be an error, not
+// a zero. Silently decoding to zero is what shipped the fee bug.
+func TestOgmiosLovelaceRejectsUnrecognizedShape(t *testing.T) {
+	bodies := []string{
+		`{}`,
+		`null`,
+		`{"coin": 155381}`,
+		`{"ada": {}}`,
+		`{"ada": {"coin": 155381}}`,
+		`{"ada": null}`,
+		`{"lovelaces": 155381}`,
+	}
+	for _, body := range bodies {
+		t.Run(body, func(t *testing.T) {
+			var amount ogmiosLovelace
+			err := json.Unmarshal([]byte(body), &amount)
+			if err == nil {
+				t.Fatalf(
+					"%s decoded to %d without error; an unrecognized"+
+						" shape must not become a silent zero",
+					body, amount.Lovelace,
+				)
+			}
+		})
+	}
+}
+
+// TestOgmiosLovelacePrefersAdaWhenBothPresent documents the precedence used if
+// a response ever carries both encodings.
+func TestOgmiosLovelacePrefersAdaWhenBothPresent(t *testing.T) {
+	var amount ogmiosLovelace
+	body := `{"ada": {"lovelace": 155381}, "lovelace": 7}`
+	if err := json.Unmarshal([]byte(body), &amount); err != nil {
+		t.Fatal(err)
+	}
+	if amount.Lovelace != 155381 {
+		t.Fatalf("lovelace = %d, want 155381", amount.Lovelace)
+	}
+}
+
+// TestProtocolParamsRejectUnrecognizedLovelaceShape checks that an unreadable
+// amount fails the whole response rather than one field.
+func TestProtocolParamsRejectUnrecognizedLovelaceShape(t *testing.T) {
+	body := protocolParamsBody(func(amount int64) string {
+		return fmt.Sprintf(`{"coin": %d}`, amount)
+	})
+	var raw ogmiosProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err == nil {
+		t.Fatal("expected an error for an unrecognized lovelace encoding")
+	}
+}
+
+// TestProtocolParamsRejectMissingRequiredFields covers the other way a
+// parameter can silently become zero: the key disappearing from the response.
+func TestProtocolParamsRejectMissingRequiredFields(t *testing.T) {
+	const body = `{"scriptExecutionPrices": {"memory": "1/1", "cpu": "1/1"}}`
+
+	var raw ogmiosProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	_, err := raw.toProtocolParams()
+	if err == nil {
+		t.Fatal("expected an error for missing fee and deposit parameters")
+	}
+	required := []string{
+		"minFeeCoefficient",
+		"minFeeConstant",
+		"minUtxoDepositCoefficient",
+		"stakeCredentialDeposit",
+		"stakePoolDeposit",
+		"minStakePoolCost",
+	}
+	for _, field := range required {
+		if !strings.Contains(err.Error(), field) {
+			t.Errorf("error %q does not report missing %s", err, field)
+		}
+	}
+}
+
+// ogmiosV6ShelleyGenesisBody is a queryNetwork/genesisConfiguration result for
+// the Shelley era as Ogmios v6.x serves it, carrying the real mainnet values.
+// Note the two shapes that are easy to get wrong: activeSlotsCoefficient is an
+// exact ratio string, and slotLength is an object in milliseconds. The
+// initialParameters/initialFunds members are abridged; Apollo does not read
+// them.
+const ogmiosV6ShelleyGenesisBody = `{
+	"era": "shelley",
+	"startTime": "2017-09-23T21:44:51Z",
+	"networkMagic": 764824073,
+	"network": "mainnet",
+	"activeSlotsCoefficient": "1/20",
+	"securityParameter": 2160,
+	"epochLength": 432000,
+	"slotsPerKesPeriod": 129600,
+	"maxKesEvolutions": 62,
+	"slotLength": {"milliseconds": 1000},
+	"updateQuorum": 5,
+	"maxLovelaceSupply": 45000000000000000,
+	"initialParameters": {
+		"minFeeCoefficient": 44,
+		"minFeeConstant": {"ada": {"lovelace": 155381}}
+	},
+	"initialDelegates": [],
+	"initialFunds": {},
+	"initialStakePools": {"stakePools": {}, "delegators": {}}
+}`
+
+func decodeGenesisParams(
+	t *testing.T,
+	body string,
+) backend.GenesisParameters {
+	t.Helper()
+	var raw ogmiosGenesisConfig
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("failed to decode genesis config: %v", err)
+	}
+	gp, err := raw.toGenesisParams()
+	if err != nil {
+		t.Fatalf("failed to convert genesis config: %v", err)
+	}
+	return gp
+}
+
+// TestGenesisParamsDecodeOgmiosV6Response decodes a realistic Ogmios v6 Shelley
+// genesis response. activeSlotsCoefficient is a ratio string and slotLength is
+// {"milliseconds": N}; decoding either into a plain scalar makes the whole
+// GenesisParams call fail.
+func TestGenesisParamsDecodeOgmiosV6Response(t *testing.T) {
+	gp := decodeGenesisParams(t, ogmiosV6ShelleyGenesisBody)
+
+	if got, want := gp.ActiveSlotsCoefficient, 0.05; got != want {
+		t.Errorf("ActiveSlotsCoefficient = %v, want %v", got, want)
+	}
+	if got, want := gp.SlotLength, 1; got != want {
+		t.Errorf("SlotLength = %d seconds, want %d", got, want)
+	}
+	// 2017-09-23T21:44:51Z, the mainnet system start, in Unix seconds.
+	if got, want := gp.SystemStart, int64(1506203091); got != want {
+		t.Errorf("SystemStart = %d, want %d", got, want)
+	}
+
+	intFields := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"NetworkMagic", gp.NetworkMagic, 764824073},
+		{"SecurityParam", gp.SecurityParam, 2160},
+		{"EpochLength", gp.EpochLength, 432000},
+		{"SlotsPerKesPeriod", gp.SlotsPerKesPeriod, 129600},
+		{"MaxKesEvolutions", gp.MaxKesEvolutions, 62},
+		{"UpdateQuorum", gp.UpdateQuorum, 5},
+	}
+	for _, field := range intFields {
+		if field.got == 0 {
+			t.Errorf("%s is zero: value was silently dropped", field.name)
+			continue
+		}
+		if field.got != field.want {
+			t.Errorf("%s = %d, want %d", field.name, field.got, field.want)
+		}
+	}
+
+	if got, want := gp.MaxLovelaceSupply, "45000000000000000"; got != want {
+		t.Errorf("MaxLovelaceSupply = %q, want %q", got, want)
+	}
+}
+
+// TestGenesisParamsAcceptLegacyScalarShapes keeps the older Ogmios encodings
+// working: a bare number for the coefficient and whole seconds for the slot
+// length.
+func TestGenesisParamsAcceptLegacyScalarShapes(t *testing.T) {
+	const body = `{
+		"startTime": "2017-09-23T21:44:51Z",
+		"networkMagic": 764824073,
+		"activeSlotsCoefficient": 0.05,
+		"securityParameter": 2160,
+		"epochLength": 432000,
+		"slotsPerKesPeriod": 129600,
+		"maxKesEvolutions": 62,
+		"slotLength": 1,
+		"updateQuorum": 5,
+		"maxLovelaceSupply": 45000000000000000
+	}`
+
+	gp := decodeGenesisParams(t, body)
+	if got, want := gp.ActiveSlotsCoefficient, 0.05; got != want {
+		t.Errorf("ActiveSlotsCoefficient = %v, want %v", got, want)
+	}
+	if got, want := gp.SlotLength, 1; got != want {
+		t.Errorf("SlotLength = %d, want %d", got, want)
+	}
+}
+
+// TestGenesisParamsRejectUnrecognizedShapes holds the genesis decoding to the
+// same rule as the protocol parameters: a value Apollo cannot interpret is an
+// error, never a zero.
+func TestGenesisParamsRejectUnrecognizedShapes(t *testing.T) {
+	bodies := map[string]string{
+		"ratio object":       `{"activeSlotsCoefficient": {"ratio": "1/20"}}`,
+		"ratio not a number": `{"activeSlotsCoefficient": "one twentieth"}`,
+		"slot length object": `{"slotLength": {"seconds": 1}}`,
+		"slot length string": `{"slotLength": "1000ms"}`,
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			var raw ogmiosGenesisConfig
+			if err := json.Unmarshal([]byte(body), &raw); err == nil {
+				t.Fatalf(
+					"%s decoded without error; an unrecognized"+
+						" shape must not become a silent zero",
+					body,
+				)
+			}
+		})
+	}
+}
+
+// TestGenesisParamsRejectInvalidStartTime keeps an unparseable timestamp from
+// silently becoming a zero system start.
+func TestGenesisParamsRejectInvalidStartTime(t *testing.T) {
+	const body = `{"startTime": "yesterday"}`
+
+	var raw ogmiosGenesisConfig
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.toGenesisParams(); err == nil {
+		t.Fatal("expected an error for an unparseable start time")
 	}
 }


### PR DESCRIPTION
Two defects that made the Ogmios backend unable to produce a submittable transaction against any Ogmios released since February 2024.

**1. Every lovelace protocol parameter decoded as 0.** `ogmiosLovelace` expected `{"lovelace": N}`, the Ogmios **v6.0.x** shape. From **v6.1.0** onward these are `Value<AdaOnly>` — `{"ada": {"lovelace": N}}`. `encoding/json` ignores the unknown key, so the field stayed 0 **with no error**.

Affected `minFeeConstant`, `stakeCredentialDeposit`, `stakePoolDeposit`, `minStakePoolCost`. With `MinFeeConstant = 0` every fee was **155,381 lovelace short** → `FeeTooSmallUTxO`. Stake and pool deposits became 0, mis-balancing certificate transactions.

```
min fee for a 1024-byte tx = 45056, want 200437 (short by 155381)
```

**2. `GenesisParams()` failed against every real v6 deployment.** `slotLength` is `{"milliseconds":1000}`, not a scalar; `activeSlotsCoefficient` is a ratio string `"1/20"`, not a float64. `startTime` was unmapped entirely, leaving `SystemStart` a silent zero.

Both shapes are now accepted (v6.0 and v6.1+), and an unrecognized shape **errors** rather than becoming a silent zero. The six fee-critical parameters are decoded through pointers so a missing key is reported rather than defaulted — that set is a strict subset of Ogmios' own schema-required list in every version v6.0 → v7.0, so it cannot falsely reject a valid response.

Also maps `maxReferenceScriptsSize`, which was unmapped, under both its v6.5+ and v7.0 spellings.

The only pre-existing Ogmios parameter test used a synthetic two-field body with no lovelace parameters at all, which is why this shipped.

---

Found during a pre-2.0 audit. Verified: new tests fail on `master` and pass here; `go test -race -count=1 ./...` green; `golangci-lint run` 0 issues; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
