### PR TITLE
fix: validate addresses and reject cross-network transactions

### DIFF
--- a/address.go
+++ b/address.go
@@ -1,0 +1,290 @@
+package apollo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// addressHeaderLen is the length of the Shelley-era address header byte.
+const addressHeaderLen = 1
+
+// bech32AddressPrefixes are the bech32 human-readable parts Cardano uses for
+// payment and reward addresses, each including the bech32 separator. An input
+// carrying one of these prefixes is a bech32 address and must never be
+// re-interpreted as base58.
+var bech32AddressPrefixes = []string{
+	"addr1",
+	"addr_test1",
+	"stake1",
+	"stake_test1",
+}
+
+// ParseAddress decodes a Cardano address from its textual bech32 (Shelley and
+// later) or base58 (Byron) form and validates it before returning.
+//
+// It exists because common.NewAddress treats *any* bech32 failure - including
+// a checksum mismatch - as a reason to retry the input as base58. Every
+// character of a mainnet "addr1..." address is also a legal base58 character,
+// so a single mistyped character silently re-decodes into unrelated bytes and
+// the caller ends up building a payment for a different recipient. Testnet
+// addresses are accidentally immune because "_" is not base58, meaning the
+// fallthrough only misfires where real funds are.
+//
+// Validation is threefold:
+//
+//  1. Non-Byron addresses must re-encode to exactly the input text.
+//     Address.String() only ever emits a canonical bech32 string, so an input
+//     that survives the comparison necessarily carried a valid checksum, and
+//     its human-readable part necessarily agrees with the network id and
+//     address type in the header byte. common.NewAddress ignores the
+//     human-readable part entirely, so this is also what stops an
+//     "addr1..."-prefixed string from being accepted as a testnet address.
+//  2. Byron addresses are accepted only when the input does not carry a
+//     bech32 address prefix, so a corrupted "addr1..." string can never be
+//     laundered through the base58 path. Byron addresses embed their own
+//     CRC32 checksum, which gouroboros verifies while decoding.
+//  3. The decoded payload length must match the address type exactly, which
+//     rejects trailing bytes, and the network id must be one Cardano actually
+//     has (0 for testnets, 1 for mainnet).
+func ParseAddress(text string) (common.Address, error) {
+	if text == "" {
+		return common.Address{}, errors.New("address is empty")
+	}
+	addr, err := common.NewAddress(text)
+	if err != nil {
+		return common.Address{}, fmt.Errorf(
+			"%q is not a valid bech32 or base58 address: %w",
+			text,
+			err,
+		)
+	}
+	if addr.Type() == common.AddressTypeByron {
+		if hasBech32AddressPrefix(text) {
+			return common.Address{}, fmt.Errorf(
+				"%q has a bech32 address prefix but decoded as a Byron "+
+					"address; it is not a valid address",
+				text,
+			)
+		}
+	} else {
+		canonical, err := canonicalAddressText(addr)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("invalid address %q: %w", text, err)
+		}
+		if !strings.EqualFold(canonical, text) {
+			return common.Address{}, fmt.Errorf(
+				"%q is not a canonical Cardano address: it decodes to %q "+
+					"(bad checksum, wrong prefix for the address network or "+
+					"type, or a non-canonical encoding)",
+				text,
+				canonical,
+			)
+		}
+	}
+	if err := validateAddress(addr); err != nil {
+		return common.Address{}, fmt.Errorf("invalid address %q: %w", text, err)
+	}
+	return addr, nil
+}
+
+// canonicalAddressText returns the canonical textual form of a non-Byron
+// address. Serialization is checked first because Address.String() panics
+// rather than returning an error when an address cannot be serialized, and a
+// malformed address must produce an error.
+func canonicalAddressText(addr common.Address) (string, error) {
+	if _, err := addr.Bytes(); err != nil {
+		return "", fmt.Errorf("address cannot be serialized: %w", err)
+	}
+	return addr.String(), nil
+}
+
+// validateAddress checks the structural invariants of a decoded address: a
+// network id that exists on Cardano and a payload whose length matches the
+// address type, so trailing bytes are never accepted.
+func validateAddress(addr common.Address) error {
+	raw, err := addr.Bytes()
+	if err != nil {
+		return fmt.Errorf("failed to serialize address: %w", err)
+	}
+	if addr.Type() == common.AddressTypeByron {
+		// Byron addresses are CBOR carrying an embedded CRC32 checksum; both
+		// are verified while decoding, and their length is not fixed.
+		return nil
+	}
+	if err := validateAddressNetworkId(addr.NetworkId()); err != nil {
+		return err
+	}
+	want, err := expectedAddressLen(addr)
+	if err != nil {
+		return err
+	}
+	if len(raw) != want {
+		return fmt.Errorf(
+			"address type %d payload is %d bytes, expected %d",
+			addr.Type(),
+			len(raw),
+			want,
+		)
+	}
+	return nil
+}
+
+// validateAddressNetworkId rejects the network ids that fit in the address
+// header nibble but do not exist on Cardano. Only 0 (testnets) and 1
+// (mainnet) are defined; common.Address.populateFromBytes accepts 2-15.
+func validateAddressNetworkId(networkId uint) error {
+	switch networkId {
+	case common.AddressNetworkTestnet, common.AddressNetworkMainnet:
+		return nil
+	default:
+		return fmt.Errorf(
+			"unknown network id %d: Cardano defines only %d (testnet) and "+
+				"%d (mainnet)",
+			networkId,
+			common.AddressNetworkTestnet,
+			common.AddressNetworkMainnet,
+		)
+	}
+}
+
+// expectedAddressLen returns the exact serialized length of a non-Byron
+// address of the given type.
+func expectedAddressLen(addr common.Address) (int, error) {
+	switch addr.Type() {
+	case common.AddressTypeKeyKey,
+		common.AddressTypeScriptKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeScriptScript:
+		return addressHeaderLen + 2*common.AddressHashSize, nil
+	case common.AddressTypeKeyNone,
+		common.AddressTypeScriptNone,
+		common.AddressTypeNoneKey,
+		common.AddressTypeNoneScript:
+		return addressHeaderLen + common.AddressHashSize, nil
+	case common.AddressTypeKeyPointer, common.AddressTypeScriptPointer:
+		pointer, ok := addr.StakingPayload().(common.AddressPayloadPointer)
+		if !ok {
+			return 0, errors.New("pointer address has no pointer payload")
+		}
+		return addressHeaderLen + common.AddressHashSize +
+			varUintLen(pointer.Slot) +
+			varUintLen(pointer.TxIndex) +
+			varUintLen(pointer.CertIndex), nil
+	default:
+		return 0, fmt.Errorf("unsupported address type %d", addr.Type())
+	}
+}
+
+// varUintLen returns the number of bytes the variable-length integer encoding
+// used by pointer addresses needs for v.
+func varUintLen(v uint64) int {
+	n := 1
+	for v >= 128 {
+		v /= 128
+		n++
+	}
+	return n
+}
+
+// hasBech32AddressPrefix reports whether text starts with a Cardano bech32
+// address human-readable part. bech32 allows an all-uppercase encoding, so the
+// comparison is case-insensitive.
+func hasBech32AddressPrefix(text string) bool {
+	lower := strings.ToLower(text)
+	for _, prefix := range bech32AddressPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateAddressNetworks fails closed when any address the transaction
+// commits to belongs to a different network than the chain context. Nothing
+// else in the builder compares addresses against Context.NetworkId(), which
+// is copied into the transaction body verbatim, so without this check a
+// mainnet-derived wallet pointed at a preprod context (or a preprod payee
+// pasted into a mainnet builder) builds and signs a transaction that either
+// is rejected by the node as WrongNetwork or looks valid while paying an
+// address the sender cannot reach.
+func (a *Apollo) validateAddressNetworks() error {
+	network := uint(a.Context.NetworkId())
+	if err := validateAddressNetworkId(network); err != nil {
+		return fmt.Errorf("chain context has an invalid network: %w", err)
+	}
+	check := func(role string, index int, addr common.Address) error {
+		if addr.NetworkId() == network {
+			return nil
+		}
+		if index < 0 {
+			return fmt.Errorf(
+				"network mismatch: %s %s is on network %d, but the chain "+
+					"context is on network %d",
+				role,
+				addr.String(),
+				addr.NetworkId(),
+				network,
+			)
+		}
+		return fmt.Errorf(
+			"network mismatch: %s %d (%s) is on network %d, but the chain "+
+				"context is on network %d",
+			role,
+			index,
+			addr.String(),
+			addr.NetworkId(),
+			network,
+		)
+	}
+	if a.wallet != nil {
+		if err := check("wallet address", -1, a.wallet.Address()); err != nil {
+			return err
+		}
+	}
+	// The resolved change address is either the explicit one or the wallet
+	// address, which is checked above.
+	if a.changeAddress != nil {
+		if err := check("change address", -1, *a.changeAddress); err != nil {
+			return err
+		}
+	}
+	for i, addr := range a.inputAddresses {
+		if err := check("input address", i, addr); err != nil {
+			return err
+		}
+	}
+	for i, payment := range a.payments {
+		txOut, err := payment.ToTxOut()
+		if err != nil {
+			return fmt.Errorf("failed to resolve payment %d: %w", i, err)
+		}
+		if txOut == nil {
+			continue
+		}
+		if err := check("payment receiver", i, txOut.Address()); err != nil {
+			return err
+		}
+	}
+	utxoGroups := []struct {
+		role  string
+		utxos []common.Utxo
+	}{
+		{"input UTxO", a.preselectedUtxos},
+		{"available UTxO", a.utxos},
+		{"collateral UTxO", a.collaterals},
+	}
+	for _, group := range utxoGroups {
+		for i, utxo := range group.utxos {
+			if utxo.Output == nil {
+				continue
+			}
+			if err := check(group.role, i, utxo.Output.Address()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/address_validation_test.go
+++ b/address_validation_test.go
@@ -1,0 +1,429 @@
+package apollo
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Every address in this file is synthetic: the payment and staking
+// credentials are fixed byte patterns, so no real wallet, no real user and no
+// real funds are involved. They exercise textual address decoding only.
+
+// syntheticAddress builds an address of the given type and network from fixed
+// credential bytes.
+func syntheticAddress(t *testing.T, addrType, network uint8) common.Address {
+	t.Helper()
+	payment := bytes.Repeat([]byte{0xaa}, common.AddressHashSize)
+	stake := bytes.Repeat([]byte{0xbb}, common.AddressHashSize)
+	switch addrType {
+	case common.AddressTypeKeyKey,
+		common.AddressTypeScriptKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeScriptScript:
+	case common.AddressTypeKeyNone, common.AddressTypeScriptNone:
+		stake = nil
+	case common.AddressTypeNoneKey, common.AddressTypeNoneScript:
+		payment = nil
+	default:
+		t.Fatalf("unsupported synthetic address type %d", addrType)
+	}
+	addr, err := common.NewAddressFromParts(addrType, network, payment, stake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+// mainnetSweepAddress is the synthetic mainnet base address the corruption
+// sweep mutates. Mainnet matters: every character of an "addr1..." string is
+// also a legal base58 character, which is what makes the bech32-to-base58
+// fallthrough dangerous there and harmless on "addr_test1..." addresses.
+func mainnetSweepAddress(t *testing.T) string {
+	t.Helper()
+	addr := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	return addr.String()
+}
+
+// addressCorruptionAlphabet is the bech32 data charset plus characters that
+// are illegal in bech32 but legal in base58 ("b", "i", "o") and the bech32
+// separator ("1"), which moves the human-readable part when substituted in.
+const addressCorruptionAlphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l1bio"
+
+// addressCorruptions returns every single-character corruption of addr that
+// leaves the human-readable part intact: substitution, insertion, deletion,
+// doubling and truncation. The HRP is preserved on purpose, because that is
+// what a realistic typo looks like and what routes the string into the
+// dangerous decode path.
+func addressCorruptions(t *testing.T, addr string) []string {
+	t.Helper()
+	sep := strings.IndexByte(addr, '1')
+	if sep < 0 {
+		t.Fatalf("address %q has no bech32 separator", addr)
+	}
+	start := sep + 1
+	capacity := 8 * len(addr) * len(addressCorruptionAlphabet)
+	seen := make(map[string]struct{}, capacity)
+	out := make([]string, 0, capacity)
+	add := func(candidate string) {
+		if candidate == addr {
+			return
+		}
+		if _, dup := seen[candidate]; dup {
+			return
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	for i := start; i < len(addr); i++ {
+		// substitute
+		for _, c := range addressCorruptionAlphabet {
+			add(addr[:i] + string(c) + addr[i+1:])
+		}
+		// delete
+		add(addr[:i] + addr[i+1:])
+		// double
+		add(addr[:i] + addr[i:i+1] + addr[i:])
+		// truncate
+		add(addr[:i])
+	}
+	// insert, including at the very end
+	for i := start; i <= len(addr); i++ {
+		for _, c := range addressCorruptionAlphabet {
+			add(addr[:i] + string(c) + addr[i:])
+		}
+	}
+	return out
+}
+
+// addressEntryPoints are the builder entry points that turn caller-supplied
+// address text into an address Apollo will pay, spend from, or send change to.
+func addressEntryPoints() []struct {
+	name  string
+	parse func(string) error
+} {
+	return []struct {
+		name  string
+		parse func(string) error
+	}{
+		{
+			"PayToAddressBech32",
+			func(text string) error {
+				_, err := New(setupFixedContext()).
+					PayToAddressBech32(text, 2_000_000)
+				return err
+			},
+		},
+		{
+			"SetChangeAddressBech32",
+			func(text string) error {
+				_, err := New(setupFixedContext()).
+					SetChangeAddressBech32(text)
+				return err
+			},
+		},
+		{
+			"AddInputAddressFromBech32",
+			func(text string) error {
+				_, err := New(setupFixedContext()).
+					AddInputAddressFromBech32(text)
+				return err
+			},
+		},
+		{
+			"NewPayment",
+			func(text string) error {
+				_, err := NewPayment(text, 2_000_000, nil)
+				return err
+			},
+		},
+	}
+}
+
+// TestAddressEntryPointsRejectCorruptedMainnetAddress sweeps single-character
+// corruptions of a mainnet address through every entry point. A bech32
+// checksum failure must never be retried as base58: on master these inputs
+// silently decode into unrelated bytes and Apollo builds a payment to a
+// different recipient.
+func TestAddressEntryPointsRejectCorruptedMainnetAddress(t *testing.T) {
+	valid := mainnetSweepAddress(t)
+	corruptions := addressCorruptions(t, valid)
+	if len(corruptions) < 6000 {
+		t.Fatalf("sweep is too small: %d corruptions", len(corruptions))
+	}
+	for _, entry := range addressEntryPoints() {
+		accepted := 0
+		var samples []string
+		for _, corrupted := range corruptions {
+			if err := entry.parse(corrupted); err == nil {
+				accepted++
+				if len(samples) < 3 {
+					samples = append(samples, corrupted)
+				}
+			}
+		}
+		if accepted != 0 {
+			t.Errorf(
+				"%s accepted %d of %d corrupted mainnet addresses; e.g. %v",
+				entry.name,
+				accepted,
+				len(corruptions),
+				samples,
+			)
+		} else {
+			t.Logf(
+				"%s rejected all %d corrupted mainnet addresses",
+				entry.name,
+				len(corruptions),
+			)
+		}
+	}
+}
+
+// TestAddressEntryPointsAcceptValidAddresses guards against the validation
+// being too strict: every canonical address form must still round-trip.
+func TestAddressEntryPointsAcceptValidAddresses(t *testing.T) {
+	types := []uint8{
+		common.AddressTypeKeyKey,
+		common.AddressTypeScriptKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeScriptScript,
+		common.AddressTypeKeyNone,
+		common.AddressTypeScriptNone,
+		common.AddressTypeNoneKey,
+		common.AddressTypeNoneScript,
+	}
+	networks := []uint8{
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	}
+	valid := make([]string, 0, len(types)*len(networks)+1)
+	for _, network := range networks {
+		for _, addrType := range types {
+			valid = append(
+				valid,
+				syntheticAddress(t, addrType, network).String(),
+			)
+		}
+	}
+	byron, err := common.NewByronAddressFromParts(
+		common.ByronAddressTypePubkey,
+		bytes.Repeat([]byte{0xaa}, common.AddressHashSize),
+		common.ByronAddressAttributes{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid = append(valid, byron.String())
+
+	for _, entry := range addressEntryPoints() {
+		for _, text := range valid {
+			if err := entry.parse(text); err != nil {
+				t.Errorf("%s rejected valid address %q: %v",
+					entry.name, text, err)
+			}
+		}
+	}
+}
+
+// TestPayToAddressBech32PreservesReceiver verifies the accepted address is
+// the one the caller asked for, byte for byte.
+func TestPayToAddressBech32PreservesReceiver(t *testing.T) {
+	want := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	a, err := New(setupFixedContext()).
+		PayToAddressBech32(want.String(), 2_000_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payment, ok := a.payments[0].(*Payment)
+	if !ok {
+		t.Fatalf("unexpected payment type %T", a.payments[0])
+	}
+	got, err := payment.Receiver.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBytes, err := want.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, wantBytes) {
+		t.Fatalf("receiver = %x, want %x", got, wantBytes)
+	}
+}
+
+// TestAddressEntryPointsRejectTrailingPayloadBytes covers the case that came
+// closest to being fatal in the wild: a base-address payload with a single
+// extra byte, which the ledger's lenient Byron-compatibility path can accept.
+func TestAddressEntryPointsRejectTrailingPayloadBytes(t *testing.T) {
+	base := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	raw, err := base.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 1+2*common.AddressHashSize {
+		t.Fatalf("unexpected base address length %d", len(raw))
+	}
+	withTrailing, err := common.NewAddressFromBytes(append(raw, 0xcc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := withTrailing.String()
+	for _, entry := range addressEntryPoints() {
+		if err := entry.parse(text); err == nil {
+			t.Errorf("%s accepted a 58-byte address payload %q",
+				entry.name, text)
+		}
+	}
+}
+
+// TestAddressEntryPointsAcceptPointerAddress guards the variable-length
+// pointer address form against the payload-length validation.
+func TestAddressEntryPointsAcceptPointerAddress(t *testing.T) {
+	pointers := [][]byte{
+		{0, 0, 0},
+		{0x81, 0x00, 0x7f, 0x01},
+	}
+	for _, pointer := range pointers {
+		addr, err := common.NewAddressFromParts(
+			common.AddressTypeKeyPointer,
+			common.AddressNetworkMainnet,
+			bytes.Repeat([]byte{0xaa}, common.AddressHashSize),
+			pointer,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := addr.String()
+		for _, entry := range addressEntryPoints() {
+			if err := entry.parse(text); err != nil {
+				t.Errorf("%s rejected pointer address %q: %v",
+					entry.name, text, err)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectPointerAddressTrailingBytes covers trailing
+// bytes after a pointer address's variable-length staking payload.
+func TestAddressEntryPointsRejectPointerAddressTrailingBytes(t *testing.T) {
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyPointer,
+		common.AddressNetworkMainnet,
+		bytes.Repeat([]byte{0xaa}, common.AddressHashSize),
+		[]byte{0, 0, 0, 0xcc},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := addr.String()
+	for _, entry := range addressEntryPoints() {
+		if err := entry.parse(text); err == nil {
+			t.Errorf("%s accepted trailing bytes in pointer address %q",
+				entry.name, text)
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectUnknownAddressType covers the header type
+// nibbles 9-13, which Cardano does not define.
+func TestAddressEntryPointsRejectUnknownAddressType(t *testing.T) {
+	for addrType := uint8(9); addrType <= 13; addrType++ {
+		raw := make([]byte, 1+2*common.AddressHashSize)
+		raw[0] = (addrType << 4) | common.AddressNetworkMainnet
+		for i := range common.AddressHashSize {
+			raw[1+i] = 0xaa
+			raw[1+common.AddressHashSize+i] = 0xbb
+		}
+		addr, err := common.NewAddressFromBytes(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := addr.String()
+		for _, entry := range addressEntryPoints() {
+			if err := entry.parse(text); err == nil {
+				t.Errorf("%s accepted unknown address type %d in %q",
+					entry.name, addrType, text)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectUnknownNetworkId covers network nibbles 2-15,
+// which fit in the header byte but do not exist on Cardano.
+func TestAddressEntryPointsRejectUnknownNetworkId(t *testing.T) {
+	for network := uint8(2); network < 16; network++ {
+		raw := make([]byte, 1+2*common.AddressHashSize)
+		raw[0] = (common.AddressTypeKeyKey << 4) | network
+		for i := range common.AddressHashSize {
+			raw[1+i] = 0xaa
+			raw[1+common.AddressHashSize+i] = 0xbb
+		}
+		addr, err := common.NewAddressFromBytes(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := addr.String()
+		for _, entry := range addressEntryPoints() {
+			if err := entry.parse(text); err == nil {
+				t.Errorf("%s accepted network id %d in %q",
+					entry.name, network, text)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectMalformedText covers inputs that are not
+// addresses at all. None of them may panic.
+func TestAddressEntryPointsRejectMalformedText(t *testing.T) {
+	valid := mainnetSweepAddress(t)
+	malformed := []string{
+		"",
+		" ",
+		"addr1",
+		"addr_test1",
+		"stake1",
+		"not-a-valid-address",
+		"invalid",
+		" " + valid,
+		valid + " ",
+		strings.ToUpper(valid[:5]) + valid[5:], // mixed case
+		"addr_test1" + valid[5:],               // testnet prefix, mainnet body
+		"addr1" + valid[10:],                   // mainnet prefix, short body
+		"DdzFF",
+	}
+	for _, entry := range addressEntryPoints() {
+		for _, text := range malformed {
+			if err := entry.parse(text); err == nil {
+				t.Errorf("%s accepted malformed address %q", entry.name, text)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsAcceptUppercaseBech32 locks in existing behavior:
+// bech32 permits an all-uppercase encoding, and it decodes to the same
+// address, so it must keep working.
+func TestAddressEntryPointsAcceptUppercaseBech32(t *testing.T) {
+	upper := strings.ToUpper(mainnetSweepAddress(t))
+	for _, entry := range addressEntryPoints() {
+		if err := entry.parse(upper); err != nil {
+			t.Errorf("%s rejected uppercase bech32 %q: %v",
+				entry.name, upper, err)
+		}
+	}
+}

--- a/apollo.go
+++ b/apollo.go
@@ -1482,6 +1482,14 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, err
 	}
 
+	// Every address this transaction commits to must be on the network the
+	// chain context is on. Checked here because the wallet, change, input and
+	// payment addresses are all resolved by this point, and before any
+	// selection or fee work so a cross-network build fails closed and early.
+	if err := a.validateAddressNetworks(); err != nil {
+		return a, err
+	}
+
 	// Auto-select collateral if needed (after UTxOs are loaded)
 	if err := a.setCollateral(); err != nil {
 		return a, err

--- a/convenience.go
+++ b/convenience.go
@@ -10,7 +10,7 @@ import (
 
 // AddInputAddressFromBech32 adds a bech32 address whose UTxOs should be used for coin selection.
 func (a *Apollo) AddInputAddressFromBech32(bech32 string) (*Apollo, error) {
-	addr, err := common.NewAddress(bech32)
+	addr, err := ParseAddress(bech32)
 	if err != nil {
 		return a, fmt.Errorf("invalid bech32 address: %w", err)
 	}
@@ -20,7 +20,7 @@ func (a *Apollo) AddInputAddressFromBech32(bech32 string) (*Apollo, error) {
 
 // PayToAddressBech32 creates a simple payment to a bech32 address.
 func (a *Apollo) PayToAddressBech32(bech32 string, lovelace int64, units ...Unit) (*Apollo, error) {
-	addr, err := common.NewAddress(bech32)
+	addr, err := ParseAddress(bech32)
 	if err != nil {
 		return a, fmt.Errorf("invalid bech32 address: %w", err)
 	}
@@ -30,7 +30,7 @@ func (a *Apollo) PayToAddressBech32(bech32 string, lovelace int64, units ...Unit
 
 // SetChangeAddressBech32 sets the change address from a bech32 string.
 func (a *Apollo) SetChangeAddressBech32(bech32 string) (*Apollo, error) {
-	addr, err := common.NewAddress(bech32)
+	addr, err := ParseAddress(bech32)
 	if err != nil {
 		return a, fmt.Errorf("invalid bech32 address: %w", err)
 	}

--- a/models.go
+++ b/models.go
@@ -125,7 +125,7 @@ type Payment struct {
 
 // NewPayment creates a new Payment.
 func NewPayment(receiver string, lovelace int64, units []Unit) (*Payment, error) {
-	addr, err := common.NewAddress(receiver)
+	addr, err := ParseAddress(receiver)
 	if err != nil {
 		return nil, fmt.Errorf("invalid receiver address: %w", err)
 	}

--- a/network_validation_test.go
+++ b/network_validation_test.go
@@ -1,0 +1,232 @@
+package apollo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// networkTestContext returns a fixed chain context on the given network, with
+// the same protocol and genesis parameters the empty fixed context uses.
+func networkTestContext(t *testing.T, network uint8) *fixed.FixedChainContext {
+	t.Helper()
+	base := fixed.NewEmptyFixedChainContext()
+	pp, err := base.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gp, err := base.GenesisParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixed.NewFixedChainContext(pp, gp, network)
+}
+
+// networkTestBuilder returns a builder funded on the wallet's own network,
+// ready for Complete().
+func networkTestBuilder(
+	t *testing.T,
+	contextNetwork, walletNetwork uint8,
+) *Apollo {
+	t.Helper()
+	cc := networkTestContext(t, contextNetwork)
+	walletAddr := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		walletNetwork,
+	)
+	addTestUtxo(cc, walletAddr, 10_000_000, 0x01, 0)
+	return New(cc).
+		SetWallet(NewExternalWallet(walletAddr)).
+		SetTtl(50000000)
+}
+
+func requireNetworkMismatch(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a network mismatch error, got none")
+	}
+	if !strings.Contains(err.Error(), "network mismatch") {
+		t.Fatalf("expected a network mismatch error, got: %v", err)
+	}
+}
+
+// TestCompleteRejectsOutputAddressOnOtherNetwork covers a preprod payee
+// pasted into a mainnet builder, and the reverse.
+func TestCompleteRejectsOutputAddressOnOtherNetwork(t *testing.T) {
+	for _, network := range []uint8{
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	} {
+		foreign := common.AddressNetworkMainnet
+		if network == common.AddressNetworkMainnet {
+			foreign = common.AddressNetworkTestnet
+		}
+		payee := syntheticAddress(t, common.AddressTypeKeyKey, uint8(foreign))
+		a := networkTestBuilder(t, network, network).
+			PayToAddress(payee, 2_000_000)
+		_, err := a.Complete()
+		requireNetworkMismatch(t, err)
+	}
+}
+
+// TestCompleteRejectsChangeAddressOnOtherNetwork covers change silently
+// leaving for an address on the wrong network.
+func TestCompleteRejectsChangeAddressOnOtherNetwork(t *testing.T) {
+	change := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkMainnet,
+		common.AddressNetworkMainnet,
+	)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	_, err := a.
+		PayToAddress(payee, 2_000_000).
+		SetChangeAddress(change).
+		Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteRejectsWalletOnOtherNetwork covers the bursa default: a wallet
+// derived for mainnet pointed at a preprod context for testing.
+func TestCompleteRejectsWalletOnOtherNetwork(t *testing.T) {
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	_, err := a.PayToAddress(payee, 2_000_000).Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteRejectsInputAddressOnOtherNetwork covers coin selection sourced
+// from an address on the wrong network.
+func TestCompleteRejectsInputAddressOnOtherNetwork(t *testing.T) {
+	foreign := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkTestnet,
+		common.AddressNetworkTestnet,
+	)
+	_, err := a.
+		AddInputAddress(foreign).
+		PayToAddress(payee, 2_000_000).
+		Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteRejectsInputUtxoOnOtherNetwork covers a pinned input whose
+// output address is on the wrong network.
+func TestCompleteRejectsInputUtxoOnOtherNetwork(t *testing.T) {
+	foreignCtx := networkTestContext(t, common.AddressNetworkMainnet)
+	foreignAddr := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	addTestUtxo(foreignCtx, foreignAddr, 10_000_000, 0x09, 0)
+	foreignUtxos, err := foreignCtx.Utxos(foreignAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(foreignUtxos) != 1 {
+		t.Fatalf("expected 1 UTxO, got %d", len(foreignUtxos))
+	}
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkTestnet,
+		common.AddressNetworkTestnet,
+	)
+	_, err = a.
+		AddInput(foreignUtxos[0]).
+		PayToAddress(payee, 2_000_000).
+		Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteAcceptsMatchingNetworks proves the check never blocks a caller
+// whose wallet, payee, change and context all agree - including the mainnet
+// case, where the wallet network is bursa's default.
+func TestCompleteAcceptsMatchingNetworks(t *testing.T) {
+	for _, network := range []uint8{
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	} {
+		a := networkTestBuilder(t, network, network)
+		payee := syntheticAddress(t, common.AddressTypeKeyKey, network)
+		change := syntheticAddress(t, common.AddressTypeKeyNone, network)
+		a, err := a.
+			PayToAddress(payee, 2_000_000).
+			SetChangeAddress(change).
+			Complete()
+		if err != nil {
+			t.Fatalf("network %d: unexpected error: %v", network, err)
+		}
+		tx := a.GetTx()
+		if tx == nil {
+			t.Fatalf("network %d: expected a transaction", network)
+		}
+		if tx.Body.TxNetworkId == nil {
+			t.Fatalf("network %d: expected a network id in the body", network)
+		}
+		if *tx.Body.TxNetworkId != network {
+			t.Fatalf("network %d: body network id = %d",
+				network, *tx.Body.TxNetworkId)
+		}
+		for i, out := range tx.Body.TxOutputs {
+			addr := out.Address()
+			if addr.NetworkId() != uint(network) {
+				t.Fatalf("network %d: output %d is on network %d",
+					network, i, addr.NetworkId())
+			}
+		}
+	}
+}
+
+// TestCompleteRejectsContextWithUnknownNetworkId covers a backend reporting a
+// network id Cardano does not have.
+func TestCompleteRejectsContextWithUnknownNetworkId(t *testing.T) {
+	a := networkTestBuilder(t, 7, common.AddressNetworkTestnet)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	_, err := a.PayToAddress(payee, 2_000_000).Complete()
+	if err == nil {
+		t.Fatal("expected an error for an unknown context network id")
+	}
+	if !strings.Contains(err.Error(), "invalid network") {
+		t.Fatalf("expected an invalid network error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Two defects with the same theme: Apollo accepted addresses it had not actually validated. Both could send real funds to the wrong place.

**1. A bech32 checksum failure fell through to base58.** All four entry points call `common.NewAddress`, which treats *any* bech32 error — including an invalid checksum — as a signal to try base58. Shelley addresses are composed entirely of base58-legal characters, so a corrupted `addr1…` silently decoded to unrelated bytes.

A sweep of 7,091 single-character corruptions (substitute/insert/delete/double/truncate, HRP intact):

| entry point | before | after |
|---|---|---|
| `PayToAddressBech32` | accepted 6635 / 7091 | **0** |
| `SetChangeAddressBech32` | accepted 6635 / 7091 | **0** |
| `AddInputAddressFromBech32` | accepted 6635 / 7091 | **0** |
| `NewPayment` | accepted 6635 / 7091 | **0** |

Filed upstream as [gouroboros#1930](https://github.com/blinklabs-io/gouroboros/issues/1930); fixed in Apollo regardless.

The new `ParseAddress` rests on a provable invariant rather than re-implementing bech32: a non-Byron address must re-encode to exactly the input text. `Address.String()` only ever emits a canonical bech32 string, so `EqualFold(addr.String(), input)` implies a valid checksum *and* an HRP matching the header byte's network and address type (the HRP was previously ignored entirely). Byron/base58 is attempted only when the input carries no bech32 address prefix. `validateAddress` then requires the payload length to match the address type exactly, rejecting trailing bytes, and the network id to be 0 or 1.

**2. No network-tag validation anywhere.** `body.TxNetworkId` was copied from the context, but no output, change, input, or wallet address was ever checked against it — so a mainnet wallet built a `network_id=0` transaction without complaint.

`validateAddressNetworks` has one call site in `Complete()`, placed after `loadUtxos()` where wallet, change, input and payment addresses are all resolved and before any selection or fee work. Errors name the role, the offending address, and both network ids.

**Behaviour changes for release notes:** addresses carrying trailing extra-data bytes and non-canonical bech32 forms are now rejected as payees; all-uppercase bech32 is still accepted and locked in by a test. Cross-network addresses now fail at `Complete()` instead of building.

**Not fixed here** (deferred to avoid concurrent edits to `apollo.go`): `resolveCredential` is a fifth bech32 entry point still calling `common.NewAddress` directly, behind `RegisterStake`/`DelegateStake`/`DelegateVote`. One-line change; produces a garbage stake credential rather than a misdirected payment. Backends also parse remote addresses unvalidated.

---

Found during a pre-2.0 audit. Verified: new tests fail on `master` and pass here; `go test -race -count=1 ./...` green; `golangci-lint run` 0 issues; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
