### PR TITLE
fix!: resolve v2.0 release blockers in the builder, backends, and hashing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ golangci-lint run
 | `backend/fixed/` | Deterministic in-memory test backend |
 | `plutusencoder/` | Struct-tag-driven Plutus data marshaling |
 | `constants/` | Network constants |
+| `internal/backendutil/` | Provider response parsing helpers (not public API) |
 
 ### Key Interfaces
 

--- a/address.go
+++ b/address.go
@@ -1,0 +1,290 @@
+package apollo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// addressHeaderLen is the length of the Shelley-era address header byte.
+const addressHeaderLen = 1
+
+// bech32AddressPrefixes are the bech32 human-readable parts Cardano uses for
+// payment and reward addresses, each including the bech32 separator. An input
+// carrying one of these prefixes is a bech32 address and must never be
+// re-interpreted as base58.
+var bech32AddressPrefixes = []string{
+	"addr1",
+	"addr_test1",
+	"stake1",
+	"stake_test1",
+}
+
+// ParseAddress decodes a Cardano address from its textual bech32 (Shelley and
+// later) or base58 (Byron) form and validates it before returning.
+//
+// It exists because common.NewAddress treats *any* bech32 failure - including
+// a checksum mismatch - as a reason to retry the input as base58. Every
+// character of a mainnet "addr1..." address is also a legal base58 character,
+// so a single mistyped character silently re-decodes into unrelated bytes and
+// the caller ends up building a payment for a different recipient. Testnet
+// addresses are accidentally immune because "_" is not base58, meaning the
+// fallthrough only misfires where real funds are.
+//
+// Validation is threefold:
+//
+//  1. Non-Byron addresses must re-encode to exactly the input text.
+//     Address.String() only ever emits a canonical bech32 string, so an input
+//     that survives the comparison necessarily carried a valid checksum, and
+//     its human-readable part necessarily agrees with the network id and
+//     address type in the header byte. common.NewAddress ignores the
+//     human-readable part entirely, so this is also what stops an
+//     "addr1..."-prefixed string from being accepted as a testnet address.
+//  2. Byron addresses are accepted only when the input does not carry a
+//     bech32 address prefix, so a corrupted "addr1..." string can never be
+//     laundered through the base58 path. Byron addresses embed their own
+//     CRC32 checksum, which gouroboros verifies while decoding.
+//  3. The decoded payload length must match the address type exactly, which
+//     rejects trailing bytes, and the network id must be one Cardano actually
+//     has (0 for testnets, 1 for mainnet).
+func ParseAddress(text string) (common.Address, error) {
+	if text == "" {
+		return common.Address{}, errors.New("address is empty")
+	}
+	addr, err := common.NewAddress(text)
+	if err != nil {
+		return common.Address{}, fmt.Errorf(
+			"%q is not a valid bech32 or base58 address: %w",
+			text,
+			err,
+		)
+	}
+	if addr.Type() == common.AddressTypeByron {
+		if hasBech32AddressPrefix(text) {
+			return common.Address{}, fmt.Errorf(
+				"%q has a bech32 address prefix but decoded as a Byron "+
+					"address; it is not a valid address",
+				text,
+			)
+		}
+	} else {
+		canonical, err := canonicalAddressText(addr)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("invalid address %q: %w", text, err)
+		}
+		if !strings.EqualFold(canonical, text) {
+			return common.Address{}, fmt.Errorf(
+				"%q is not a canonical Cardano address: it decodes to %q "+
+					"(bad checksum, wrong prefix for the address network or "+
+					"type, or a non-canonical encoding)",
+				text,
+				canonical,
+			)
+		}
+	}
+	if err := validateAddress(addr); err != nil {
+		return common.Address{}, fmt.Errorf("invalid address %q: %w", text, err)
+	}
+	return addr, nil
+}
+
+// canonicalAddressText returns the canonical textual form of a non-Byron
+// address. Serialization is checked first because Address.String() panics
+// rather than returning an error when an address cannot be serialized, and a
+// malformed address must produce an error.
+func canonicalAddressText(addr common.Address) (string, error) {
+	if _, err := addr.Bytes(); err != nil {
+		return "", fmt.Errorf("address cannot be serialized: %w", err)
+	}
+	return addr.String(), nil
+}
+
+// validateAddress checks the structural invariants of a decoded address: a
+// network id that exists on Cardano and a payload whose length matches the
+// address type, so trailing bytes are never accepted.
+func validateAddress(addr common.Address) error {
+	raw, err := addr.Bytes()
+	if err != nil {
+		return fmt.Errorf("failed to serialize address: %w", err)
+	}
+	if addr.Type() == common.AddressTypeByron {
+		// Byron addresses are CBOR carrying an embedded CRC32 checksum; both
+		// are verified while decoding, and their length is not fixed.
+		return nil
+	}
+	if err := validateAddressNetworkId(addr.NetworkId()); err != nil {
+		return err
+	}
+	want, err := expectedAddressLen(addr)
+	if err != nil {
+		return err
+	}
+	if len(raw) != want {
+		return fmt.Errorf(
+			"address type %d payload is %d bytes, expected %d",
+			addr.Type(),
+			len(raw),
+			want,
+		)
+	}
+	return nil
+}
+
+// validateAddressNetworkId rejects the network ids that fit in the address
+// header nibble but do not exist on Cardano. Only 0 (testnets) and 1
+// (mainnet) are defined; common.Address.populateFromBytes accepts 2-15.
+func validateAddressNetworkId(networkId uint) error {
+	switch networkId {
+	case common.AddressNetworkTestnet, common.AddressNetworkMainnet:
+		return nil
+	default:
+		return fmt.Errorf(
+			"unknown network id %d: Cardano defines only %d (testnet) and "+
+				"%d (mainnet)",
+			networkId,
+			common.AddressNetworkTestnet,
+			common.AddressNetworkMainnet,
+		)
+	}
+}
+
+// expectedAddressLen returns the exact serialized length of a non-Byron
+// address of the given type.
+func expectedAddressLen(addr common.Address) (int, error) {
+	switch addr.Type() {
+	case common.AddressTypeKeyKey,
+		common.AddressTypeScriptKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeScriptScript:
+		return addressHeaderLen + 2*common.AddressHashSize, nil
+	case common.AddressTypeKeyNone,
+		common.AddressTypeScriptNone,
+		common.AddressTypeNoneKey,
+		common.AddressTypeNoneScript:
+		return addressHeaderLen + common.AddressHashSize, nil
+	case common.AddressTypeKeyPointer, common.AddressTypeScriptPointer:
+		pointer, ok := addr.StakingPayload().(common.AddressPayloadPointer)
+		if !ok {
+			return 0, errors.New("pointer address has no pointer payload")
+		}
+		return addressHeaderLen + common.AddressHashSize +
+			varUintLen(pointer.Slot) +
+			varUintLen(pointer.TxIndex) +
+			varUintLen(pointer.CertIndex), nil
+	default:
+		return 0, fmt.Errorf("unsupported address type %d", addr.Type())
+	}
+}
+
+// varUintLen returns the number of bytes the variable-length integer encoding
+// used by pointer addresses needs for v.
+func varUintLen(v uint64) int {
+	n := 1
+	for v >= 128 {
+		v /= 128
+		n++
+	}
+	return n
+}
+
+// hasBech32AddressPrefix reports whether text starts with a Cardano bech32
+// address human-readable part. bech32 allows an all-uppercase encoding, so the
+// comparison is case-insensitive.
+func hasBech32AddressPrefix(text string) bool {
+	lower := strings.ToLower(text)
+	for _, prefix := range bech32AddressPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateAddressNetworks fails closed when any address the transaction
+// commits to belongs to a different network than the chain context. Nothing
+// else in the builder compares addresses against Context.NetworkId(), which
+// is copied into the transaction body verbatim, so without this check a
+// mainnet-derived wallet pointed at a preprod context (or a preprod payee
+// pasted into a mainnet builder) builds and signs a transaction that either
+// is rejected by the node as WrongNetwork or looks valid while paying an
+// address the sender cannot reach.
+func (a *Apollo) validateAddressNetworks() error {
+	network := uint(a.Context.NetworkId())
+	if err := validateAddressNetworkId(network); err != nil {
+		return fmt.Errorf("chain context has an invalid network: %w", err)
+	}
+	check := func(role string, index int, addr common.Address) error {
+		if addr.NetworkId() == network {
+			return nil
+		}
+		if index < 0 {
+			return fmt.Errorf(
+				"network mismatch: %s %s is on network %d, but the chain "+
+					"context is on network %d",
+				role,
+				addr.String(),
+				addr.NetworkId(),
+				network,
+			)
+		}
+		return fmt.Errorf(
+			"network mismatch: %s %d (%s) is on network %d, but the chain "+
+				"context is on network %d",
+			role,
+			index,
+			addr.String(),
+			addr.NetworkId(),
+			network,
+		)
+	}
+	if a.wallet != nil {
+		if err := check("wallet address", -1, a.wallet.Address()); err != nil {
+			return err
+		}
+	}
+	// The resolved change address is either the explicit one or the wallet
+	// address, which is checked above.
+	if a.changeAddress != nil {
+		if err := check("change address", -1, *a.changeAddress); err != nil {
+			return err
+		}
+	}
+	for i, addr := range a.inputAddresses {
+		if err := check("input address", i, addr); err != nil {
+			return err
+		}
+	}
+	for i, payment := range a.payments {
+		txOut, err := payment.ToTxOut()
+		if err != nil {
+			return fmt.Errorf("failed to resolve payment %d: %w", i, err)
+		}
+		if txOut == nil {
+			continue
+		}
+		if err := check("payment receiver", i, txOut.Address()); err != nil {
+			return err
+		}
+	}
+	utxoGroups := []struct {
+		role  string
+		utxos []common.Utxo
+	}{
+		{"input UTxO", a.preselectedUtxos},
+		{"available UTxO", a.utxos},
+		{"collateral UTxO", a.collaterals},
+	}
+	for _, group := range utxoGroups {
+		for i, utxo := range group.utxos {
+			if utxo.Output == nil {
+				continue
+			}
+			if err := check(group.role, i, utxo.Output.Address()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/address_validation_test.go
+++ b/address_validation_test.go
@@ -1,0 +1,429 @@
+package apollo
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Every address in this file is synthetic: the payment and staking
+// credentials are fixed byte patterns, so no real wallet, no real user and no
+// real funds are involved. They exercise textual address decoding only.
+
+// syntheticAddress builds an address of the given type and network from fixed
+// credential bytes.
+func syntheticAddress(t *testing.T, addrType, network uint8) common.Address {
+	t.Helper()
+	payment := bytes.Repeat([]byte{0xaa}, common.AddressHashSize)
+	stake := bytes.Repeat([]byte{0xbb}, common.AddressHashSize)
+	switch addrType {
+	case common.AddressTypeKeyKey,
+		common.AddressTypeScriptKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeScriptScript:
+	case common.AddressTypeKeyNone, common.AddressTypeScriptNone:
+		stake = nil
+	case common.AddressTypeNoneKey, common.AddressTypeNoneScript:
+		payment = nil
+	default:
+		t.Fatalf("unsupported synthetic address type %d", addrType)
+	}
+	addr, err := common.NewAddressFromParts(addrType, network, payment, stake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+// mainnetSweepAddress is the synthetic mainnet base address the corruption
+// sweep mutates. Mainnet matters: every character of an "addr1..." string is
+// also a legal base58 character, which is what makes the bech32-to-base58
+// fallthrough dangerous there and harmless on "addr_test1..." addresses.
+func mainnetSweepAddress(t *testing.T) string {
+	t.Helper()
+	addr := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	return addr.String()
+}
+
+// addressCorruptionAlphabet is the bech32 data charset plus characters that
+// are illegal in bech32 but legal in base58 ("b", "i", "o") and the bech32
+// separator ("1"), which moves the human-readable part when substituted in.
+const addressCorruptionAlphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l1bio"
+
+// addressCorruptions returns every single-character corruption of addr that
+// leaves the human-readable part intact: substitution, insertion, deletion,
+// doubling and truncation. The HRP is preserved on purpose, because that is
+// what a realistic typo looks like and what routes the string into the
+// dangerous decode path.
+func addressCorruptions(t *testing.T, addr string) []string {
+	t.Helper()
+	sep := strings.IndexByte(addr, '1')
+	if sep < 0 {
+		t.Fatalf("address %q has no bech32 separator", addr)
+	}
+	start := sep + 1
+	capacity := 8 * len(addr) * len(addressCorruptionAlphabet)
+	seen := make(map[string]struct{}, capacity)
+	out := make([]string, 0, capacity)
+	add := func(candidate string) {
+		if candidate == addr {
+			return
+		}
+		if _, dup := seen[candidate]; dup {
+			return
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	for i := start; i < len(addr); i++ {
+		// substitute
+		for _, c := range addressCorruptionAlphabet {
+			add(addr[:i] + string(c) + addr[i+1:])
+		}
+		// delete
+		add(addr[:i] + addr[i+1:])
+		// double
+		add(addr[:i] + addr[i:i+1] + addr[i:])
+		// truncate
+		add(addr[:i])
+	}
+	// insert, including at the very end
+	for i := start; i <= len(addr); i++ {
+		for _, c := range addressCorruptionAlphabet {
+			add(addr[:i] + string(c) + addr[i:])
+		}
+	}
+	return out
+}
+
+// addressEntryPoints are the builder entry points that turn caller-supplied
+// address text into an address Apollo will pay, spend from, or send change to.
+func addressEntryPoints() []struct {
+	name  string
+	parse func(string) error
+} {
+	return []struct {
+		name  string
+		parse func(string) error
+	}{
+		{
+			"PayToAddressBech32",
+			func(text string) error {
+				_, err := New(setupFixedContext()).
+					PayToAddressBech32(text, 2_000_000)
+				return err
+			},
+		},
+		{
+			"SetChangeAddressBech32",
+			func(text string) error {
+				_, err := New(setupFixedContext()).
+					SetChangeAddressBech32(text)
+				return err
+			},
+		},
+		{
+			"AddInputAddressFromBech32",
+			func(text string) error {
+				_, err := New(setupFixedContext()).
+					AddInputAddressFromBech32(text)
+				return err
+			},
+		},
+		{
+			"NewPayment",
+			func(text string) error {
+				_, err := NewPayment(text, 2_000_000, nil)
+				return err
+			},
+		},
+	}
+}
+
+// TestAddressEntryPointsRejectCorruptedMainnetAddress sweeps single-character
+// corruptions of a mainnet address through every entry point. A bech32
+// checksum failure must never be retried as base58: on master these inputs
+// silently decode into unrelated bytes and Apollo builds a payment to a
+// different recipient.
+func TestAddressEntryPointsRejectCorruptedMainnetAddress(t *testing.T) {
+	valid := mainnetSweepAddress(t)
+	corruptions := addressCorruptions(t, valid)
+	if len(corruptions) < 6000 {
+		t.Fatalf("sweep is too small: %d corruptions", len(corruptions))
+	}
+	for _, entry := range addressEntryPoints() {
+		accepted := 0
+		var samples []string
+		for _, corrupted := range corruptions {
+			if err := entry.parse(corrupted); err == nil {
+				accepted++
+				if len(samples) < 3 {
+					samples = append(samples, corrupted)
+				}
+			}
+		}
+		if accepted != 0 {
+			t.Errorf(
+				"%s accepted %d of %d corrupted mainnet addresses; e.g. %v",
+				entry.name,
+				accepted,
+				len(corruptions),
+				samples,
+			)
+		} else {
+			t.Logf(
+				"%s rejected all %d corrupted mainnet addresses",
+				entry.name,
+				len(corruptions),
+			)
+		}
+	}
+}
+
+// TestAddressEntryPointsAcceptValidAddresses guards against the validation
+// being too strict: every canonical address form must still round-trip.
+func TestAddressEntryPointsAcceptValidAddresses(t *testing.T) {
+	types := []uint8{
+		common.AddressTypeKeyKey,
+		common.AddressTypeScriptKey,
+		common.AddressTypeKeyScript,
+		common.AddressTypeScriptScript,
+		common.AddressTypeKeyNone,
+		common.AddressTypeScriptNone,
+		common.AddressTypeNoneKey,
+		common.AddressTypeNoneScript,
+	}
+	networks := []uint8{
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	}
+	valid := make([]string, 0, len(types)*len(networks)+1)
+	for _, network := range networks {
+		for _, addrType := range types {
+			valid = append(
+				valid,
+				syntheticAddress(t, addrType, network).String(),
+			)
+		}
+	}
+	byron, err := common.NewByronAddressFromParts(
+		common.ByronAddressTypePubkey,
+		bytes.Repeat([]byte{0xaa}, common.AddressHashSize),
+		common.ByronAddressAttributes{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid = append(valid, byron.String())
+
+	for _, entry := range addressEntryPoints() {
+		for _, text := range valid {
+			if err := entry.parse(text); err != nil {
+				t.Errorf("%s rejected valid address %q: %v",
+					entry.name, text, err)
+			}
+		}
+	}
+}
+
+// TestPayToAddressBech32PreservesReceiver verifies the accepted address is
+// the one the caller asked for, byte for byte.
+func TestPayToAddressBech32PreservesReceiver(t *testing.T) {
+	want := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	a, err := New(setupFixedContext()).
+		PayToAddressBech32(want.String(), 2_000_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payment, ok := a.payments[0].(*Payment)
+	if !ok {
+		t.Fatalf("unexpected payment type %T", a.payments[0])
+	}
+	got, err := payment.Receiver.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBytes, err := want.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, wantBytes) {
+		t.Fatalf("receiver = %x, want %x", got, wantBytes)
+	}
+}
+
+// TestAddressEntryPointsRejectTrailingPayloadBytes covers the case that came
+// closest to being fatal in the wild: a base-address payload with a single
+// extra byte, which the ledger's lenient Byron-compatibility path can accept.
+func TestAddressEntryPointsRejectTrailingPayloadBytes(t *testing.T) {
+	base := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	raw, err := base.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 1+2*common.AddressHashSize {
+		t.Fatalf("unexpected base address length %d", len(raw))
+	}
+	withTrailing, err := common.NewAddressFromBytes(append(raw, 0xcc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := withTrailing.String()
+	for _, entry := range addressEntryPoints() {
+		if err := entry.parse(text); err == nil {
+			t.Errorf("%s accepted a 58-byte address payload %q",
+				entry.name, text)
+		}
+	}
+}
+
+// TestAddressEntryPointsAcceptPointerAddress guards the variable-length
+// pointer address form against the payload-length validation.
+func TestAddressEntryPointsAcceptPointerAddress(t *testing.T) {
+	pointers := [][]byte{
+		{0, 0, 0},
+		{0x81, 0x00, 0x7f, 0x01},
+	}
+	for _, pointer := range pointers {
+		addr, err := common.NewAddressFromParts(
+			common.AddressTypeKeyPointer,
+			common.AddressNetworkMainnet,
+			bytes.Repeat([]byte{0xaa}, common.AddressHashSize),
+			pointer,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := addr.String()
+		for _, entry := range addressEntryPoints() {
+			if err := entry.parse(text); err != nil {
+				t.Errorf("%s rejected pointer address %q: %v",
+					entry.name, text, err)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectPointerAddressTrailingBytes covers trailing
+// bytes after a pointer address's variable-length staking payload.
+func TestAddressEntryPointsRejectPointerAddressTrailingBytes(t *testing.T) {
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyPointer,
+		common.AddressNetworkMainnet,
+		bytes.Repeat([]byte{0xaa}, common.AddressHashSize),
+		[]byte{0, 0, 0, 0xcc},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := addr.String()
+	for _, entry := range addressEntryPoints() {
+		if err := entry.parse(text); err == nil {
+			t.Errorf("%s accepted trailing bytes in pointer address %q",
+				entry.name, text)
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectUnknownAddressType covers the header type
+// nibbles 9-13, which Cardano does not define.
+func TestAddressEntryPointsRejectUnknownAddressType(t *testing.T) {
+	for addrType := uint8(9); addrType <= 13; addrType++ {
+		raw := make([]byte, 1+2*common.AddressHashSize)
+		raw[0] = (addrType << 4) | common.AddressNetworkMainnet
+		for i := range common.AddressHashSize {
+			raw[1+i] = 0xaa
+			raw[1+common.AddressHashSize+i] = 0xbb
+		}
+		addr, err := common.NewAddressFromBytes(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := addr.String()
+		for _, entry := range addressEntryPoints() {
+			if err := entry.parse(text); err == nil {
+				t.Errorf("%s accepted unknown address type %d in %q",
+					entry.name, addrType, text)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectUnknownNetworkId covers network nibbles 2-15,
+// which fit in the header byte but do not exist on Cardano.
+func TestAddressEntryPointsRejectUnknownNetworkId(t *testing.T) {
+	for network := uint8(2); network < 16; network++ {
+		raw := make([]byte, 1+2*common.AddressHashSize)
+		raw[0] = (common.AddressTypeKeyKey << 4) | network
+		for i := range common.AddressHashSize {
+			raw[1+i] = 0xaa
+			raw[1+common.AddressHashSize+i] = 0xbb
+		}
+		addr, err := common.NewAddressFromBytes(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := addr.String()
+		for _, entry := range addressEntryPoints() {
+			if err := entry.parse(text); err == nil {
+				t.Errorf("%s accepted network id %d in %q",
+					entry.name, network, text)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsRejectMalformedText covers inputs that are not
+// addresses at all. None of them may panic.
+func TestAddressEntryPointsRejectMalformedText(t *testing.T) {
+	valid := mainnetSweepAddress(t)
+	malformed := []string{
+		"",
+		" ",
+		"addr1",
+		"addr_test1",
+		"stake1",
+		"not-a-valid-address",
+		"invalid",
+		" " + valid,
+		valid + " ",
+		strings.ToUpper(valid[:5]) + valid[5:], // mixed case
+		"addr_test1" + valid[5:],               // testnet prefix, mainnet body
+		"addr1" + valid[10:],                   // mainnet prefix, short body
+		"DdzFF",
+	}
+	for _, entry := range addressEntryPoints() {
+		for _, text := range malformed {
+			if err := entry.parse(text); err == nil {
+				t.Errorf("%s accepted malformed address %q", entry.name, text)
+			}
+		}
+	}
+}
+
+// TestAddressEntryPointsAcceptUppercaseBech32 locks in existing behavior:
+// bech32 permits an all-uppercase encoding, and it decodes to the same
+// address, so it must keep working.
+func TestAddressEntryPointsAcceptUppercaseBech32(t *testing.T) {
+	upper := strings.ToUpper(mainnetSweepAddress(t))
+	for _, entry := range addressEntryPoints() {
+		if err := entry.parse(upper); err != nil {
+			t.Errorf("%s rejected uppercase bech32 %q: %v",
+				entry.name, upper, err)
+		}
+	}
+}

--- a/apollo.go
+++ b/apollo.go
@@ -318,8 +318,16 @@ func (a *Apollo) AddCollateral(utxo common.Utxo) *Apollo {
 }
 
 // AddDatum adds a datum to the witness set.
+//
+// The datum's wire bytes are pinned onto it (see DatumWireCbor), so a datum
+// whose original CBOR cannot be reproduced on the wire is rejected here rather
+// than being silently rehashed into a transaction the ledger would refuse.
 func (a *Apollo) AddDatum(datum *common.Datum) *Apollo {
 	if datum != nil {
+		if _, err := DatumWireCbor(datum); err != nil {
+			a.setErrOnce(fmt.Errorf("AddDatum: %w", err))
+			return a
+		}
 		a.datums = append(a.datums, *datum)
 	}
 	return a
@@ -456,11 +464,12 @@ func (a *Apollo) PayToContractWithDatumHash(addr common.Address, datum *common.D
 		Units:    units,
 	}
 	if datum != nil {
-		datumCbor, err := cbor.Encode(datum)
+		// Hash the bytes the datum will occupy in the witness set, so the
+		// output's datum hash matches the datum the ledger sees.
+		hash, err := DatumHash(datum)
 		if err != nil {
-			return a, fmt.Errorf("failed to encode datum: %w", err)
+			return a, err
 		}
-		hash := common.Blake2b256Hash(datumCbor)
 		p.DatumHash = hash.Bytes()
 		a.datums = append(a.datums, *datum)
 	}
@@ -1455,9 +1464,11 @@ func (a *Apollo) GetUsedUTxOs() map[string]bool {
 	return cp
 }
 
-// GetBurns returns the total minted/burned value.
+// GetBurns returns the absolute quantities of all assets being burned
+// (negative mint amounts), which must be covered by transaction inputs. Use
+// GetMints for the net mint value, which retains negative quantities.
 func (a *Apollo) GetBurns() (Value, error) {
-	return a.mintValue()
+	return a.burnRequirementValue()
 }
 
 // GetWallet returns the current wallet.
@@ -1479,6 +1490,14 @@ func (a *Apollo) Complete() (*Apollo, error) {
 
 	// Load UTxOs from input addresses if needed (must happen before collateral selection)
 	if err := a.loadUtxos(); err != nil {
+		return a, err
+	}
+
+	// Every address this transaction commits to must be on the network the
+	// chain context is on. Checked here because the wallet, change, input and
+	// payment addresses are all resolved by this point, and before any
+	// selection or fee work so a cross-network build fails closed and early.
+	if err := a.validateAddressNetworks(); err != nil {
 		return a, err
 	}
 
@@ -1588,43 +1607,105 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, fmt.Errorf("preliminary fee overflows int64: max fee=%d reference script fee=%d", prelimFee, refScriptFeeReserve)
 	}
 	prelimFee += refScriptFeeReserve
-	selectionTarget, err := balanceRequired.Add(NewSimpleValue(uint64(prelimFee))) //nolint:gosec // maxFee is bounded above and refScriptFeeReserve overflow is checked above
-	if err != nil {
-		return a, fmt.Errorf("selection target overflow: %w", err)
-	}
-	// Tokens being burned must be present in the inputs. mintValue adds them
-	// to totalInput as negative amounts, which selection would otherwise
-	// ignore, silently building a transaction that cannot conserve value.
-	if a.hasMint() {
-		burnValue, err := a.burnRequirementValue()
-		if err != nil {
-			return a, err
+
+	// buildSelectionTarget converts a fee reserve into the value coin selection
+	// must cover. Tokens being burned must be present in the inputs: mintValue
+	// adds them to totalInput as negative amounts, which selection would
+	// otherwise ignore, silently building a transaction that cannot conserve
+	// value.
+	buildSelectionTarget := func(reserve int64) (Value, error) {
+		if reserve < 0 {
+			return Value{}, fmt.Errorf("negative fee reserve: %d", reserve)
 		}
-		selectionTarget, err = selectionTarget.Add(burnValue)
-		if err != nil {
-			return a, fmt.Errorf("selection target overflow: %w", err)
+		target, addErr := balanceRequired.Add(NewSimpleValue(uint64(reserve))) //nolint:gosec // checked non-negative above
+		if addErr != nil {
+			return Value{}, fmt.Errorf("selection target overflow: %w", addErr)
+		}
+		if a.hasMint() {
+			burnValue, burnErr := a.burnRequirementValue()
+			if burnErr != nil {
+				return Value{}, burnErr
+			}
+			target, addErr = target.Add(burnValue)
+			if addErr != nil {
+				return Value{}, fmt.Errorf("selection target overflow: %w", addErr)
+			}
+		}
+		return target, nil
+	}
+
+	// Reserving the full MaxTxFee makes selection refuse wallets that can
+	// comfortably afford the transaction: MaxTxFee prices a maximum-size
+	// transaction (876277 lovelace on mainnet parameters) while a simple
+	// transfer costs nearer 170000, so the top ~0.7 ADA of every wallet was
+	// unspendable and reported as "insufficient UTxOs to cover required value".
+	//
+	// Try a reserve estimated from the shape known so far. If the inputs it
+	// selects turn out to need more fee than was reserved, roll the reservation
+	// bookkeeping back and re-select against the full MaxTxFee ceiling, which is
+	// exactly the previous behaviour -- so this never selects less
+	// conservatively than before, it only avoids doing so unnecessarily.
+	//
+	// A smaller reserve is a strictly smaller selection target, so a failure at
+	// the estimated reserve would also fail at the ceiling; such failures are
+	// genuine insufficiency and are reported directly.
+	// The reserve starts at the fee for the shape known before selection and
+	// grows to whatever the selected inputs actually cost, re-selecting each
+	// time, until the reserve covers the fee it produces. Growth is monotone and
+	// capped at prelimFee, so the loop terminates and the last attempt is always
+	// the old ceiling behaviour.
+	const maxSelectionAttempts = 3
+	reserve := prelimFee
+	if initialFee, estErr := a.estimateFee(a.preselectedUtxos, outputs); estErr == nil {
+		reserve = initialFee + a.FeePadding
+		if reserve < 0 || reserve > prelimFee {
+			reserve = prelimFee
 		}
 	}
 
-	// Coin selection. setCollateral() reserves an auto-selected collateral UTxO
-	// out of the pool so multi-UTxO wallets keep a separate collateral and an
-	// unchanged tx shape. If that reservation starves selection (e.g. a wallet
-	// with a single UTxO), release the collateral for overlap - the ledger lets
-	// one UTxO be both a spending input and collateral - and retry once.
-	selectedUtxos, err := a.selectCoins(selectionTarget, totalInput)
-	if err != nil {
-		if a.releaseCollateralForOverlap() {
-			selectedUtxos, err = a.selectCoins(selectionTarget, totalInput)
-			if err != nil {
-				// The overlap retry also failed. Restore the collateral
-				// reservation and clear the overlap flag so a subsequent
-				// Complete() on this builder starts from consistent state.
-				a.restoreCollateralReservation()
-			}
+	var selectedUtxos []common.Utxo
+	for attempt := 0; ; attempt++ {
+		selectionTarget, targetErr := buildSelectionTarget(reserve)
+		if targetErr != nil {
+			return a, targetErr
 		}
+		preSelectionState := a.snapshotSelectionState()
+		selectedUtxos, err = a.selectCoinsAllowingCollateralOverlap(
+			selectionTarget,
+			totalInput,
+		)
 		if err != nil {
 			return a, fmt.Errorf("coin selection failed: %w", err)
 		}
+		if reserve >= prelimFee || attempt+1 >= maxSelectionAttempts {
+			break
+		}
+
+		// Price the shape actually selected. estimateFee already includes the
+		// reference-script surcharge for the inputs it is given, so its result
+		// is directly comparable to the reserve.
+		trialInputs := make(
+			[]common.Utxo,
+			0,
+			len(a.preselectedUtxos)+len(selectedUtxos),
+		)
+		trialInputs = append(trialInputs, a.preselectedUtxos...)
+		trialInputs = append(trialInputs, selectedUtxos...)
+		selectedFee, feeEstErr := a.estimateFee(SortInputs(trialInputs), outputs)
+		needed := prelimFee
+		if feeEstErr == nil {
+			needed = selectedFee + a.FeePadding
+			if needed < 0 || needed > prelimFee {
+				needed = prelimFee
+			}
+		}
+		if needed <= reserve {
+			break
+		}
+		// The reserve was too small for what it selected. Roll the reservation
+		// bookkeeping back so the next attempt selects from the same pool.
+		a.restoreSelectionState(preSelectionState)
+		reserve = needed
 	}
 
 	// Build inputs (explicit allocation to avoid slice aliasing)
@@ -1699,8 +1780,20 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	var previousShape string
 	seenShapes := make(map[string]struct{}, maxEvaluationIterations)
 	converged := false
+	// requestedFee is the size-based fee that drives the iteration.
+	// buildBalancedOutputs may return a larger fee than it was given, by
+	// absorbing sub-min-UTxO ADA change into it and dropping the change
+	// output. That surcharge is not something estimateFee can predict from the
+	// resulting outputs, so convergence is judged on requestedFee while fee
+	// carries the amount actually charged. Comparing the absorbed fee against
+	// a fresh estimate instead never terminates.
+	requestedFee := fee
 	for range maxEvaluationIterations {
-		balanced, balanceErr := a.buildBalancedOutputs(baseOutputs, fee, balance)
+		balanced, balanceErr := a.buildBalancedOutputs(
+			baseOutputs,
+			requestedFee,
+			balance,
+		)
 		if balanceErr != nil {
 			return a, balanceErr
 		}
@@ -1729,18 +1822,30 @@ func (a *Apollo) Complete() (*Apollo, error) {
 			return a, fmt.Errorf("failed to encode evaluation shape: %w", bodyErr)
 		}
 		shape := string(bodyBytes)
-		newFee := fee
+		nextFee := requestedFee
 		if !a.forceFee && a.Fee == 0 {
-			newFee, err = a.estimateFee(allInputUtxos, outputs)
+			nextFee, err = a.estimateFee(allInputUtxos, outputs)
 			if err != nil {
 				return a, fmt.Errorf("fee re-estimation failed: %w", err)
 			}
-			newFee += a.FeePadding
-			if newFee < 0 {
-				newFee = 0
+			nextFee += a.FeePadding
+			if nextFee < 0 {
+				nextFee = 0
 			}
 		}
-		if newFee == fee && previousShape == shape {
+		// Never settle on a fee below one already required by a shape that was
+		// considered. Around the change output's min-UTxO threshold the same
+		// transaction is bistable: at the lower fee the change clears min-UTxO
+		// and is emitted, which pushes the size-based fee up; at the higher fee
+		// the change falls below min-UTxO and is absorbed, which pulls the
+		// estimate back down. Allowing the fee to move downward alternates
+		// between those two shapes indefinitely, and the cheaper of them
+		// underpays its own size. Moving only upward terminates and never
+		// underpays.
+		if nextFee < requestedFee {
+			nextFee = requestedFee
+		}
+		if nextFee == requestedFee && previousShape == shape {
 			converged = true
 			break
 		}
@@ -1749,7 +1854,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		}
 		seenShapes[shape] = struct{}{}
 		previousShape = shape
-		fee = newFee
+		requestedFee = nextFee
 	}
 	if !converged {
 		return a, errors.New("evaluation transaction did not converge after 5 iterations")
@@ -1928,8 +2033,37 @@ func (a *Apollo) sumUtxoValues(utxos []common.Utxo) (Value, error) {
 	return total, nil
 }
 
+// pickSingleInput chooses one UTxO to spend when the balance equation is
+// already satisfied by implicit inputs and the transaction only needs a
+// non-empty input set. A pure-ADA UTxO is preferred so the change output is not
+// forced to carry native assets, and candidates are considered in canonical
+// order so the choice is deterministic.
+func pickSingleInput(available []common.Utxo) (common.Utxo, error) {
+	if len(available) == 0 {
+		return common.Utxo{}, errors.New(
+			"no available UTxO to spend: a transaction must spend at least one input",
+		)
+	}
+	sorted := SortUtxos(available)
+	for _, utxo := range sorted {
+		assets := utxo.Output.Assets()
+		if assets == nil || len(assets.Policies()) == 0 {
+			return utxo, nil
+		}
+	}
+	return sorted[0], nil
+}
+
 func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error) {
-	if currentInput.GreaterOrEqual(required) {
+	// Withdrawals, mints, and certificate deposit refunds are implicit inputs
+	// in the balance equation, so currentInput can already cover the target
+	// with no UTxO being spent at all. The ledger still requires a non-empty
+	// input set (InputSetEmptyUTxO), and a transaction that spends nothing also
+	// carries no payment-key witness and has nothing establishing its
+	// uniqueness. If the caller pinned an input we are already satisfied;
+	// otherwise selection must contribute one even though no value is needed.
+	covered := currentInput.GreaterOrEqual(required)
+	if covered && len(a.preselectedUtxos) > 0 {
 		return nil, nil
 	}
 
@@ -1957,13 +2091,27 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 		}
 	}
 
-	selector := a.coinSelector
-	if selector == nil {
-		selector = defaultCoinSelector
-	}
-	selected, err := selector.Select(available, remaining)
-	if err != nil {
-		return nil, err
+	var selected []common.Utxo
+	if covered {
+		// The value is already satisfied, so spend exactly one UTxO purely to
+		// satisfy the non-empty input set rule. Prefer a pure-ADA UTxO so the
+		// change output does not have to carry native assets it did not need
+		// to, and pick deterministically so construction stays reproducible.
+		pick, pickErr := pickSingleInput(available)
+		if pickErr != nil {
+			return nil, pickErr
+		}
+		selected = []common.Utxo{pick}
+	} else {
+		selector := a.coinSelector
+		if selector == nil {
+			selector = defaultCoinSelector
+		}
+		var selErr error
+		selected, selErr = selector.Select(available, remaining)
+		if selErr != nil {
+			return nil, selErr
+		}
 	}
 	availableByRef := make(map[string]common.Utxo, len(available))
 	for _, utxo := range available {
@@ -2256,7 +2404,36 @@ func (a *Apollo) estimateExecutionUnits(
 		return nil, fmt.Errorf("failed to encode preliminary tx: %w", err)
 	}
 
-	evalResult, err := backend.EvaluateTxContext(a.requestContext, a.Context, txBytes, inputs)
+	// Only backends reporting CapabilityEvaluateTxAdditionalUtxos accept a
+	// resolved UTxO set. The ChainContext contract lets the rest ignore the
+	// argument or reject it outright, and backend/utxorpc rejects it, so
+	// forwarding the spending inputs unconditionally made every Plutus build
+	// fail there. Send nil instead and let the evaluator resolve inputs from
+	// its own chain view.
+	//
+	// That is correct for on-chain inputs. Apollo cannot narrow it further:
+	// there is no off-chain UTxO API and no provenance flag, so caller-supplied
+	// inputs (AddInput, AddLoadedUTxOs, CollectFrom) are indistinguishable from
+	// chain-loaded ones. Erroring on them would leave these backends as broken
+	// as before, because every script input arrives that way. Degrading is safe
+	// because it cannot understate a budget: an evaluator that cannot resolve an
+	// input either fails the call or omits that redeemer, and the validation
+	// below rejects a response missing any registered redeemer. Off-chain and
+	// chained inputs therefore fail loudly, and need a backend that reports the
+	// capability.
+	additionalUtxos := inputs
+	if !backend.Supports(
+		a.Context,
+		backend.CapabilityEvaluateTxAdditionalUtxos,
+	) {
+		additionalUtxos = nil
+	}
+	evalResult, err := backend.EvaluateTxContext(
+		a.requestContext,
+		a.Context,
+		txBytes,
+		additionalUtxos,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("EvaluateTx failed: %w", err)
 	}
@@ -2532,14 +2709,12 @@ func (a *Apollo) buildWitnessSet(inputs []common.Utxo) conway.ConwayTransactionW
 		ws.WsNativeScripts = cbor.NewSetType(a.nativescripts, true)
 	}
 	if len(a.datums) > 0 {
-		ws.WsPlutusData = cbor.NewSetType(a.datums, true)
+		ws.WsPlutusData = WitnessPlutusData(a.datums)
 	}
 
 	redeemerMap := a.buildRedeemerMap(inputs)
 	if len(redeemerMap) > 0 {
-		ws.WsRedeemers = conway.ConwayRedeemers{
-			Redeemers: redeemerMap,
-		}
+		ws.WsRedeemers = WitnessRedeemers(redeemerMap)
 	}
 
 	return ws
@@ -3051,6 +3226,52 @@ func (a *Apollo) restoreCollateralReservation() {
 	a.collateralOverlapRef = ""
 }
 
+// selectionState captures the UTxO reservation bookkeeping that coin selection
+// mutates, so a speculative selection can be rolled back and retried against a
+// different fee reserve.
+type selectionState struct {
+	usedUtxos            map[string]bool
+	collateralOverlapRef string
+}
+
+func (a *Apollo) snapshotSelectionState() selectionState {
+	return selectionState{
+		usedUtxos:            maps.Clone(a.usedUtxos),
+		collateralOverlapRef: a.collateralOverlapRef,
+	}
+}
+
+func (a *Apollo) restoreSelectionState(s selectionState) {
+	a.usedUtxos = maps.Clone(s.usedUtxos)
+	a.collateralOverlapRef = s.collateralOverlapRef
+}
+
+// selectCoinsAllowingCollateralOverlap runs coin selection, and on failure
+// retries once with the auto-selected collateral released. setCollateral()
+// reserves a collateral UTxO out of the pool so multi-UTxO wallets keep a
+// separate collateral and an unchanged tx shape; when that reservation starves
+// selection (a wallet with a single UTxO, say) the ledger does permit one UTxO
+// to be both a spending input and collateral. If the retry also fails, the
+// reservation is restored so a subsequent Complete() starts from consistent
+// state.
+func (a *Apollo) selectCoinsAllowingCollateralOverlap(
+	target, totalInput Value,
+) ([]common.Utxo, error) {
+	selected, err := a.selectCoins(target, totalInput)
+	if err == nil {
+		return selected, nil
+	}
+	if a.releaseCollateralForOverlap() {
+		selected, retryErr := a.selectCoins(target, totalInput)
+		if retryErr == nil {
+			return selected, nil
+		}
+		a.restoreCollateralReservation()
+		return nil, retryErr
+	}
+	return nil, err
+}
+
 // finalizeCollateral sizes and validates the total collateral and the
 // collateral-return output against the final transaction fee. The ledger
 // requires
@@ -3423,9 +3644,12 @@ func (a *Apollo) computeAuxDataHash() (*common.Blake2b256, error) {
 	if md == nil {
 		return nil, nil
 	}
-	mdBytes, err := cbor.Encode(md)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode metadata: %w", err)
+	// Hash the exact bytes buildMetadata stored, which are the bytes that will
+	// be serialized as auxiliary_data. Re-encoding here instead would let the
+	// declared hash and the wire representation drift apart.
+	mdBytes := md.Cbor()
+	if len(mdBytes) == 0 {
+		return nil, errors.New("metadata has no stored CBOR encoding")
 	}
 	hash := common.Blake2b256Hash(mdBytes)
 	return &hash, nil
@@ -3453,7 +3677,18 @@ func (a *Apollo) buildMetadata() (*common.MetaMap, error) {
 		}
 		pairs = append(pairs, common.MetaPair{Key: key, Value: val})
 	}
-	return &common.MetaMap{Pairs: pairs}, nil
+	md := &common.MetaMap{Pairs: pairs}
+	// gouroboros serializes auxiliary data from the value's stored CBOR
+	// (ConwayTransaction.MarshalCBOR emits TxMetadata.Cbor()), so a freshly
+	// built MetaMap must carry its own encoding. Without this the transaction
+	// is emitted with auxiliary_data set to CBOR null while the body still
+	// declares auxiliary_data_hash, and the metadata is silently dropped.
+	mdBytes, err := cbor.Encode(md)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode metadata: %w", err)
+	}
+	md.SetCbor(mdBytes)
+	return md, nil
 }
 
 // toMetadatum converts a Go value to a TransactionMetadatum.

--- a/apollo_test.go
+++ b/apollo_test.go
@@ -1070,6 +1070,8 @@ func TestGetWallet(t *testing.T) {
 	}
 }
 
+// A positive mint is not a burn, so GetBurns reports nothing for it while
+// GetMints reports the minted quantity.
 func TestGetBurnsMintPositive(t *testing.T) {
 	cc := setupFixedContext()
 	a := New(cc)
@@ -1080,11 +1082,21 @@ func TestGetBurnsMintPositive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !burns.HasAssets() {
+	if burns.Assets != nil {
+		t.Errorf("expected no burns for a positive mint, got %v", burns.Assets)
+	}
+
+	mints, err := a.GetMints()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mints.HasAssets() {
 		t.Error("expected mint value to have assets")
 	}
 }
 
+// A negative mint is a burn, so GetBurns reports its absolute quantity while
+// GetMints keeps the signed quantity.
 func TestGetBurnsMintNegative(t *testing.T) {
 	cc := setupFixedContext()
 	a := New(cc)
@@ -1096,10 +1108,32 @@ func TestGetBurnsMintNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// HasAssets returns false for negative quantities since MultiAssetIsEmpty
-	// only considers positive quantities as "non-empty"
 	if burns.Assets == nil {
-		t.Error("expected burn to populate Assets field")
+		t.Fatal("expected burn to populate Assets field")
+	}
+	policyBytes, err := hex.DecodeString(
+		"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var policyId common.Blake2b224
+	copy(policyId[:], policyBytes)
+	qty := burns.Assets.Asset(policyId, []byte("token"))
+	if qty == nil || qty.Int64() != 100 {
+		t.Errorf("burn quantity = %v, want 100", qty)
+	}
+
+	mints, err := a.GetMints()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mints.Assets == nil {
+		t.Fatal("expected mints to populate Assets field")
+	}
+	mintQty := mints.Assets.Asset(policyId, []byte("token"))
+	if mintQty == nil || mintQty.Int64() != -100 {
+		t.Errorf("mint quantity = %v, want -100", mintQty)
 	}
 }
 

--- a/backend/base.go
+++ b/backend/base.go
@@ -1,16 +1,13 @@
 package backend
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
 	"reflect"
 	"strconv"
-	"strings"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -382,17 +379,6 @@ func TierRefScriptFeeRational(totalRefScriptSize int, baseFeePerByte *big.Rat, s
 	return new(big.Int).Quo(acc.Num(), acc.Denom()).Int64()
 }
 
-// ParseRational parses a provider-supplied rational number without passing it
-// through floating point. Decimal and exponent forms accepted by JSON numbers
-// are supported by math/big.
-func ParseRational(s string) (*big.Rat, error) {
-	value, ok := new(big.Rat).SetString(s)
-	if !ok {
-		return nil, fmt.Errorf("invalid rational number %q", s)
-	}
-	return value, nil
-}
-
 func rationalFromFloat64(value float64) *big.Rat {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		return nil
@@ -417,149 +403,6 @@ func (p ProtocolParameters) CoinsPerUtxoByteValue() int64 {
 		}
 	}
 	return 4310 // default fallback
-}
-
-// BoundedInt converts an API-supplied int64 to int, rejecting negative values
-// and values that would not fit in 32 bits.
-func BoundedInt(v int64, name string) (int, error) {
-	if v < 0 || v > math.MaxInt32 {
-		return 0, fmt.Errorf("%s out of range: %d", name, v)
-	}
-	return int(v), nil
-}
-
-// BoundedIntFromUint64 converts an API-supplied uint64 to int, rejecting
-// values that would not fit in 32 bits.
-func BoundedIntFromUint64(v uint64, name string) (int, error) {
-	if v > math.MaxInt32 {
-		return 0, fmt.Errorf("%s out of range: %d", name, v)
-	}
-	return int(v), nil
-}
-
-// AddressAmount represents a unit and quantity from API responses.
-type AddressAmount struct {
-	Unit     string `json:"unit"`
-	Quantity string `json:"quantity"`
-}
-
-// ParseAssetUnit splits an API asset unit into policy ID and asset name.
-func ParseAssetUnit(unit string) (common.Blake2b224, cbor.ByteString, error) {
-	if len(unit) < common.Blake2b224Size*2 {
-		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("asset unit is too short: %q", unit)
-	}
-	policyHex := unit[:common.Blake2b224Size*2]
-	nameHex := unit[common.Blake2b224Size*2:]
-
-	policyBytes, err := hex.DecodeString(policyHex)
-	if err != nil {
-		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid policy ID hex %q: %w", policyHex, err)
-	}
-	if len(policyBytes) != common.Blake2b224Size {
-		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid policy ID length: expected %d bytes, got %d", common.Blake2b224Size, len(policyBytes))
-	}
-	var policyId common.Blake2b224
-	copy(policyId[:], policyBytes)
-
-	nameBytes, err := hex.DecodeString(nameHex)
-	if err != nil {
-		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid asset name hex %q: %w", nameHex, err)
-	}
-	if len(nameBytes) > 32 {
-		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid asset name length: expected at most 32 bytes, got %d", len(nameBytes))
-	}
-	return policyId, cbor.NewByteString(nameBytes), nil
-}
-
-// ParseRedeemerTag parses a redeemer purpose string to a RedeemerTag.
-func ParseRedeemerTag(s string) (common.RedeemerTag, error) {
-	switch strings.ToLower(s) {
-	case "spend":
-		return common.RedeemerTagSpend, nil
-	case "mint":
-		return common.RedeemerTagMint, nil
-	case "cert", "publish":
-		return common.RedeemerTagCert, nil
-	case "reward", "withdraw":
-		return common.RedeemerTagReward, nil
-	default:
-		return 0, fmt.Errorf("unsupported redeemer tag %q", s)
-	}
-}
-
-// ParseFraction parses a fraction string (e.g. "1/2") to a float32.
-func ParseFraction(s string) (float64, error) {
-	parts := strings.Split(s, "/")
-	if len(parts) == 2 {
-		num, err := strconv.ParseFloat(parts[0], 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid numerator %q: %w", parts[0], err)
-		}
-		if math.IsNaN(num) || math.IsInf(num, 0) {
-			return 0, fmt.Errorf("invalid numerator (NaN/Inf) in fraction %q", s)
-		}
-		den, err := strconv.ParseFloat(parts[1], 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid denominator %q: %w", parts[1], err)
-		}
-		if den == 0 || math.IsNaN(den) || math.IsInf(den, 0) {
-			return 0, fmt.Errorf("invalid denominator in fraction %q", s)
-		}
-		return num / den, nil
-	}
-	val, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid number %q: %w", s, err)
-	}
-	if math.IsNaN(val) || math.IsInf(val, 0) {
-		return 0, fmt.Errorf("invalid number (NaN/Inf) %q", s)
-	}
-	return val, nil
-}
-
-// ScriptRefFromBytes builds a common.ScriptRef of the given script ref type
-// from raw script bytes. Native scripts are decoded from their CBOR
-// representation. When expectedHashHex is non-empty, the script hash is
-// recomputed for the claimed language and compared against it, failing closed
-// if a provider returns script bytes (or a language) that do not match the
-// hash it claims for them. An empty expectedHashHex skips verification for
-// providers that do not supply a script hash.
-func ScriptRefFromBytes(scriptType uint, scriptBytes []byte, expectedHashHex string) (*common.ScriptRef, error) {
-	var script common.Script
-	switch scriptType {
-	case common.ScriptRefTypeNativeScript:
-		var native common.NativeScript
-		if _, err := cbor.Decode(scriptBytes, &native); err != nil {
-			return nil, fmt.Errorf("failed to decode native script: %w", err)
-		}
-		script = native
-	case common.ScriptRefTypePlutusV1:
-		script = common.PlutusV1Script(scriptBytes)
-	case common.ScriptRefTypePlutusV2:
-		script = common.PlutusV2Script(scriptBytes)
-	case common.ScriptRefTypePlutusV3:
-		script = common.PlutusV3Script(scriptBytes)
-	case common.ScriptRefTypePlutusV4:
-		script = common.PlutusV4Script(scriptBytes)
-	default:
-		return nil, fmt.Errorf("unsupported script ref type %d", scriptType)
-	}
-	if expectedHashHex != "" {
-		expectedBytes, err := hex.DecodeString(expectedHashHex)
-		if err != nil {
-			return nil, fmt.Errorf("invalid script hash hex %q: %w", expectedHashHex, err)
-		}
-		if len(expectedBytes) != common.Blake2b224Size {
-			return nil, fmt.Errorf("invalid script hash length: expected %d bytes, got %d", common.Blake2b224Size, len(expectedBytes))
-		}
-		var expected common.Blake2b224
-		copy(expected[:], expectedBytes)
-		if computed := script.Hash(); computed != expected {
-			return nil, fmt.Errorf("reference script hash mismatch: computed %s, provider claimed %s",
-				hex.EncodeToString(computed.Bytes()), expectedHashHex)
-		}
-	}
-	return &common.ScriptRef{Type: scriptType, Script: script}, nil
 }
 
 // ComputeMaxTxFee computes the maximum transaction fee from protocol parameters,

--- a/backend/base_test.go
+++ b/backend/base_test.go
@@ -1,12 +1,6 @@
 package backend
 
-import (
-	"encoding/hex"
-	"testing"
-
-	"github.com/blinklabs-io/gouroboros/cbor"
-	"github.com/blinklabs-io/gouroboros/ledger/common"
-)
+import "testing"
 
 type nilChainContext struct {
 	ChainContext
@@ -76,54 +70,6 @@ func TestProtocolParametersStruct(t *testing.T) {
 	}
 }
 
-func TestParseFractionValid(t *testing.T) {
-	val, err := ParseFraction("1/2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if val != 0.5 {
-		t.Errorf("expected 0.5, got %f", val)
-	}
-}
-
-func TestParseFractionPlainNumber(t *testing.T) {
-	val, err := ParseFraction("0.0577")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if val < 0.0576 || val > 0.0578 {
-		t.Errorf("expected ~0.0577, got %f", val)
-	}
-}
-
-func TestParseFractionInvalidNumerator(t *testing.T) {
-	_, err := ParseFraction("abc/100")
-	if err == nil {
-		t.Error("expected error for invalid numerator")
-	}
-}
-
-func TestParseFractionInvalidDenominator(t *testing.T) {
-	_, err := ParseFraction("1/xyz")
-	if err == nil {
-		t.Error("expected error for invalid denominator")
-	}
-}
-
-func TestParseFractionDivisionByZero(t *testing.T) {
-	_, err := ParseFraction("1/0")
-	if err == nil {
-		t.Error("expected error for division by zero")
-	}
-}
-
-func TestParseFractionInvalidString(t *testing.T) {
-	_, err := ParseFraction("not-a-number")
-	if err == nil {
-		t.Error("expected error for invalid string")
-	}
-}
-
 func TestGenesisParametersStruct(t *testing.T) {
 	gp := GenesisParameters{
 		NetworkMagic: 764824073,
@@ -137,75 +83,6 @@ func TestGenesisParametersStruct(t *testing.T) {
 	}
 }
 
-func TestParseAssetUnit(t *testing.T) {
-	policyHex := "00000000000000000000000000000000000000000000000000000001"
-	assetNameHex := hex.EncodeToString([]byte("TOKEN"))
-	policyID, assetName, err := ParseAssetUnit(policyHex + assetNameHex)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := hex.EncodeToString(policyID.Bytes()); got != policyHex {
-		t.Fatalf("policy ID = %s, want %s", got, policyHex)
-	}
-	if want := cbor.NewByteString([]byte("TOKEN")); assetName != want {
-		t.Fatalf("asset name = %s, want %s", assetName.String(), want.String())
-	}
-}
-
-func TestParseAssetUnitRejectsInvalidInput(t *testing.T) {
-	tests := []string{
-		"abcd",
-		"0000000000000000000000000000000000000000000000000000000z",
-		"00000000000000000000000000000000000000000000000000000001zz",
-		"00000000000000000000000000000000000000000000000000000001" +
-			"000000000000000000000000000000000000000000000000000000000000000000",
-	}
-	for _, unit := range tests {
-		t.Run(unit, func(t *testing.T) {
-			if _, _, err := ParseAssetUnit(unit); err == nil {
-				t.Fatal("expected error")
-			}
-		})
-	}
-}
-
-func TestParseAssetUnitAllowsEmptyAssetName(t *testing.T) {
-	policyHex := "00000000000000000000000000000000000000000000000000000001"
-	policyID, assetName, err := ParseAssetUnit(policyHex)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var expected common.Blake2b224
-	expected[27] = 1
-	if policyID != expected {
-		t.Fatalf("policy ID = %x, want %x", policyID.Bytes(), expected.Bytes())
-	}
-	if want := cbor.NewByteString(nil); assetName != want {
-		t.Fatalf("asset name = %s, want empty", assetName.String())
-	}
-}
-
-func TestBoundedInt(t *testing.T) {
-	if v, err := BoundedInt(12345, "x"); err != nil || v != 12345 {
-		t.Errorf("BoundedInt(12345) = %d, %v; want 12345, nil", v, err)
-	}
-	if _, err := BoundedInt(-1, "x"); err == nil {
-		t.Error("BoundedInt(-1) should error")
-	}
-	if _, err := BoundedInt(int64(1)<<32, "x"); err == nil {
-		t.Error("BoundedInt(2^32) should error")
-	}
-}
-
-func TestBoundedIntFromUint64(t *testing.T) {
-	if v, err := BoundedIntFromUint64(12345, "x"); err != nil || v != 12345 {
-		t.Errorf("BoundedIntFromUint64(12345) = %d, %v; want 12345, nil", v, err)
-	}
-	if _, err := BoundedIntFromUint64(uint64(1)<<32, "x"); err == nil {
-		t.Error("BoundedIntFromUint64(2^32) should error")
-	}
-}
-
 func TestCoinsPerUtxoByteValueRejectsOutOfRange(t *testing.T) {
 	pp := ProtocolParameters{CoinsPerUtxoByte: "-4310"}
 	if v := pp.CoinsPerUtxoByteValue(); v != 4310 {
@@ -214,109 +91,6 @@ func TestCoinsPerUtxoByteValueRejectsOutOfRange(t *testing.T) {
 	pp = ProtocolParameters{CoinsPerUtxoByte: "9223372036854775807"}
 	if v := pp.CoinsPerUtxoByteValue(); v != 4310 {
 		t.Errorf("oversized value should fall back to 4310, got %d", v)
-	}
-}
-
-func TestScriptRefFromBytesVerifiesHash(t *testing.T) {
-	script := common.PlutusV2Script([]byte{0x01, 0x02, 0x03})
-	correctHash := hex.EncodeToString(script.Hash().Bytes())
-
-	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, script, correctHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ref.Type != common.ScriptRefTypePlutusV2 {
-		t.Fatalf("script ref type = %d, want %d", ref.Type, common.ScriptRefTypePlutusV2)
-	}
-	if _, ok := ref.Script.(common.PlutusV2Script); !ok {
-		t.Fatalf("expected PlutusV2 script, got %T", ref.Script)
-	}
-}
-
-func TestScriptRefFromBytesPlutusV4(t *testing.T) {
-	script := common.PlutusV4Script([]byte{0x01, 0x02, 0x03})
-	correctHash := hex.EncodeToString(script.Hash().Bytes())
-
-	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV4, script, correctHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ref.Type != common.ScriptRefTypePlutusV4 {
-		t.Fatalf("script ref type = %d, want %d", ref.Type, common.ScriptRefTypePlutusV4)
-	}
-	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
-		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
-	}
-}
-
-func TestScriptRefFromBytesRejectsHashMismatch(t *testing.T) {
-	script := common.PlutusV2Script([]byte{0x01, 0x02, 0x03})
-	// The same bytes hashed as PlutusV1 produce a different script hash.
-	wrongHash := hex.EncodeToString(common.PlutusV1Script(script).Hash().Bytes())
-	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, script, wrongHash); err == nil {
-		t.Fatal("expected script hash mismatch error")
-	}
-}
-
-func TestScriptRefFromBytesRejectsClaimedLanguageMismatch(t *testing.T) {
-	// Provider claims PlutusV1 for bytes whose hash was computed as PlutusV2.
-	scriptBytes := []byte{0x01, 0x02, 0x03}
-	v2Hash := hex.EncodeToString(common.PlutusV2Script(scriptBytes).Hash().Bytes())
-	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV1, scriptBytes, v2Hash); err == nil {
-		t.Fatal("expected script hash mismatch error for wrong language claim")
-	}
-}
-
-func TestScriptRefFromBytesSkipsVerificationWithoutHash(t *testing.T) {
-	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV3, []byte{0x0a}, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := ref.Script.(common.PlutusV3Script); !ok {
-		t.Fatalf("expected PlutusV3 script, got %T", ref.Script)
-	}
-}
-
-func TestScriptRefFromBytesRejectsInvalidHashHex(t *testing.T) {
-	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, []byte{0x01}, "zz"); err == nil {
-		t.Fatal("expected invalid hash hex error")
-	}
-	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, []byte{0x01}, "abcd"); err == nil {
-		t.Fatal("expected invalid hash length error")
-	}
-}
-
-func TestScriptRefFromBytesRejectsUnsupportedType(t *testing.T) {
-	if _, err := ScriptRefFromBytes(99, []byte{0x01}, ""); err == nil {
-		t.Fatal("expected unsupported script ref type error")
-	}
-}
-
-func TestScriptRefFromBytesNativeScript(t *testing.T) {
-	// Native script: ScriptPubkey = [0, key_hash]
-	keyHash := make([]byte, 28)
-	keyHash[0] = 0xAA
-	scriptCbor, err := cbor.Encode([]any{0, keyHash})
-	if err != nil {
-		t.Fatal(err)
-	}
-	ref, err := ScriptRefFromBytes(common.ScriptRefTypeNativeScript, scriptCbor, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	native, ok := ref.Script.(common.NativeScript)
-	if !ok {
-		t.Fatalf("expected native script, got %T", ref.Script)
-	}
-
-	// Round-trip the computed hash through verification.
-	correctHash := hex.EncodeToString(native.Hash().Bytes())
-	if _, err := ScriptRefFromBytes(common.ScriptRefTypeNativeScript, scriptCbor, correctHash); err != nil {
-		t.Fatalf("expected native script hash to verify: %v", err)
-	}
-	wrongHash := hex.EncodeToString(make([]byte, common.Blake2b224Size))
-	if _, err := ScriptRefFromBytes(common.ScriptRefTypeNativeScript, scriptCbor, wrongHash); err == nil {
-		t.Fatal("expected native script hash mismatch error")
 	}
 }
 

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 
 	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/internal/backendutil"
 )
 
 // BlockFrostChainContext implements backend.ChainContext using the BlockFrost API.
@@ -702,7 +703,7 @@ func parseOgmiosV6EvaluationResult(raw json.RawMessage) (map[common.RedeemerKey]
 		if item.Validator.Purpose == "" {
 			return nil, fmt.Errorf("malformed evaluation result entry: %s", evalErrorSnippet(raw))
 		}
-		tag, err := backend.ParseRedeemerTag(item.Validator.Purpose)
+		tag, err := backendutil.ParseRedeemerTag(item.Validator.Purpose)
 		if err != nil {
 			return nil, fmt.Errorf("invalid redeemer purpose %q: %w", item.Validator.Purpose, err)
 		}
@@ -748,7 +749,7 @@ func parseOgmiosV5EvaluationResult(raw json.RawMessage) (map[common.RedeemerKey]
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("malformed redeemer key %q: expected format 'tag:index'", key)
 		}
-		tag, err := backend.ParseRedeemerTag(parts[0])
+		tag, err := backendutil.ParseRedeemerTag(parts[0])
 		if err != nil {
 			return nil, fmt.Errorf("invalid redeemer tag in key %q: %w", key, err)
 		}
@@ -933,23 +934,23 @@ type bfProtocolParams struct {
 }
 
 func (p *bfProtocolParams) toProtocolParams() (backend.ProtocolParameters, error) {
-	maxBlockSize, err := backend.BoundedInt(p.MaxBlockSize, "max_block_size")
+	maxBlockSize, err := backendutil.BoundedInt(p.MaxBlockSize, "max_block_size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxTxSize, err := backend.BoundedInt(p.MaxTxSize, "max_tx_size")
+	maxTxSize, err := backendutil.BoundedInt(p.MaxTxSize, "max_tx_size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxBlockHeaderSize, err := backend.BoundedInt(p.MaxBlockHeaderSize, "max_block_header_size")
+	maxBlockHeaderSize, err := backendutil.BoundedInt(p.MaxBlockHeaderSize, "max_block_header_size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	collateralPercent, err := backend.BoundedInt(p.CollateralPercent, "collateral_percent")
+	collateralPercent, err := backendutil.BoundedInt(p.CollateralPercent, "collateral_percent")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxCollateralInputs, err := backend.BoundedInt(p.MaxCollateralIn, "max_collateral_inputs")
+	maxCollateralInputs, err := backendutil.BoundedInt(p.MaxCollateralIn, "max_collateral_inputs")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -974,7 +975,7 @@ func (p *bfProtocolParams) toProtocolParams() (backend.ProtocolParameters, error
 		CoinsPerUtxoByte:    p.CoinsPerUtxoSize,
 	}
 	if p.MinFeeRefScriptCostPerByte != "" {
-		price, err := backend.ParseRational(p.MinFeeRefScriptCostPerByte.String())
+		price, err := backendutil.ParseRational(p.MinFeeRefScriptCostPerByte.String())
 		if err != nil {
 			return backend.ProtocolParameters{}, fmt.Errorf("invalid min_fee_ref_script_cost_per_byte: %w", err)
 		}
@@ -1102,7 +1103,7 @@ func (raw *bfAddressUTxO) toUtxo(address common.Address) (common.Utxo, error) {
 			if qty.Sign() < 0 {
 				return common.Utxo{}, fmt.Errorf("negative asset quantity %s for unit %s", qty.String(), amt.Unit)
 			}
-			policyId, assetName, err := backend.ParseAssetUnit(amt.Unit)
+			policyId, assetName, err := backendutil.ParseAssetUnit(amt.Unit)
 			if err != nil {
 				return common.Utxo{}, fmt.Errorf("invalid asset unit %q: %w", amt.Unit, err)
 			}

--- a/backend/maestro/maestro.go
+++ b/backend/maestro/maestro.go
@@ -25,6 +25,7 @@ import (
 	"github.com/maestro-org/go-sdk/utils"
 
 	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/internal/backendutil"
 )
 
 // MaestroChainContext implements backend.ChainContext using the Maestro API.
@@ -134,32 +135,32 @@ func (m *MaestroChainContext) ProtocolParamsContext(ctx context.Context) (backen
 	}
 
 	data := resp.Data
-	priceMem, err := backend.ParseFraction(data.ScriptExecutionPrices.Memory)
+	priceMem, err := backendutil.ParseFraction(data.ScriptExecutionPrices.Memory)
 	if err != nil {
 		return backend.ProtocolParameters{}, fmt.Errorf("invalid memory price: %w", err)
 	}
-	priceStep, err := backend.ParseFraction(data.ScriptExecutionPrices.Steps)
+	priceStep, err := backendutil.ParseFraction(data.ScriptExecutionPrices.Steps)
 	if err != nil {
 		return backend.ProtocolParameters{}, fmt.Errorf("invalid step price: %w", err)
 	}
 
-	maxBlockSize, err := backend.BoundedInt(data.MaxBlockBodySize.Bytes, "max block body size")
+	maxBlockSize, err := backendutil.BoundedInt(data.MaxBlockBodySize.Bytes, "max block body size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxTxSize, err := backend.BoundedInt(data.MaxTransactionSize.Bytes, "max transaction size")
+	maxTxSize, err := backendutil.BoundedInt(data.MaxTransactionSize.Bytes, "max transaction size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxBlockHeaderSize, err := backend.BoundedInt(data.MaxBlockHeaderSize.Bytes, "max block header size")
+	maxBlockHeaderSize, err := backendutil.BoundedInt(data.MaxBlockHeaderSize.Bytes, "max block header size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	collateralPercent, err := backend.BoundedInt(data.CollateralPercentage, "collateral percentage")
+	collateralPercent, err := backendutil.BoundedInt(data.CollateralPercentage, "collateral percentage")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxCollateralInputs, err := backend.BoundedInt(data.MaxCollateralInputs, "max collateral inputs")
+	maxCollateralInputs, err := backendutil.BoundedInt(data.MaxCollateralInputs, "max collateral inputs")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -506,7 +507,7 @@ func evaluationsToExUnits(evals models.EvaluateTxResponse) (map[common.RedeemerK
 		if uint64(eval.RedeemerIndex) > uint64(math.MaxUint32) {
 			return nil, fmt.Errorf("redeemer index %d exceeds uint32 range", eval.RedeemerIndex)
 		}
-		tag, err := backend.ParseRedeemerTag(eval.RedeemerTag)
+		tag, err := backendutil.ParseRedeemerTag(eval.RedeemerTag)
 		if err != nil {
 			return nil, fmt.Errorf("invalid redeemer tag %q: %w", eval.RedeemerTag, err)
 		}
@@ -605,7 +606,7 @@ func maestroUtxoToCommon(raw models.Utxo, address common.Address) (common.Utxo, 
 			if asset.Amount < 0 {
 				return common.Utxo{}, fmt.Errorf("negative asset amount %d for unit %s", asset.Amount, asset.Unit)
 			}
-			policyId, assetName, err := backend.ParseAssetUnit(asset.Unit)
+			policyId, assetName, err := backendutil.ParseAssetUnit(asset.Unit)
 			if err != nil {
 				return common.Utxo{}, fmt.Errorf("invalid asset unit %q: %w", asset.Unit, err)
 			}
@@ -727,7 +728,7 @@ func maestroScriptRef(scriptType string, scriptCbor []byte, expectedHashHex stri
 	default:
 		return nil, fmt.Errorf("unknown script type %q", scriptType)
 	}
-	return backend.ScriptRefFromBytes(refType, scriptCbor, expectedHashHex)
+	return backendutil.ScriptRefFromBytes(refType, scriptCbor, expectedHashHex)
 }
 
 // maestroCostModelKey translates Maestro cost model keys to the canonical form

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/SundaeSwap-finance/kugo"
 	ogmigo "github.com/SundaeSwap-finance/ogmigo/v6"
@@ -22,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 
 	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/internal/backendutil"
 )
 
 // OgmiosChainContext implements backend.ChainContext using Ogmios + Kupo.
@@ -83,10 +86,12 @@ func (o *OgmiosChainContext) GenesisParamsContext(ctx context.Context) (backend.
 
 	var genesis ogmiosGenesisConfig
 	if err := json.Unmarshal(raw, &genesis); err != nil {
-		return backend.GenesisParameters{}, err
+		return backend.GenesisParameters{}, fmt.Errorf(
+			"failed to parse genesis config: %w", err,
+		)
 	}
 
-	return genesis.toGenesisParams(), nil
+	return genesis.toGenesisParams()
 }
 
 func (o *OgmiosChainContext) NetworkId() uint8 {
@@ -346,7 +351,7 @@ func evaluateResponseToExUnits(resp *ogmigo.EvaluateTxResponse) (map[common.Rede
 
 	result := make(map[common.RedeemerKey]common.ExUnits, len(resp.ExUnits))
 	for _, eu := range resp.ExUnits {
-		tag, err := backend.ParseRedeemerTag(eu.Validator.Purpose)
+		tag, err := backendutil.ParseRedeemerTag(eu.Validator.Purpose)
 		if err != nil {
 			return nil, fmt.Errorf("invalid redeemer purpose %q: %w", eu.Validator.Purpose, err)
 		}
@@ -418,25 +423,33 @@ func (o *OgmiosChainContext) ScriptCborContext(
 // --- Ogmios response types and conversion ---
 
 type ogmiosProtocolParams struct {
-	MinFeeCoefficient  int64           `json:"minFeeCoefficient"`
-	MinFeeConstant     ogmiosLovelace  `json:"minFeeConstant"`
+	// The fee- and deposit-critical parameters are decoded through pointers so
+	// that a key missing from the response is reported by toProtocolParams
+	// instead of defaulting to zero. Ogmios sends all of them in every era.
+	MinFeeCoefficient  *int64          `json:"minFeeCoefficient"`
+	MinFeeConstant     *ogmiosLovelace `json:"minFeeConstant"`
 	MaxBlockBodySize   ogmiosBytes     `json:"maxBlockBodySize"`
 	MaxBlockHeaderSize ogmiosBytes     `json:"maxBlockHeaderSize"`
 	MaxTxSize          ogmiosBytes     `json:"maxTransactionSize"`
-	StakeKeyDeposit    ogmiosLovelace  `json:"stakeCredentialDeposit"`
-	PoolDeposit        ogmiosLovelace  `json:"stakePoolDeposit"`
-	MinPoolCost        ogmiosLovelace  `json:"minStakePoolCost"`
+	StakeKeyDeposit    *ogmiosLovelace `json:"stakeCredentialDeposit"`
+	PoolDeposit        *ogmiosLovelace `json:"stakePoolDeposit"`
+	MinPoolCost        *ogmiosLovelace `json:"minStakePoolCost"`
 	CollateralPercent  int             `json:"collateralPercentage"`
 	MaxCollateral      int             `json:"maxCollateralInputs"`
 	MaxValSize         ogmiosBytes     `json:"maxValueSize"`
 	ScriptPrices       ogmiosPrices    `json:"scriptExecutionPrices"`
 	MaxTxExUnits       ogmiosExUnits   `json:"maxExecutionUnitsPerTransaction"`
 	MaxBlockExUnits    ogmiosExUnits   `json:"maxExecutionUnitsPerBlock"`
-	MinUtxoDeposit     int64           `json:"minUtxoDepositCoefficient"`
+	MinUtxoDeposit     *int64          `json:"minUtxoDepositCoefficient"`
 	CostModels         json.RawMessage `json:"plutusCostModels"`
 	// Ogmios v6 exposes Conway reference-script pricing as a structured object
 	// {base, range, multiplier}; base is the lovelace-per-byte first-tier price.
 	MinFeeReferenceScripts *ogmiosRefScripts `json:"minFeeReferenceScripts"`
+	// maxReferenceScriptsSize arrived in Ogmios v6.5 and was renamed to
+	// maxReferenceScriptsSizePerTransaction in v7.0. Both spellings are
+	// optional: Ogmios before v6.5 sends neither.
+	MaxRefScriptsSize   *ogmiosBytes `json:"maxReferenceScriptsSize"`
+	MaxRefScriptsSizeTx *ogmiosBytes `json:"maxReferenceScriptsSizePerTransaction"`
 }
 
 type ogmiosRefScripts struct {
@@ -445,8 +458,40 @@ type ogmiosRefScripts struct {
 	Multiplier json.Number `json:"multiplier"`
 }
 
+// ogmiosLovelace decodes a lovelace-valued Ogmios protocol parameter.
+//
+// Ogmios v6.0.x encoded these as a bare {"lovelace": N}. Since v6.1.0 they are
+// Value<AdaOnly>, i.e. {"ada": {"lovelace": N}}. Both shapes are accepted so
+// older deployments keep working, and an amount carrying neither key is an
+// error rather than a zero: decoding an unrecognized shape to 0 in silence is
+// what left every fee short by the whole minFeeConstant.
 type ogmiosLovelace struct {
-	Lovelace int64 `json:"lovelace"`
+	Lovelace int64
+}
+
+func (l *ogmiosLovelace) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Ada *struct {
+			Lovelace *int64 `json:"lovelace"`
+		} `json:"ada"`
+		Lovelace *int64 `json:"lovelace"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	switch {
+	case wire.Ada != nil && wire.Ada.Lovelace != nil:
+		l.Lovelace = *wire.Ada.Lovelace
+	case wire.Lovelace != nil:
+		l.Lovelace = *wire.Lovelace
+	default:
+		return fmt.Errorf(
+			"unrecognized lovelace amount %s: want "+
+				`{"ada":{"lovelace":N}} or {"lovelace":N}`,
+			data,
+		)
+	}
+	return nil
 }
 
 type ogmiosBytes struct {
@@ -463,19 +508,50 @@ type ogmiosExUnits struct {
 	CPU    int64 `json:"cpu"`
 }
 
+// missingRequired lists the protocol parameters Apollo cannot balance a
+// transaction without. Reporting them is what keeps a renamed or restructured
+// Ogmios field from quietly becoming a zero fee, deposit, or min-UTxO cost.
+func (p *ogmiosProtocolParams) missingRequired() []string {
+	required := []struct {
+		name    string
+		present bool
+	}{
+		{"minFeeCoefficient", p.MinFeeCoefficient != nil},
+		{"minFeeConstant", p.MinFeeConstant != nil},
+		{"minUtxoDepositCoefficient", p.MinUtxoDeposit != nil},
+		{"stakeCredentialDeposit", p.StakeKeyDeposit != nil},
+		{"stakePoolDeposit", p.PoolDeposit != nil},
+		{"minStakePoolCost", p.MinPoolCost != nil},
+	}
+	missing := make([]string, 0, len(required))
+	for _, field := range required {
+		if !field.present {
+			missing = append(missing, field.name)
+		}
+	}
+	return missing
+}
+
 func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, error) {
-	priceMem, err := backend.ParseFraction(p.ScriptPrices.Memory)
+	if missing := p.missingRequired(); len(missing) > 0 {
+		return backend.ProtocolParameters{}, fmt.Errorf(
+			"ogmios protocol parameters missing required fields: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	priceMem, err := backendutil.ParseFraction(p.ScriptPrices.Memory)
 	if err != nil {
 		return backend.ProtocolParameters{}, fmt.Errorf("invalid memory price: %w", err)
 	}
-	priceStep, err := backend.ParseFraction(p.ScriptPrices.CPU)
+	priceStep, err := backendutil.ParseFraction(p.ScriptPrices.CPU)
 	if err != nil {
 		return backend.ProtocolParameters{}, fmt.Errorf("invalid CPU price: %w", err)
 	}
 
 	pp := backend.ProtocolParameters{
 		MinFeeConstant:      p.MinFeeConstant.Lovelace,
-		MinFeeCoefficient:   p.MinFeeCoefficient,
+		MinFeeCoefficient:   *p.MinFeeCoefficient,
 		MaxBlockSize:        p.MaxBlockBodySize.Bytes,
 		MaxTxSize:           p.MaxTxSize.Bytes,
 		MaxBlockHeaderSize:  p.MaxBlockHeaderSize.Bytes,
@@ -491,15 +567,22 @@ func (p *ogmiosProtocolParams) toProtocolParams() (backend.ProtocolParameters, e
 		MaxValSize:          strconv.Itoa(p.MaxValSize.Bytes),
 		CollateralPercent:   p.CollateralPercent,
 		MaxCollateralInputs: p.MaxCollateral,
-		CoinsPerUtxoByte:    strconv.FormatInt(p.MinUtxoDeposit, 10),
+		CoinsPerUtxoByte:    strconv.FormatInt(*p.MinUtxoDeposit, 10),
+	}
+
+	switch {
+	case p.MaxRefScriptsSize != nil:
+		pp.MaximumReferenceScriptsSize = p.MaxRefScriptsSize.Bytes
+	case p.MaxRefScriptsSizeTx != nil:
+		pp.MaximumReferenceScriptsSize = p.MaxRefScriptsSizeTx.Bytes
 	}
 
 	if p.MinFeeReferenceScripts != nil {
-		base, err := backend.ParseRational(p.MinFeeReferenceScripts.Base.String())
+		base, err := backendutil.ParseRational(p.MinFeeReferenceScripts.Base.String())
 		if err != nil {
 			return backend.ProtocolParameters{}, fmt.Errorf("invalid reference-script base price: %w", err)
 		}
-		multiplier, err := backend.ParseRational(p.MinFeeReferenceScripts.Multiplier.String())
+		multiplier, err := backendutil.ParseRational(p.MinFeeReferenceScripts.Multiplier.String())
 		if err != nil {
 			return backend.ProtocolParameters{}, fmt.Errorf("invalid reference-script multiplier: %w", err)
 		}
@@ -545,29 +628,119 @@ func ogmiosCostModelKey(key string) string {
 }
 
 type ogmiosGenesisConfig struct {
-	NetworkMagic      int     `json:"networkMagic"`
-	EpochLength       int     `json:"epochLength"`
-	SlotLength        int     `json:"slotLength"`
-	SlotsPerKesPeriod int     `json:"slotsPerKesPeriod"`
-	MaxKesEvolutions  int     `json:"maxKESEvolutions"`
-	SecurityParam     int     `json:"securityParameter"`
-	UpdateQuorum      int     `json:"updateQuorum"`
-	ActiveSlots       float64 `json:"activeSlotsCoefficient"`
-	MaxLovelaceSupply int64   `json:"maxLovelaceSupply"`
+	// Ogmios reports the system start as an ISO-8601 timestamp, while
+	// GenesisParameters carries Unix seconds like the other backends.
+	StartTime         string           `json:"startTime"`
+	NetworkMagic      int              `json:"networkMagic"`
+	EpochLength       int              `json:"epochLength"`
+	SlotLength        ogmiosSlotLength `json:"slotLength"`
+	SlotsPerKesPeriod int              `json:"slotsPerKesPeriod"`
+	MaxKesEvolutions  int              `json:"maxKesEvolutions"`
+	SecurityParam     int              `json:"securityParameter"`
+	UpdateQuorum      int              `json:"updateQuorum"`
+	ActiveSlots       ogmiosRatio      `json:"activeSlotsCoefficient"`
+	MaxLovelaceSupply int64            `json:"maxLovelaceSupply"`
 }
 
-func (g *ogmiosGenesisConfig) toGenesisParams() backend.GenesisParameters {
+// ogmiosRatio decodes an Ogmios ratio. Ogmios v6 sends these as exact
+// "numerator/denominator" strings (e.g. "1/20" for the mainnet active-slots
+// coefficient); v5 sent a bare JSON number. Both are accepted, and a value in
+// neither form is an error rather than a zero.
+type ogmiosRatio struct {
+	Value float64
+}
+
+func (r *ogmiosRatio) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err == nil {
+		value, parseErr := backendutil.ParseFraction(text)
+		if parseErr != nil {
+			return fmt.Errorf("invalid ratio %q: %w", text, parseErr)
+		}
+		r.Value = value
+		return nil
+	}
+	var number float64
+	if err := json.Unmarshal(data, &number); err != nil {
+		return fmt.Errorf(
+			"unrecognized ratio %s: want a \"num/den\" string or a number",
+			data,
+		)
+	}
+	r.Value = number
+	return nil
+}
+
+// ogmiosSlotLength decodes an Ogmios slot length. Ogmios v6 sends
+// {"milliseconds": N}; v5 sent a bare number of seconds. Both are accepted and
+// normalized to the whole seconds that GenesisParameters reports, so the value
+// is never silently zero.
+type ogmiosSlotLength struct {
+	Seconds int
+}
+
+func (s *ogmiosSlotLength) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Milliseconds *int64 `json:"milliseconds"`
+	}
+	if err := json.Unmarshal(data, &wire); err == nil &&
+		wire.Milliseconds != nil {
+		millis := *wire.Milliseconds
+		if millis < 0 || millis/1000 > math.MaxInt32 {
+			return fmt.Errorf("slot length out of range: %d ms", millis)
+		}
+		s.Seconds = int(millis / 1000)
+		return nil
+	}
+	var seconds int
+	if err := json.Unmarshal(data, &seconds); err != nil {
+		return fmt.Errorf(
+			`unrecognized slot length %s: want {"milliseconds":N} or N`,
+			data,
+		)
+	}
+	s.Seconds = seconds
+	return nil
+}
+
+func (g *ogmiosGenesisConfig) toGenesisParams() (
+	backend.GenesisParameters,
+	error,
+) {
+	systemStart, err := parseOgmiosStartTime(g.StartTime)
+	if err != nil {
+		return backend.GenesisParameters{}, err
+	}
+
 	return backend.GenesisParameters{
-		ActiveSlotsCoefficient: g.ActiveSlots,
+		ActiveSlotsCoefficient: g.ActiveSlots.Value,
 		UpdateQuorum:           g.UpdateQuorum,
 		NetworkMagic:           g.NetworkMagic,
 		EpochLength:            g.EpochLength,
 		MaxLovelaceSupply:      strconv.FormatInt(g.MaxLovelaceSupply, 10),
-		SlotLength:             g.SlotLength,
+		SystemStart:            systemStart,
+		SlotLength:             g.SlotLength.Seconds,
 		SlotsPerKesPeriod:      g.SlotsPerKesPeriod,
 		MaxKesEvolutions:       g.MaxKesEvolutions,
 		SecurityParam:          g.SecurityParam,
+	}, nil
+}
+
+// parseOgmiosStartTime converts an Ogmios ISO-8601 genesis start time to the
+// Unix seconds reported by GenesisParameters. The Ogmios schema makes the
+// trailing zone designator optional, so a bare local-style timestamp is
+// accepted as UTC. An empty value yields zero; anything unparseable is an
+// error rather than a zero timestamp.
+func parseOgmiosStartTime(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
 	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.Unix(), nil
+		}
+	}
+	return 0, fmt.Errorf("invalid genesis start time %q", value)
 }
 
 // datumFetcher resolves a datum's CBOR (hex-encoded) by its hash. It is
@@ -862,7 +1035,7 @@ func kupoScriptToScriptRef(script kugo.Script, expectedHashHex string) (*common.
 		return nil, fmt.Errorf("unsupported kupo script language: %d", script.Language)
 	}
 
-	return backend.ScriptRefFromBytes(scriptType, scriptBytes, expectedHashHex)
+	return backendutil.ScriptRefFromBytes(scriptType, scriptBytes, expectedHashHex)
 }
 
 // ogmiosScriptToScriptRef converts an Ogmios script JSON to a common.ScriptRef.
@@ -903,5 +1076,5 @@ func ogmiosScriptToScriptRef(scriptJSON json.RawMessage) (*common.ScriptRef, err
 		return nil, fmt.Errorf("unsupported ogmios script language %q", raw.Language)
 	}
 
-	return backend.ScriptRefFromBytes(scriptType, scriptBytes, "")
+	return backendutil.ScriptRefFromBytes(scriptType, scriptBytes, "")
 }

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -570,6 +572,12 @@ func TestOgmiosScriptRefJSONLanguageDetection(t *testing.T) {
 
 func TestProtocolParamsPreserveReferenceScriptFeeParameters(t *testing.T) {
 	const body = `{
+		"minFeeCoefficient": 44,
+		"minFeeConstant": {"ada": {"lovelace": 155381}},
+		"minUtxoDepositCoefficient": 4310,
+		"stakeCredentialDeposit": {"ada": {"lovelace": 2000000}},
+		"stakePoolDeposit": {"ada": {"lovelace": 500000000}},
+		"minStakePoolCost": {"ada": {"lovelace": 170000000}},
 		"scriptExecutionPrices": {"memory": "1/1", "cpu": "1/1"},
 		"minFeeReferenceScripts": {
 			"base": 15.125,
@@ -599,5 +607,516 @@ func TestProtocolParamsPreserveReferenceScriptFeeParameters(t *testing.T) {
 	want := backend.TierRefScriptFeeRational(53, big.NewRat(121, 8), 7, big.NewRat(2469, 2000))
 	if got := backend.TierRefScriptFeeRational(53, pp.RefScriptFeePerByteRational(), pp.RefScriptSizeIncrement(), pp.RefScriptMultiplierRational()); got != want {
 		t.Fatalf("reference-script fee = %d, want %d", got, want)
+	}
+}
+
+// ogmiosV6ProtocolParamsTemplate is a queryLedgerState/protocolParameters
+// result as Ogmios v6.x serves it on a Conway-era network. Every lovelace
+// parameter is a %s placeholder so the same response can be rendered in both
+// encodings Ogmios has used (see adaLovelace and bareLovelace); the remaining
+// fields are reproduced as sent, except that the Plutus cost model arrays are
+// truncated to keep the fixture readable.
+const ogmiosV6ProtocolParamsTemplate = `{
+	"minFeeCoefficient": 44,
+	"minFeeConstant": %s,
+	"minUtxoDepositCoefficient": 4310,
+	"minUtxoDepositConstant": %s,
+	"maxBlockBodySize": {"bytes": 90112},
+	"maxBlockHeaderSize": {"bytes": 1100},
+	"maxTransactionSize": {"bytes": 16384},
+	"maxValueSize": {"bytes": 5000},
+	"maxReferenceScriptsSize": {"bytes": 204800},
+	"extraEntropy": "neutral",
+	"stakeCredentialDeposit": %s,
+	"stakePoolDeposit": %s,
+	"stakePoolRetirementEpochBound": 18,
+	"stakePoolPledgeInfluence": "3/10",
+	"minStakePoolCost": %s,
+	"desiredNumberOfStakePools": 500,
+	"monetaryExpansion": "3/1000",
+	"treasuryExpansion": "1/5",
+	"collateralPercentage": 150,
+	"maxCollateralInputs": 3,
+	"version": {"major": 10, "minor": 0},
+	"scriptExecutionPrices": {"memory": "577/10000", "cpu": "721/10000000"},
+	"maxExecutionUnitsPerTransaction": {
+		"memory": 14000000,
+		"cpu": 10000000000
+	},
+	"maxExecutionUnitsPerBlock": {"memory": 62000000, "cpu": 20000000000},
+	"minFeeReferenceScripts": {"base": 15, "range": 25600, "multiplier": 1.2},
+	"plutusCostModels": {
+		"plutus:v1": [100788, 420, 1, 1, 1000, 173, 0, 1],
+		"plutus:v2": [100788, 420, 1, 1, 1000, 173, 0, 1],
+		"plutus:v3": [100788, 420, 1, 1, 1000, 173, 0, 1]
+	},
+	"stakePoolVotingThresholds": {
+		"noConfidence": "51/100",
+		"constitutionalCommittee": {
+			"default": "51/100",
+			"stateOfNoConfidence": "51/100"
+		},
+		"hardForkInitiation": "51/100",
+		"protocolParametersUpdate": {"security": "51/100"}
+	},
+	"delegateRepresentativeVotingThresholds": {
+		"noConfidence": "67/100",
+		"constitutionalCommittee": {
+			"default": "67/100",
+			"stateOfNoConfidence": "3/5"
+		},
+		"constitution": "3/4",
+		"hardForkInitiation": "3/5",
+		"protocolParametersUpdate": {
+			"network": "67/100",
+			"economic": "67/100",
+			"technical": "67/100",
+			"governance": "3/4"
+		},
+		"treasuryWithdrawals": "67/100"
+	},
+	"constitutionalCommitteeMinSize": 7,
+	"constitutionalCommitteeMaxTermLength": 146,
+	"governanceActionLifetime": 6,
+	"governanceActionDeposit": %s,
+	"delegateRepresentativeDeposit": %s,
+	"delegateRepresentativeMaxIdleTime": 20
+}`
+
+// adaLovelace renders the Value<AdaOnly> encoding Ogmios has used since v6.1.0.
+func adaLovelace(amount int64) string {
+	return fmt.Sprintf(`{"ada": {"lovelace": %d}}`, amount)
+}
+
+// bareLovelace renders the flat encoding used by Ogmios v6.0.x.
+func bareLovelace(amount int64) string {
+	return fmt.Sprintf(`{"lovelace": %d}`, amount)
+}
+
+// protocolParamsBody renders ogmiosV6ProtocolParamsTemplate with every lovelace
+// amount encoded by the given function. The argument order must match the
+// placeholder order in the template.
+func protocolParamsBody(encode func(int64) string) string {
+	return fmt.Sprintf(
+		ogmiosV6ProtocolParamsTemplate,
+		encode(155381),       // minFeeConstant
+		encode(0),            // minUtxoDepositConstant
+		encode(2000000),      // stakeCredentialDeposit
+		encode(500000000),    // stakePoolDeposit
+		encode(170000000),    // minStakePoolCost
+		encode(100000000000), // governanceActionDeposit
+		encode(500000000),    // delegateRepresentativeDeposit
+	)
+}
+
+func decodeProtocolParams(
+	t *testing.T,
+	body string,
+) backend.ProtocolParameters {
+	t.Helper()
+	var raw ogmiosProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("failed to decode protocol params: %v", err)
+	}
+	pp, err := raw.toProtocolParams()
+	if err != nil {
+		t.Fatalf("failed to convert protocol params: %v", err)
+	}
+	return pp
+}
+
+// assertOgmiosV6ProtocolParams checks every parameter Apollo reads out of an
+// Ogmios protocol-parameters response against the fixture above. The zero
+// checks are the point of the test: a lovelace amount whose wire shape is not
+// understood decodes to 0 without an error, and a zero minFeeConstant leaves
+// every computed fee short by 155381 lovelace.
+func assertOgmiosV6ProtocolParams(t *testing.T, pp backend.ProtocolParameters) {
+	t.Helper()
+
+	intFields := []struct {
+		name string
+		got  int64
+		want int64
+	}{
+		{"MinFeeConstant", pp.MinFeeConstant, 155381},
+		{"MinFeeCoefficient", pp.MinFeeCoefficient, 44},
+		{"CoinsPerUtxoByteValue", pp.CoinsPerUtxoByteValue(), 4310},
+		{"MaxBlockSize", int64(pp.MaxBlockSize), 90112},
+		{"MaxBlockHeaderSize", int64(pp.MaxBlockHeaderSize), 1100},
+		{"MaxTxSize", int64(pp.MaxTxSize), 16384},
+		{"CollateralPercent", int64(pp.CollateralPercent), 150},
+		{"MaxCollateralInputs", int64(pp.MaxCollateralInputs), 3},
+		{
+			"MaximumReferenceScriptsSize",
+			int64(pp.MaximumReferenceScriptsSize),
+			204800,
+		},
+		{
+			"MinFeeReferenceScriptsRange",
+			int64(pp.MinFeeReferenceScriptsRange),
+			25600,
+		},
+	}
+	for _, field := range intFields {
+		if field.got == 0 {
+			t.Errorf("%s is zero: value was silently dropped", field.name)
+			continue
+		}
+		if field.got != field.want {
+			t.Errorf("%s = %d, want %d", field.name, field.got, field.want)
+		}
+	}
+
+	stringFields := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"KeyDeposits", pp.KeyDeposits, "2000000"},
+		{"PoolDeposits", pp.PoolDeposits, "500000000"},
+		{"MinPoolCost", pp.MinPoolCost, "170000000"},
+		{"CoinsPerUtxoByte", pp.CoinsPerUtxoByte, "4310"},
+		{"MaxTxExMem", pp.MaxTxExMem, "14000000"},
+		{"MaxTxExSteps", pp.MaxTxExSteps, "10000000000"},
+		{"MaxBlockExMem", pp.MaxBlockExMem, "62000000"},
+		{"MaxBlockExSteps", pp.MaxBlockExSteps, "20000000000"},
+		{"MaxValSize", pp.MaxValSize, "5000"},
+	}
+	for _, field := range stringFields {
+		if field.got == "" || field.got == "0" {
+			t.Errorf("%s = %q: value was silently dropped", field.name, field.got)
+			continue
+		}
+		if field.got != field.want {
+			t.Errorf("%s = %q, want %q", field.name, field.got, field.want)
+		}
+	}
+
+	if got, want := pp.PriceMem, 577.0/10000.0; got != want {
+		t.Errorf("PriceMem = %v, want %v", got, want)
+	}
+	if got, want := pp.PriceStep, 721.0/10000000.0; got != want {
+		t.Errorf("PriceStep = %v, want %v", got, want)
+	}
+
+	base, wantBase := pp.RefScriptFeePerByteRational(), big.NewRat(15, 1)
+	if base.Cmp(wantBase) != 0 {
+		t.Errorf("RefScriptFeePerByteRational() = %s, want %s", base, wantBase)
+	}
+	mult, wantMult := pp.RefScriptMultiplierRational(), big.NewRat(6, 5)
+	if mult.Cmp(wantMult) != 0 {
+		t.Errorf("RefScriptMultiplierRational() = %s, want %s", mult, wantMult)
+	}
+
+	for _, language := range []string{"PlutusV1", "PlutusV2", "PlutusV3"} {
+		costs, ok := pp.CostModels[language]
+		if !ok {
+			t.Errorf("cost models missing %s", language)
+			continue
+		}
+		if len(costs) == 0 || costs[0] != 100788 {
+			t.Errorf("%s cost model = %v", language, costs)
+		}
+	}
+}
+
+// TestProtocolParamsDecodeLovelaceShapes decodes a realistic Ogmios v6
+// protocol-parameters response in both lovelace encodings. Ogmios v6.0.x sent
+// a bare {"lovelace": N}; v6.1.0 onward sends {"ada": {"lovelace": N}}. Both
+// must yield the real parameter values.
+func TestProtocolParamsDecodeLovelaceShapes(t *testing.T) {
+	shapes := []struct {
+		name   string
+		encode func(int64) string
+	}{
+		{"ada nested (v6.1.0 onward)", adaLovelace},
+		{"bare lovelace (v6.0.x)", bareLovelace},
+	}
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			pp := decodeProtocolParams(t, protocolParamsBody(shape.encode))
+			assertOgmiosV6ProtocolParams(t, pp)
+		})
+	}
+}
+
+// TestProtocolParamsAcceptRenamedReferenceScriptsSize covers the v7.0 rename of
+// maxReferenceScriptsSize to maxReferenceScriptsSizePerTransaction.
+func TestProtocolParamsAcceptRenamedReferenceScriptsSize(t *testing.T) {
+	body := strings.Replace(
+		protocolParamsBody(adaLovelace),
+		`"maxReferenceScriptsSize"`,
+		`"maxReferenceScriptsSizePerTransaction"`,
+		1,
+	)
+	if body == protocolParamsBody(adaLovelace) {
+		t.Fatal("fixture no longer contains maxReferenceScriptsSize")
+	}
+
+	pp := decodeProtocolParams(t, body)
+	if got, want := pp.MaximumReferenceScriptsSize, 204800; got != want {
+		t.Fatalf("MaximumReferenceScriptsSize = %d, want %d", got, want)
+	}
+}
+
+// TestProtocolParamsLovelaceShapesAgree pins the two encodings to identical
+// results, so neither path can drift away from the other.
+func TestProtocolParamsLovelaceShapesAgree(t *testing.T) {
+	nested := decodeProtocolParams(t, protocolParamsBody(adaLovelace))
+	bare := decodeProtocolParams(t, protocolParamsBody(bareLovelace))
+	if !reflect.DeepEqual(nested, bare) {
+		t.Fatalf("encodings disagree:\nnested = %+v\nbare   = %+v", nested, bare)
+	}
+}
+
+// TestProtocolParamsProduceLedgerMinFee mirrors the fee formula Apollo applies
+// in Complete() to prove the decoded parameters produce the fee the ledger
+// expects. With a dropped minFeeConstant this fee is 155381 lovelace short and
+// the node rejects the transaction with FeeTooSmallUTxO.
+func TestProtocolParamsProduceLedgerMinFee(t *testing.T) {
+	pp := decodeProtocolParams(t, protocolParamsBody(adaLovelace))
+
+	const txSize = 1024
+	got := int64(txSize)*pp.MinFeeCoefficient + pp.MinFeeConstant
+	want := int64(txSize*44 + 155381)
+	if got != want {
+		t.Fatalf(
+			"min fee for a %d-byte tx = %d, want %d (short by %d)",
+			txSize, got, want, want-got,
+		)
+	}
+}
+
+// TestOgmiosLovelaceRejectsUnrecognizedShape is the guard against the next
+// wire-format change: an amount Apollo cannot interpret must be an error, not
+// a zero. Silently decoding to zero is what shipped the fee bug.
+func TestOgmiosLovelaceRejectsUnrecognizedShape(t *testing.T) {
+	bodies := []string{
+		`{}`,
+		`null`,
+		`{"coin": 155381}`,
+		`{"ada": {}}`,
+		`{"ada": {"coin": 155381}}`,
+		`{"ada": null}`,
+		`{"lovelaces": 155381}`,
+	}
+	for _, body := range bodies {
+		t.Run(body, func(t *testing.T) {
+			var amount ogmiosLovelace
+			err := json.Unmarshal([]byte(body), &amount)
+			if err == nil {
+				t.Fatalf(
+					"%s decoded to %d without error; an unrecognized"+
+						" shape must not become a silent zero",
+					body, amount.Lovelace,
+				)
+			}
+		})
+	}
+}
+
+// TestOgmiosLovelacePrefersAdaWhenBothPresent documents the precedence used if
+// a response ever carries both encodings.
+func TestOgmiosLovelacePrefersAdaWhenBothPresent(t *testing.T) {
+	var amount ogmiosLovelace
+	body := `{"ada": {"lovelace": 155381}, "lovelace": 7}`
+	if err := json.Unmarshal([]byte(body), &amount); err != nil {
+		t.Fatal(err)
+	}
+	if amount.Lovelace != 155381 {
+		t.Fatalf("lovelace = %d, want 155381", amount.Lovelace)
+	}
+}
+
+// TestProtocolParamsRejectUnrecognizedLovelaceShape checks that an unreadable
+// amount fails the whole response rather than one field.
+func TestProtocolParamsRejectUnrecognizedLovelaceShape(t *testing.T) {
+	body := protocolParamsBody(func(amount int64) string {
+		return fmt.Sprintf(`{"coin": %d}`, amount)
+	})
+	var raw ogmiosProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err == nil {
+		t.Fatal("expected an error for an unrecognized lovelace encoding")
+	}
+}
+
+// TestProtocolParamsRejectMissingRequiredFields covers the other way a
+// parameter can silently become zero: the key disappearing from the response.
+func TestProtocolParamsRejectMissingRequiredFields(t *testing.T) {
+	const body = `{"scriptExecutionPrices": {"memory": "1/1", "cpu": "1/1"}}`
+
+	var raw ogmiosProtocolParams
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	_, err := raw.toProtocolParams()
+	if err == nil {
+		t.Fatal("expected an error for missing fee and deposit parameters")
+	}
+	required := []string{
+		"minFeeCoefficient",
+		"minFeeConstant",
+		"minUtxoDepositCoefficient",
+		"stakeCredentialDeposit",
+		"stakePoolDeposit",
+		"minStakePoolCost",
+	}
+	for _, field := range required {
+		if !strings.Contains(err.Error(), field) {
+			t.Errorf("error %q does not report missing %s", err, field)
+		}
+	}
+}
+
+// ogmiosV6ShelleyGenesisBody is a queryNetwork/genesisConfiguration result for
+// the Shelley era as Ogmios v6.x serves it, carrying the real mainnet values.
+// Note the two shapes that are easy to get wrong: activeSlotsCoefficient is an
+// exact ratio string, and slotLength is an object in milliseconds. The
+// initialParameters/initialFunds members are abridged; Apollo does not read
+// them.
+const ogmiosV6ShelleyGenesisBody = `{
+	"era": "shelley",
+	"startTime": "2017-09-23T21:44:51Z",
+	"networkMagic": 764824073,
+	"network": "mainnet",
+	"activeSlotsCoefficient": "1/20",
+	"securityParameter": 2160,
+	"epochLength": 432000,
+	"slotsPerKesPeriod": 129600,
+	"maxKesEvolutions": 62,
+	"slotLength": {"milliseconds": 1000},
+	"updateQuorum": 5,
+	"maxLovelaceSupply": 45000000000000000,
+	"initialParameters": {
+		"minFeeCoefficient": 44,
+		"minFeeConstant": {"ada": {"lovelace": 155381}}
+	},
+	"initialDelegates": [],
+	"initialFunds": {},
+	"initialStakePools": {"stakePools": {}, "delegators": {}}
+}`
+
+func decodeGenesisParams(
+	t *testing.T,
+	body string,
+) backend.GenesisParameters {
+	t.Helper()
+	var raw ogmiosGenesisConfig
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("failed to decode genesis config: %v", err)
+	}
+	gp, err := raw.toGenesisParams()
+	if err != nil {
+		t.Fatalf("failed to convert genesis config: %v", err)
+	}
+	return gp
+}
+
+// TestGenesisParamsDecodeOgmiosV6Response decodes a realistic Ogmios v6 Shelley
+// genesis response. activeSlotsCoefficient is a ratio string and slotLength is
+// {"milliseconds": N}; decoding either into a plain scalar makes the whole
+// GenesisParams call fail.
+func TestGenesisParamsDecodeOgmiosV6Response(t *testing.T) {
+	gp := decodeGenesisParams(t, ogmiosV6ShelleyGenesisBody)
+
+	if got, want := gp.ActiveSlotsCoefficient, 0.05; got != want {
+		t.Errorf("ActiveSlotsCoefficient = %v, want %v", got, want)
+	}
+	if got, want := gp.SlotLength, 1; got != want {
+		t.Errorf("SlotLength = %d seconds, want %d", got, want)
+	}
+	// 2017-09-23T21:44:51Z, the mainnet system start, in Unix seconds.
+	if got, want := gp.SystemStart, int64(1506203091); got != want {
+		t.Errorf("SystemStart = %d, want %d", got, want)
+	}
+
+	intFields := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"NetworkMagic", gp.NetworkMagic, 764824073},
+		{"SecurityParam", gp.SecurityParam, 2160},
+		{"EpochLength", gp.EpochLength, 432000},
+		{"SlotsPerKesPeriod", gp.SlotsPerKesPeriod, 129600},
+		{"MaxKesEvolutions", gp.MaxKesEvolutions, 62},
+		{"UpdateQuorum", gp.UpdateQuorum, 5},
+	}
+	for _, field := range intFields {
+		if field.got == 0 {
+			t.Errorf("%s is zero: value was silently dropped", field.name)
+			continue
+		}
+		if field.got != field.want {
+			t.Errorf("%s = %d, want %d", field.name, field.got, field.want)
+		}
+	}
+
+	if got, want := gp.MaxLovelaceSupply, "45000000000000000"; got != want {
+		t.Errorf("MaxLovelaceSupply = %q, want %q", got, want)
+	}
+}
+
+// TestGenesisParamsAcceptLegacyScalarShapes keeps the older Ogmios encodings
+// working: a bare number for the coefficient and whole seconds for the slot
+// length.
+func TestGenesisParamsAcceptLegacyScalarShapes(t *testing.T) {
+	const body = `{
+		"startTime": "2017-09-23T21:44:51Z",
+		"networkMagic": 764824073,
+		"activeSlotsCoefficient": 0.05,
+		"securityParameter": 2160,
+		"epochLength": 432000,
+		"slotsPerKesPeriod": 129600,
+		"maxKesEvolutions": 62,
+		"slotLength": 1,
+		"updateQuorum": 5,
+		"maxLovelaceSupply": 45000000000000000
+	}`
+
+	gp := decodeGenesisParams(t, body)
+	if got, want := gp.ActiveSlotsCoefficient, 0.05; got != want {
+		t.Errorf("ActiveSlotsCoefficient = %v, want %v", got, want)
+	}
+	if got, want := gp.SlotLength, 1; got != want {
+		t.Errorf("SlotLength = %d, want %d", got, want)
+	}
+}
+
+// TestGenesisParamsRejectUnrecognizedShapes holds the genesis decoding to the
+// same rule as the protocol parameters: a value Apollo cannot interpret is an
+// error, never a zero.
+func TestGenesisParamsRejectUnrecognizedShapes(t *testing.T) {
+	bodies := map[string]string{
+		"ratio object":       `{"activeSlotsCoefficient": {"ratio": "1/20"}}`,
+		"ratio not a number": `{"activeSlotsCoefficient": "one twentieth"}`,
+		"slot length object": `{"slotLength": {"seconds": 1}}`,
+		"slot length string": `{"slotLength": "1000ms"}`,
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			var raw ogmiosGenesisConfig
+			if err := json.Unmarshal([]byte(body), &raw); err == nil {
+				t.Fatalf(
+					"%s decoded without error; an unrecognized"+
+						" shape must not become a silent zero",
+					body,
+				)
+			}
+		})
+	}
+}
+
+// TestGenesisParamsRejectInvalidStartTime keeps an unparseable timestamp from
+// silently becoming a zero system start.
+func TestGenesisParamsRejectInvalidStartTime(t *testing.T) {
+	const body = `{"startTime": "yesterday"}`
+
+	var raw ogmiosGenesisConfig
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.toGenesisParams(); err == nil {
+		t.Fatal("expected an error for an unparseable start time")
 	}
 }

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -24,6 +24,7 @@ import (
 	sdk "github.com/utxorpc/go-sdk"
 
 	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/internal/backendutil"
 )
 
 // UtxoRpcChainContext implements backend.ChainContext using the UTxO RPC protocol.
@@ -152,23 +153,23 @@ func (u *UtxoRpcChainContext) ProtocolParamsContext(ctx context.Context) (backen
 		return backend.ProtocolParameters{}, errors.New("no cardano params in response")
 	}
 
-	maxBlockSize, err := backend.BoundedIntFromUint64(params.GetMaxBlockBodySize(), "max block body size")
+	maxBlockSize, err := backendutil.BoundedIntFromUint64(params.GetMaxBlockBodySize(), "max block body size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxTxSize, err := backend.BoundedIntFromUint64(params.GetMaxTxSize(), "max tx size")
+	maxTxSize, err := backendutil.BoundedIntFromUint64(params.GetMaxTxSize(), "max tx size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxBlockHeaderSize, err := backend.BoundedIntFromUint64(params.GetMaxBlockHeaderSize(), "max block header size")
+	maxBlockHeaderSize, err := backendutil.BoundedIntFromUint64(params.GetMaxBlockHeaderSize(), "max block header size")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	collateralPercent, err := backend.BoundedIntFromUint64(params.GetCollateralPercentage(), "collateral percentage")
+	collateralPercent, err := backendutil.BoundedIntFromUint64(params.GetCollateralPercentage(), "collateral percentage")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
-	maxCollateralInputs, err := backend.BoundedIntFromUint64(params.GetMaxCollateralInputs(), "max collateral inputs")
+	maxCollateralInputs, err := backendutil.BoundedIntFromUint64(params.GetMaxCollateralInputs(), "max collateral inputs")
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,16 +2,8 @@ package constants
 
 const MinLovelace = 1_000_000
 
-type Network int
-
-const (
-	MAINNET Network = iota
-	TESTNET
-	PREVIEW
-	PREPROD
-)
-
+// Blockfrost API base URLs. Backend constructors take a Cardano network ID
+// (mainnet = 1, testnets = 0) alongside one of these URLs.
 const BlockfrostBaseUrlMainnet = "https://cardano-mainnet.blockfrost.io/api/v0"
-const BlockfrostBaseUrlTestnet = "https://cardano-testnet.blockfrost.io/api/v0"
 const BlockfrostBaseUrlPreview = "https://cardano-preview.blockfrost.io/api/v0"
 const BlockfrostBaseUrlPreprod = "https://cardano-preprod.blockfrost.io/api/v0"

--- a/convenience.go
+++ b/convenience.go
@@ -10,7 +10,7 @@ import (
 
 // AddInputAddressFromBech32 adds a bech32 address whose UTxOs should be used for coin selection.
 func (a *Apollo) AddInputAddressFromBech32(bech32 string) (*Apollo, error) {
-	addr, err := common.NewAddress(bech32)
+	addr, err := ParseAddress(bech32)
 	if err != nil {
 		return a, fmt.Errorf("invalid bech32 address: %w", err)
 	}
@@ -20,7 +20,7 @@ func (a *Apollo) AddInputAddressFromBech32(bech32 string) (*Apollo, error) {
 
 // PayToAddressBech32 creates a simple payment to a bech32 address.
 func (a *Apollo) PayToAddressBech32(bech32 string, lovelace int64, units ...Unit) (*Apollo, error) {
-	addr, err := common.NewAddress(bech32)
+	addr, err := ParseAddress(bech32)
 	if err != nil {
 		return a, fmt.Errorf("invalid bech32 address: %w", err)
 	}
@@ -30,7 +30,7 @@ func (a *Apollo) PayToAddressBech32(bech32 string, lovelace int64, units ...Unit
 
 // SetChangeAddressBech32 sets the change address from a bech32 string.
 func (a *Apollo) SetChangeAddressBech32(bech32 string) (*Apollo, error) {
-	addr, err := common.NewAddress(bech32)
+	addr, err := ParseAddress(bech32)
 	if err != nil {
 		return a, fmt.Errorf("invalid bech32 address: %w", err)
 	}

--- a/datum_hash_test.go
+++ b/datum_hash_test.go
@@ -1,0 +1,259 @@
+package apollo
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+)
+
+// blake2bOfNothing is what common.Datum.Hash returns for a datum that was
+// built in Go rather than decoded from CBOR: its stored CBOR is empty, so the
+// method hashes the empty string. Any datum hash equal to this is a bug.
+const blake2bOfNothing = "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787" +
+	"faab45cdf12fe3a8"
+
+func decodeDatum(t *testing.T, cborHex string) common.Datum {
+	t.Helper()
+	raw, err := hex.DecodeString(cborHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var datum common.Datum
+	if err := datum.UnmarshalCBOR(raw); err != nil {
+		t.Fatalf("decode datum %s: %v", cborHex, err)
+	}
+	return datum
+}
+
+// TestDatumHashUsesWireBytesForBuiltDatum covers the trap that
+// common.Datum.Hash falls into for a datum that was never decoded.
+func TestDatumHashUsesWireBytesForBuiltDatum(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	if len(datum.Cbor()) != 0 {
+		t.Fatalf("expected no stored CBOR, got %x", datum.Cbor())
+	}
+	if got := datum.Hash().String(); got != blake2bOfNothing {
+		t.Fatalf(
+			"common.Datum.Hash on a built datum = %s, want %s",
+			got,
+			blake2bOfNothing,
+		)
+	}
+
+	got, err := DatumHash(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(wire) != "1863" {
+		t.Fatalf("unexpected wire bytes %x", wire)
+	}
+	want := common.Blake2b256Hash(wire)
+	if got != want {
+		t.Fatalf("DatumHash = %x, want %x", got.Bytes(), want.Bytes())
+	}
+	if got.String() == blake2bOfNothing {
+		t.Fatal("DatumHash returned the hash of the empty string")
+	}
+	// DatumWireCbor pins the wire bytes, so the obvious method now agrees.
+	if datum.Hash() != want {
+		t.Fatalf(
+			"common.Datum.Hash = %x after pinning, want %x",
+			datum.Hash().Bytes(),
+			want.Bytes(),
+		)
+	}
+}
+
+func TestDatumWireCborKeepsCanonicalStoredBytes(t *testing.T) {
+	datum := decodeDatum(t, "d8799f4161ff")
+	got, err := DatumWireCbor(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != "d8799f4161ff" {
+		t.Fatalf("DatumWireCbor = %x, want d8799f4161ff", got)
+	}
+	hash, err := DatumHash(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != datum.Hash() {
+		t.Fatalf(
+			"DatumHash %x disagrees with common.Datum.Hash %x",
+			hash.Bytes(),
+			datum.Hash().Bytes(),
+		)
+	}
+}
+
+// TestDatumWireCborRejectsNonCanonicalStoredBytes covers datum encodings that
+// plutigo cannot reproduce. Hashing the stored bytes while the witness set
+// carries the re-encoded bytes is what silently locks funds, so Apollo refuses
+// the datum instead.
+func TestDatumWireCborRejectsNonCanonicalStoredBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cborHex  string
+		wantWire string
+	}{
+		{
+			name: "definite byte string above the 64 byte chunk limit",
+			cborHex: "d8799f5864" +
+				strings.Repeat("ab", 100) + "ff",
+			wantWire: "d8799f5f5840" + strings.Repeat("ab", 64) +
+				"5824" + strings.Repeat("ab", 36) + "ffff",
+		},
+		{
+			name:     "non-minimal integer",
+			cborHex:  "1801",
+			wantWire: "01",
+		},
+		{
+			name:     "two byte integer holding a small value",
+			cborHex:  "190001",
+			wantWire: "01",
+		},
+		{
+			name:     "bignum tag around a small value",
+			cborHex:  "c24101",
+			wantWire: "01",
+		},
+		{
+			name:     "indefinite length byte string",
+			cborHex:  "5f4161ff",
+			wantWire: "4161",
+		},
+		{
+			name:     "indefinite length constr fields",
+			cborHex:  "d8669f18809f01ffff",
+			wantWire: "d8668218809f01ff",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			datum := decodeDatum(t, test.cborHex)
+			wire, err := cbor.Encode(&datum)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hex.EncodeToString(wire) != test.wantWire {
+				t.Fatalf(
+					"wire bytes = %x, want %s",
+					wire,
+					test.wantWire,
+				)
+			}
+			storedHash := common.Blake2b256Hash(datum.Cbor())
+			wireHash := common.Blake2b256Hash(wire)
+			if storedHash == wireHash {
+				t.Fatalf(
+					"stored and wire bytes hash alike (%x); not a divergent case",
+					storedHash.Bytes(),
+				)
+			}
+
+			if _, err := DatumWireCbor(&datum); err == nil {
+				t.Fatal("expected DatumWireCbor to reject the datum")
+			} else {
+				if !strings.Contains(err.Error(), storedHash.String()) {
+					t.Errorf(
+						"error does not name the original hash %s: %v",
+						storedHash.String(),
+						err,
+					)
+				}
+				if !strings.Contains(err.Error(), wireHash.String()) {
+					t.Errorf(
+						"error does not name the wire hash %s: %v",
+						wireHash.String(),
+						err,
+					)
+				}
+			}
+
+			if _, err := DatumHash(&datum); err == nil {
+				t.Fatal("expected DatumHash to reject the datum")
+			}
+		})
+	}
+}
+
+func TestAddDatumRejectsNonCanonicalStoredBytes(t *testing.T) {
+	datum := decodeDatum(t, "d8799f5864"+strings.Repeat("ab", 100)+"ff")
+	cc := setupFixedContext()
+	a := New(cc).AddDatum(&datum)
+	if len(a.datums) != 0 {
+		t.Fatalf("expected the datum to be rejected, got %d", len(a.datums))
+	}
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected Complete to report the datum error")
+	} else if !strings.Contains(err.Error(), "AddDatum") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestPayToContractWithDatumHashPreservesDatumIdentity requires that Apollo
+// either declares the hash the caller's datum bytes actually have, or refuses
+// the payment. Silently declaring some other hash creates an output at a script
+// address whose datum the counterparty cannot match, locking the funds.
+func TestPayToContractWithDatumHashPreservesDatumIdentity(t *testing.T) {
+	datum := decodeDatum(t, "d8799f5864"+strings.Repeat("ab", 100)+"ff")
+	want := common.Blake2b256Hash(datum.Cbor())
+
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	a, err := New(cc).PayToContractWithDatumHash(addr, &datum, 2_000_000)
+	if err != nil {
+		// Refusing a datum whose bytes cannot be preserved is correct.
+		return
+	}
+	if len(a.payments) != 1 {
+		t.Fatalf("expected 1 payment, got %d", len(a.payments))
+	}
+	txOut, err := a.payments[0].ToTxOut()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := txOut.DatumHash()
+	if got == nil {
+		t.Fatal("output carries no datum hash")
+	}
+	if *got != want {
+		t.Fatalf(
+			"output declares datum hash %x for a datum whose bytes hash to %x",
+			got.Bytes(),
+			want.Bytes(),
+		)
+	}
+}
+
+func TestPayToContractWithDatumHashRejectsNonCanonicalDatum(t *testing.T) {
+	datum := decodeDatum(t, "d8799f5864"+strings.Repeat("ab", 100)+"ff")
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	_, err := New(cc).PayToContractWithDatumHash(addr, &datum, 2_000_000)
+	if err == nil {
+		t.Fatal("expected PayToContractWithDatumHash to reject the datum")
+	}
+	if !strings.Contains(err.Error(), "canonical Plutus form") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDatumWireCborRejectsNil(t *testing.T) {
+	if _, err := DatumWireCbor(nil); err == nil {
+		t.Fatal("expected an error for a nil datum")
+	}
+	if _, err := DatumHash(nil); err == nil {
+		t.Fatal("expected an error for a nil datum")
+	}
+}

--- a/docs/v2_migration/MIGRATION.md
+++ b/docs/v2_migration/MIGRATION.md
@@ -407,7 +407,11 @@ type PaymentI interface {
 }
 ```
 
-**`ParseFraction` returns errors**: `backend.ParseFraction` now returns `(float64, error)` instead of silently returning 0 on invalid input.
+**Provider response parsing is internal**: the helpers that normalize provider
+API responses (`ParseFraction`, `ParseRational`, `ParseAssetUnit`,
+`ParseRedeemerTag`, `BoundedInt`, `BoundedIntFromUint64`, `ScriptRefFromBytes`)
+are no longer exported from `backend`. They live in an internal package and
+validate their input instead of silently returning zero values.
 
 ### 15. Wallet Passphrase Support
 
@@ -430,6 +434,18 @@ if err != nil {
     return err
 }
 ```
+
+### 16. Removed Constants and Types
+
+| Removed | Replacement |
+|---------|-------------|
+| `constants.Network`, `constants.MAINNET`, `constants.TESTNET`, `constants.PREVIEW`, `constants.PREPROD` | Pass the Cardano network ID directly: mainnet = `1`, testnets = `0`. The old enum numbered mainnet `0`, the inverse of the network IDs every backend constructor takes |
+| `constants.BlockfrostBaseUrlTestnet` | `constants.BlockfrostBaseUrlPreview` or `constants.BlockfrostBaseUrlPreprod`; the legacy testnet was decommissioned in 2023 |
+| `backend.AddressAmount` | None; it was never used by any API |
+
+`GetBurns()` now returns the absolute quantities of assets being burned rather
+than the net mint value. Use `GetMints()` for the net mint value, which retains
+negative quantities for burns.
 
 ## Selected v2 Public API
 
@@ -474,6 +490,7 @@ documentation and exported declarations are the authoritative complete API.
 - `AddDatum(datum) *Apollo`
 - `AttachDatum(datum) *Apollo`
 - `Mint(unit, redeemer, exUnits) *Apollo`
+- `GetMints() (Value, error)`
 - `GetBurns() (Value, error)`
 
 ### Reference Inputs

--- a/evaluation_capability_test.go
+++ b/evaluation_capability_test.go
@@ -1,0 +1,274 @@
+package apollo
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// capabilityEvalContext is a deterministic evaluation backend whose reported
+// capabilities and additionalUtxos handling are configurable, so a build can be
+// driven through both sides of the CapabilityEvaluateTxAdditionalUtxos gate.
+// It performs no network I/O.
+type capabilityEvalContext struct {
+	*fixed.FixedChainContext
+
+	// supportsAdditionalUtxos adds CapabilityEvaluateTxAdditionalUtxos to the
+	// reported set, as Maestro and Ogmios do.
+	supportsAdditionalUtxos bool
+	// rejectAdditionalUtxos fails on a non-empty set, as backend/utxorpc does.
+	rejectAdditionalUtxos bool
+
+	// result is returned for every accepted call.
+	result map[common.RedeemerKey]common.ExUnits
+
+	// received records the additionalUtxos of each call, preserving nil.
+	received [][]common.Utxo
+}
+
+func (c *capabilityEvalContext) Capabilities() backend.CapabilitySet {
+	caps := c.FixedChainContext.Capabilities() |
+		backend.CapabilitySet(backend.CapabilityEvaluateTx)
+	if c.supportsAdditionalUtxos {
+		caps |= backend.CapabilitySet(
+			backend.CapabilityEvaluateTxAdditionalUtxos,
+		)
+	}
+	return caps
+}
+
+func (c *capabilityEvalContext) EvaluateTx(
+	_ []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	c.received = append(c.received, additionalUtxos)
+	if c.rejectAdditionalUtxos && len(additionalUtxos) > 0 {
+		return nil, backend.NewUnsupportedError(
+			"UTxO RPC", backend.CapabilityEvaluateTxAdditionalUtxos)
+	}
+	if c.result == nil {
+		return nil, errors.New("capabilityEvalContext: result not configured")
+	}
+	return c.result, nil
+}
+
+// setupCapabilityMintBuilder builds a Plutus minting transaction, the smallest
+// script build that still forwards resolved spending inputs to the evaluator.
+func setupCapabilityMintBuilder(
+	t *testing.T,
+	cc *capabilityEvalContext,
+) *Apollo {
+	t.Helper()
+	addr := testAddress(t)
+	addTestUtxo(cc.FixedChainContext, addr, 50_000_000, 0x31, 0)
+	addTestUtxo(cc.FixedChainContext, addr, 20_000_000, 0x32, 0)
+
+	policyHex := strings.Repeat("ab", 28)
+	redeemer := testRedeemerDatum()
+	p, err := NewPayment(validTestAddrBech32, 2_000_000,
+		[]Unit{NewUnit(policyHex, "746f6b656e", 5)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Mint(NewUnit(policyHex, "746f6b656e", 5), &redeemer, nil)
+}
+
+// TestPlutusBuildSucceedsWhenBackendRejectsAdditionalUtxos is the regression
+// test for the release blocker: Apollo forwarded every resolved spending input
+// as additionalUtxos, and a backend that rejects a non-empty set (UTxO RPC)
+// could therefore not build any Plutus transaction at all.
+func TestPlutusBuildSucceedsWhenBackendRejectsAdditionalUtxos(t *testing.T) {
+	cc := &capabilityEvalContext{
+		FixedChainContext:     setupFixedContext(),
+		rejectAdditionalUtxos: true,
+		result:                mintRedeemerUnits(1_000, 1_000),
+	}
+	a, err := setupCapabilityMintBuilder(t, cc).Complete()
+	if err != nil {
+		t.Fatalf("Complete on additional-UTxO-rejecting backend: %v", err)
+	}
+	if a.GetTx() == nil {
+		t.Fatal("expected a built transaction")
+	}
+	if len(cc.received) == 0 {
+		t.Fatal("expected EvaluateTx to be called")
+	}
+}
+
+// TestPlutusSpendSucceedsWhenBackendRejectsAdditionalUtxos covers the script
+// spend path, where the redeemer index is resolved against the same inputs
+// slice that used to be forwarded as additionalUtxos.
+func TestPlutusSpendSucceedsWhenBackendRejectsAdditionalUtxos(t *testing.T) {
+	cc := &capabilityEvalContext{
+		FixedChainContext:     setupFixedContext(),
+		rejectAdditionalUtxos: true,
+	}
+	addr := testAddress(t)
+	addTestUtxo(cc.FixedChainContext, addr, 30_000_000, 0x41, 0)
+
+	var scriptHash common.Blake2b256
+	scriptHash[0] = 0x42
+	scriptUtxo := makeTestUtxo(t, scriptHash, 0, 10_000_000)
+	cc.AddUtxo(addr, scriptUtxo)
+
+	// The spend redeemer index follows the canonical input ordering, so resolve
+	// it from the sorted inputs rather than assuming index 0.
+	inputs := SortInputs([]common.Utxo{scriptUtxo})
+	spendIndex := uint32(0)
+	for i, utxo := range inputs {
+		if utxoRef(utxo) == utxoRef(scriptUtxo) {
+			spendIndex = uint32(i) //nolint:gosec // bounded by len(inputs)
+		}
+	}
+	cc.result = map[common.RedeemerKey]common.ExUnits{
+		{Tag: common.RedeemerTagSpend, Index: spendIndex}: {
+			Memory: 1_000, Steps: 1_000,
+		},
+	}
+
+	redeemer := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AttachScript(common.PlutusV2Script([]byte{0x01, 0x02})).
+		CollectFrom(scriptUtxo, redeemer, common.ExUnits{}).
+		AddPayment(p).
+		SetTtl(50_000_000)
+
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete on additional-UTxO-rejecting backend: %v", err)
+	}
+	for i, utxos := range cc.received {
+		if utxos != nil {
+			t.Fatalf("call %d received %d additional UTxOs, want nil",
+				i, len(utxos))
+		}
+	}
+}
+
+// TestEvaluationOmitsAdditionalUtxosWhenCapabilityAbsent asserts the gate
+// itself: a context that declines the capability must be handed nil, not an
+// argument the ChainContext contract permits it to reject.
+func TestEvaluationOmitsAdditionalUtxosWhenCapabilityAbsent(t *testing.T) {
+	cc := &capabilityEvalContext{
+		FixedChainContext: setupFixedContext(),
+		result:            mintRedeemerUnits(1_000, 1_000),
+	}
+	if backend.Supports(cc, backend.CapabilityEvaluateTxAdditionalUtxos) {
+		t.Fatal("stub must not report additional-UTxO support")
+	}
+	if _, err := setupCapabilityMintBuilder(t, cc).Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.received) == 0 {
+		t.Fatal("expected EvaluateTx to be called")
+	}
+	for i, utxos := range cc.received {
+		if utxos != nil {
+			t.Fatalf("call %d received %d additional UTxOs, want nil",
+				i, len(utxos))
+		}
+	}
+}
+
+// TestEvaluationSendsAdditionalUtxosWhenCapabilityPresent is the other half of
+// the gate: a reporting context must still receive the full resolved input set,
+// which is what off-chain and chained inputs depend on.
+func TestEvaluationSendsAdditionalUtxosWhenCapabilityPresent(t *testing.T) {
+	cc := &capabilityEvalContext{
+		FixedChainContext:       setupFixedContext(),
+		supportsAdditionalUtxos: true,
+		result:                  mintRedeemerUnits(1_000, 1_000),
+	}
+	a, err := setupCapabilityMintBuilder(t, cc).Complete()
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.received) == 0 {
+		t.Fatal("expected EvaluateTx to be called")
+	}
+	wanted := a.GetTx().Body.Inputs()
+	for i, utxos := range cc.received {
+		if len(utxos) != len(wanted) {
+			t.Fatalf("call %d received %d additional UTxOs, want %d",
+				i, len(utxos), len(wanted))
+		}
+		refs := make(map[string]bool, len(utxos))
+		for _, utxo := range utxos {
+			refs[utxoRef(utxo)] = true
+		}
+		for _, in := range wanted {
+			ref := utxoRef(common.Utxo{Id: in})
+			if !refs[ref] {
+				t.Fatalf("call %d omitted resolved input %s", i, ref)
+			}
+		}
+	}
+}
+
+// unreportedEvalContext embeds the ChainContext interface rather than the stub
+// type, so the stub's Capabilities method is not promoted and the wrapper does
+// not satisfy backend.CapabilityReporter. It stands in for a third-party
+// backend written before capability reporting existed.
+type unreportedEvalContext struct {
+	backend.ChainContext
+	inner *capabilityEvalContext
+}
+
+// TestEvaluationSendsAdditionalUtxosForUnreportedContext pins the documented
+// fallback for third-party backends: backend.CapabilitiesOf reports
+// AllCapabilities for a ChainContext that does not implement
+// CapabilityReporter, so such a context keeps the historic behavior of
+// receiving the resolved input set.
+func TestEvaluationSendsAdditionalUtxosForUnreportedContext(t *testing.T) {
+	stub := &capabilityEvalContext{
+		FixedChainContext: setupFixedContext(),
+		result:            mintRedeemerUnits(1_000, 1_000),
+	}
+	cc := &unreportedEvalContext{ChainContext: stub, inner: stub}
+	if _, ok := backend.ChainContext(cc).(backend.CapabilityReporter); ok {
+		t.Fatal("wrapper must not satisfy backend.CapabilityReporter")
+	}
+	if !backend.Supports(cc, backend.CapabilityEvaluateTxAdditionalUtxos) {
+		t.Fatal("a context without CapabilityReporter must report everything")
+	}
+
+	addr := testAddress(t)
+	addTestUtxo(stub.FixedChainContext, addr, 50_000_000, 0x51, 0)
+	policyHex := strings.Repeat("ab", 28)
+	redeemer := testRedeemerDatum()
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Mint(NewUnit(policyHex, "746f6b656e", 1), &redeemer, nil)
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(cc.inner.received) == 0 {
+		t.Fatal("expected EvaluateTx to be called")
+	}
+	for i, utxos := range cc.inner.received {
+		if len(utxos) == 0 {
+			t.Fatalf("call %d received no additional UTxOs", i)
+		}
+	}
+}

--- a/evaluation_convergence_test.go
+++ b/evaluation_convergence_test.go
@@ -1,0 +1,180 @@
+package apollo
+
+import (
+	"math/big"
+	"testing"
+)
+
+// buildTransfer completes a plain lovelace payment from a wallet holding
+// exactly balance, with no scripts involved.
+func buildTransfer(
+	t *testing.T,
+	balance uint64,
+	pay int64,
+) (*Apollo, error) {
+	t.Helper()
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, balance, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, pay, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Complete()
+}
+
+// minFeeForTx returns the protocol minimum size-based fee for the serialized
+// transaction, computed independently of the builder.
+func minFeeForTx(t *testing.T, a *Apollo) uint64 {
+	t.Helper()
+	txCbor, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pp, err := a.Context.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pp.MinFeeCoefficient <= 0 || pp.MinFeeConstant <= 0 {
+		t.Fatalf(
+			"protocol params not usable: minFeeA=%d minFeeB=%d",
+			pp.MinFeeCoefficient, pp.MinFeeConstant,
+		)
+	}
+	//nolint:gosec // protocol params validated positive above
+	return uint64(len(txCbor))*uint64(pp.MinFeeCoefficient) +
+		uint64(pp.MinFeeConstant)
+}
+
+// TestDustChangeIsAbsorbedIntoFee is the regression guard for the fee
+// convergence loop. When change falls below the change output's min-UTxO,
+// buildBalancedOutputs drops the change output and adds the remainder to the
+// fee. The loop previously fed that dust-inclusive fee back into estimateFee,
+// which cannot predict the surcharge, so the comparison never matched and
+// every such transaction failed with "did not converge".
+func TestDustChangeIsAbsorbedIntoFee(t *testing.T) {
+	const pay = 2_000_000
+
+	// Change of 900_000 is below the ~978_370 min-UTxO for an ADA-only change
+	// output, so it must be absorbed rather than emitted.
+	a, err := buildTransfer(t, pay+900_000, pay)
+	if err != nil {
+		t.Fatalf("dust-change transfer failed to build: %v", err)
+	}
+
+	tx := a.GetTx()
+	if got := len(tx.Body.Outputs()); got != 1 {
+		t.Errorf("built %d outputs, want 1 (change must be absorbed)", got)
+	}
+	if got, want := tx.Body.TxFee, uint64(900_000); got != want {
+		t.Errorf("fee = %d, want %d (payment remainder absorbed)", got, want)
+	}
+	assertValueConserved(t, a, pay+900_000)
+}
+
+// TestDustChangeBandBuilds sweeps the whole range in which change is dust and
+// asserts every balance produces a valid, fully funded transaction.
+func TestDustChangeBandBuilds(t *testing.T) {
+	const pay = 2_000_000
+
+	// The lower bound is imposed by coin selection, which currently reserves
+	// the whole of MaxTxFee (876_277 on these parameters) rather than an
+	// estimate, so balances below payment+MaxTxFee never reach the fee loop.
+	// That over-reserve is a separate defect; this test covers the range the
+	// convergence loop is actually reached for, spanning both the dust-absorbed
+	// and change-emitted outcomes.
+	for balance := uint64(pay + 880_000); balance <= pay+1_200_000; balance += 5_000 {
+		a, err := buildTransfer(t, balance, pay)
+		if err != nil {
+			t.Errorf("balance %d: %v", balance, err)
+			continue
+		}
+		tx := a.GetTx()
+		outputs := len(tx.Body.Outputs())
+		if outputs != 1 && outputs != 2 {
+			t.Errorf("balance %d: built %d outputs, want 1 or 2", balance, outputs)
+		}
+		// Whether change was absorbed or emitted, the fee must still cover the
+		// transaction's own size. Absorbing dust must never underpay.
+		if minFee := minFeeForTx(t, a); tx.Body.TxFee < minFee {
+			t.Errorf(
+				"balance %d: fee %d is below the minimum %d for the built tx",
+				balance, tx.Body.TxFee, minFee,
+			)
+		}
+		assertValueConserved(t, a, balance)
+	}
+}
+
+// TestChangeAboveMinUtxoIsStillEmitted confirms the fix did not turn ordinary
+// change into absorbed dust.
+func TestChangeAboveMinUtxoIsStillEmitted(t *testing.T) {
+	const pay = 2_000_000
+	const balance = 10_000_000
+
+	a, err := buildTransfer(t, balance, pay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := a.GetTx()
+	if got := len(tx.Body.Outputs()); got != 2 {
+		t.Fatalf("built %d outputs, want 2 (payment plus change)", got)
+	}
+	if minFee := minFeeForTx(t, a); tx.Body.TxFee < minFee {
+		t.Errorf("fee %d is below the minimum %d", tx.Body.TxFee, minFee)
+	}
+	// With ample change the fee should be the size-based fee, not inflated.
+	if tx.Body.TxFee > 1_000_000 {
+		t.Errorf("fee %d is implausibly large for a simple transfer", tx.Body.TxFee)
+	}
+	assertValueConserved(t, a, balance)
+}
+
+// TestForceFeeStillBypassesEstimation guards the other branch of the loop:
+// with a forced fee, no re-estimation happens and the forced value is charged.
+func TestForceFeeStillBypassesEstimation(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		ForceFee(300_000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := a.GetTx().Body.TxFee, uint64(300_000); got != want {
+		t.Errorf("forced fee = %d, want %d", got, want)
+	}
+}
+
+// assertValueConserved checks the Cardano balance equation against the single
+// input the helpers create: sum(outputs) + fee must equal the input value.
+func assertValueConserved(t *testing.T, a *Apollo, inputValue uint64) {
+	t.Helper()
+	tx := a.GetTx()
+	out := new(big.Int)
+	for _, o := range tx.Body.Outputs() {
+		out.Add(out, o.Amount())
+	}
+	got := new(big.Int).Add(out, new(big.Int).SetUint64(tx.Body.TxFee))
+	want := new(big.Int).SetUint64(inputValue)
+	if got.Cmp(want) != 0 {
+		t.Errorf(
+			"value not conserved: outputs %s + fee %d = %s, inputs %d",
+			out, tx.Body.TxFee, got, inputValue,
+		)
+	}
+}

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	plutigoData "github.com/blinklabs-io/plutigo/data"
 
+	"github.com/Salvionied/apollo/v2/backend"
 	"github.com/Salvionied/apollo/v2/backend/fixed"
 )
 
@@ -39,6 +40,15 @@ type balancedEvalContext struct {
 
 	// resultFor returns ExUnits (or an error) for the call.
 	resultFor func(call int, tx *conway.ConwayTransaction, utxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error)
+}
+
+// Capabilities advertises evaluation on top of the fixed context's in-memory
+// operations. This stub honours additionalUtxos (its assertions read them), so
+// it must report CapabilityEvaluateTxAdditionalUtxos for Apollo to send them.
+func (c *balancedEvalContext) Capabilities() backend.CapabilitySet {
+	return c.FixedChainContext.Capabilities() |
+		backend.CapabilitySet(backend.CapabilityEvaluateTx|
+			backend.CapabilityEvaluateTxAdditionalUtxos)
 }
 
 func (c *balancedEvalContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {

--- a/helpers.go
+++ b/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 )
 
@@ -490,8 +491,99 @@ func NewVkeyWitnessFromSkey(
 	}
 }
 
+// DatumWireCbor returns the CBOR bytes datum will occupy in the witness set
+// and records them on the datum so that common.Datum.Hash, the witness set,
+// and every hash Apollo derives from the datum all agree.
+//
+// A datum decoded from CBOR keeps its original bytes, and those bytes are what
+// the datum hash on chain was computed over. gouroboros re-encodes datums
+// through plutigo whenever it marshals them, and plutigo emits the canonical
+// Plutus form (minimal integers, definite-length collections, byte strings
+// chunked above 64 bytes), so a datum whose stored CBOR is not already
+// canonical cannot be put back on the wire byte for byte. Hashing the stored
+// bytes anyway would declare a datum hash that no longer matches the datum in
+// the witness set, so the ledger would reject the transaction with
+// NotAllowedSupplementalDatums or MissingRequiredDatums. Apollo reports that
+// up front instead. Callers willing to accept the canonical re-encoding, and
+// the different datum hash that comes with it, can clear the stored bytes with
+// datum.SetCbor(nil); callers that only need an output to carry a datum hash
+// somebody else computed can use PayToContractAsHash, which does not put the
+// datum in the witness set at all.
+func DatumWireCbor(datum *common.Datum) ([]byte, error) {
+	if datum == nil {
+		return nil, errors.New("datum is nil")
+	}
+	encoded, err := cbor.Encode(datum)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode datum: %w", err)
+	}
+	stored := datum.Cbor()
+	if len(stored) == 0 {
+		datum.SetCbor(encoded)
+		return encoded, nil
+	}
+	if !bytes.Equal(stored, encoded) {
+		return nil, fmt.Errorf(
+			"datum CBOR is not in canonical Plutus form and cannot be "+
+				"preserved: its original bytes hash to %s but the witness "+
+				"set would carry bytes hashing to %s; clear the original "+
+				"bytes with SetCbor(nil) to accept the canonical form, or "+
+				"use PayToContractAsHash to reference the original hash "+
+				"without the datum",
+			common.Blake2b256Hash(stored).String(),
+			common.Blake2b256Hash(encoded).String(),
+		)
+	}
+	return stored, nil
+}
+
+// DatumHash returns the blake2b-256 hash of the CBOR bytes datum occupies in
+// the witness set, which is the datum hash the ledger matches an output's
+// datum hash against.
+//
+// Prefer this over common.Datum.Hash: that method hashes the datum's stored
+// CBOR, which is empty for a datum built in Go rather than decoded from CBOR,
+// so it silently returns blake2b-256 of the empty string. DatumHash also
+// records the wire bytes on datum, after which common.Datum.Hash agrees.
+func DatumHash(datum *common.Datum) (common.Blake2b256, error) {
+	datumCbor, err := DatumWireCbor(datum)
+	if err != nil {
+		return common.Blake2b256{}, err
+	}
+	return common.Blake2b256Hash(datumCbor), nil
+}
+
+// WitnessPlutusData builds witness set field 4 (plutus_data) for the given
+// witness datums exactly as it goes on the wire.
+//
+// Conway's CDDL types the field as nonempty_set<plutus_data>, which permits
+// both a tag-258 set and a bare array. Apollo emits the tag-258 form for every
+// set it writes, so the tag is part of the field bytes the ledger hashes.
+// buildWitnessSet and ComputeScriptDataHash both go through this constructor
+// so the script integrity preimage cannot drift from the serialized field.
+func WitnessPlutusData(datums []common.Datum) cbor.SetType[common.Datum] {
+	return cbor.NewSetType(datums, true)
+}
+
+// WitnessRedeemers builds witness set field 5 (redeemers) for the given
+// redeemer map exactly as it goes on the wire. As with WitnessPlutusData, both
+// the witness set and the script integrity preimage are derived from it.
+func WitnessRedeemers(
+	redeemers map[common.RedeemerKey]common.RedeemerValue,
+) conway.ConwayRedeemers {
+	return conway.ConwayRedeemers{Redeemers: redeemers}
+}
+
 // ComputeScriptDataHash computes the script data hash per the ledger rules:
 // blake2b-256(redeemers_cbor || datums_cbor || lang_views_cbor).
+//
+// The ledger recomputes this hash over the original on-wire bytes of witness
+// set fields 5 and 4, so both halves of the preimage are produced by
+// serializing the very field values buildWitnessSet puts in the witness set,
+// rather than by re-deriving equivalent-looking CBOR. Re-deriving is how the
+// tag-258 set prefix on field 4 came to be missing from the preimage while
+// present on the wire, which made the ledger reject every transaction that
+// carried witness datums with ScriptIntegrityHashMismatch.
 //
 // When there are no witness datums, datums_cbor is omitted entirely (Alonzo,
 // Babbage, and Conway). Encoding an empty datum array here produces
@@ -506,21 +598,21 @@ func ComputeScriptDataHash(
 		return nil, nil
 	}
 
-	var redeemerBytes []byte
-	var err error
-	if len(redeemers) > 0 {
-		redeemerBytes, err = cbor.Encode(redeemers)
-	} else {
-		// Empty Conway redeemer map must be 0xa0, not CBOR null.
-		redeemerBytes, err = cbor.Encode(map[common.RedeemerKey]common.RedeemerValue{})
+	// An absent field 5 hashes as the empty Conway redeemer map 0xa0, which is
+	// what a nil map must not encode to (CBOR null).
+	if redeemers == nil {
+		redeemers = map[common.RedeemerKey]common.RedeemerValue{}
 	}
+	redeemerField := WitnessRedeemers(redeemers)
+	redeemerBytes, err := cbor.Encode(&redeemerField)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode redeemers: %w", err)
 	}
 
 	var datumBytes []byte
 	if len(datums) > 0 {
-		datumBytes, err = cbor.Encode(datums)
+		datumField := WitnessPlutusData(datums)
+		datumBytes, err = cbor.Encode(&datumField)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode datums: %w", err)
 		}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"bytes"
 	"math/big"
 	"strings"
 	"testing"
@@ -601,9 +602,19 @@ func TestComputeScriptDataHashIncludesNonEmptyDatums(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	datumBytes, err := cbor.Encode(datums)
+	// The datums half of the preimage is the plutus_data witness field as it is
+	// serialized, tag-258 set prefix included, not a bare CBOR array.
+	datumField := WitnessPlutusData(datums)
+	datumBytes, err := cbor.Encode(&datumField)
 	if err != nil {
 		t.Fatal(err)
+	}
+	bareDatumBytes, err := cbor.Encode(datums)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(datumBytes, bareDatumBytes) {
+		t.Fatal("witness field and bare array encodings are identical")
 	}
 	langViews, err := common.EncodeLangViews(
 		map[uint]struct{}{1: {}},
@@ -615,6 +626,10 @@ func TestComputeScriptDataHashIncludesNonEmptyDatums(t *testing.T) {
 	want := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), datumBytes...), langViews...))
 	if *got != want {
 		t.Fatalf("hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+	stale := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), bareDatumBytes...), langViews...))
+	if *got == stale {
+		t.Fatal("preimage still uses the untagged datum array")
 	}
 }
 

--- a/input_set_test.go
+++ b/input_set_test.go
@@ -1,0 +1,141 @@
+package apollo
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// stakeAddressFor builds a reward address controlled by the same stake
+// credential as addr, suitable for AddWithdrawal.
+func stakeAddressFor(t *testing.T, addr common.Address) common.Address {
+	t.Helper()
+	stake, err := common.NewAddressFromParts(
+		common.AddressTypeNoneKey,
+		uint8(addr.NetworkId()), //nolint:gosec // network id is 0 or 1
+		nil,
+		addr.StakeKeyHash().Bytes(),
+	)
+	if err != nil {
+		t.Fatalf("build reward address: %v", err)
+	}
+	return stake
+}
+
+// TestWithdrawalTransactionSpendsAtLeastOneInput is the regression guard for a
+// transaction built with an empty input set.
+//
+// Withdrawals are implicit inputs in Cardano's balance equation, so a reward
+// claim large enough to cover the whole selection target made coin selection
+// return no UTxOs at all. The resulting body had inputs = [], which the ledger
+// rejects with InputSetEmptyUTxO. It also carried no payment-key witness and
+// nothing establishing the transaction's uniqueness.
+func TestWithdrawalTransactionSpendsAtLeastOneInput(t *testing.T) {
+	for _, reward := range []uint64{
+		500_000,     // below the selection reserve: selection ran before
+		5_000_000,   // above it: selection short-circuited
+		50_000_000,  // far above it
+		500_000_000, // far above the wallet balance itself
+	} {
+		cc := setupFixedContext()
+		addr := testAddress(t)
+		addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+		a, err := New(cc).
+			SetWallet(NewExternalWallet(addr)).
+			SetTtl(50_000_000).
+			AddWithdrawal(stakeAddressFor(t, addr), reward, nil, nil).
+			Complete()
+		if err != nil {
+			t.Errorf("reward %d: Complete failed: %v", reward, err)
+			continue
+		}
+
+		inputs := a.GetTx().Body.Inputs()
+		if len(inputs) == 0 {
+			t.Errorf(
+				"reward %d: built a transaction with an empty input set "+
+					"(InputSetEmptyUTxO)",
+				reward,
+			)
+			continue
+		}
+		t.Logf(
+			"reward %d -> inputs=%d outputs=%d fee=%d",
+			reward, len(inputs), len(a.GetTx().Body.Outputs()),
+			a.GetTx().Body.TxFee,
+		)
+	}
+}
+
+// TestWithdrawalOnlyTransactionConservesValue checks that forcing an input into
+// a withdrawal-funded transaction still balances: the spent UTxO plus the
+// reward must equal the outputs plus the fee.
+func TestWithdrawalOnlyTransactionConservesValue(t *testing.T) {
+	const balance = 10_000_000
+	const reward = 50_000_000
+
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, balance, 0x01, 0)
+
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		SetTtl(50_000_000).
+		AddWithdrawal(stakeAddressFor(t, addr), reward, nil, nil).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := a.GetTx()
+	inputs := tx.Body.Inputs()
+	if len(inputs) != 1 {
+		t.Fatalf("spent %d inputs, want 1", len(inputs))
+	}
+
+	var out uint64
+	for _, o := range tx.Body.Outputs() {
+		out += o.Amount().Uint64()
+	}
+	// One spent UTxO of `balance`, plus the withdrawal, funds outputs and fee.
+	if got, want := out+tx.Body.TxFee, uint64(balance+reward); got != want {
+		t.Errorf(
+			"value not conserved: outputs %d + fee %d = %d, want %d",
+			out, tx.Body.TxFee, got, want,
+		)
+	}
+	if got := len(tx.Body.Withdrawals()); got != 1 {
+		t.Errorf("body has %d withdrawals, want 1", got)
+	}
+}
+
+// TestPreselectedInputSatisfiesTheInputSet confirms the guarantee is satisfied
+// by a caller-pinned input without selection contributing another one.
+func TestPreselectedInputSatisfiesTheInputSet(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+	addTestUtxo(cc, addr, 10_000_000, 0x02, 0)
+
+	utxos, err := cc.Utxos(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) < 1 {
+		t.Fatal("fixture produced no UTxOs")
+	}
+
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		SetTtl(50_000_000).
+		AddInput(utxos[0]).
+		AddWithdrawal(stakeAddressFor(t, addr), 50_000_000, nil, nil).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(a.GetTx().Body.Inputs()); got != 1 {
+		t.Errorf("spent %d inputs, want exactly the 1 preselected", got)
+	}
+}

--- a/internal/backendutil/backendutil.go
+++ b/internal/backendutil/backendutil.go
@@ -1,0 +1,165 @@
+// Package backendutil holds parsing and validation helpers shared by the
+// backend implementations in this module. These helpers exist to normalize
+// provider API responses, so they are internal rather than part of Apollo's
+// public API surface.
+package backendutil
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ParseRational parses a provider-supplied rational number without passing it
+// through floating point. Decimal and exponent forms accepted by JSON numbers
+// are supported by math/big.
+func ParseRational(s string) (*big.Rat, error) {
+	value, ok := new(big.Rat).SetString(s)
+	if !ok {
+		return nil, fmt.Errorf("invalid rational number %q", s)
+	}
+	return value, nil
+}
+
+// BoundedInt converts an API-supplied int64 to int, rejecting negative values
+// and values that would not fit in 32 bits.
+func BoundedInt(v int64, name string) (int, error) {
+	if v < 0 || v > math.MaxInt32 {
+		return 0, fmt.Errorf("%s out of range: %d", name, v)
+	}
+	return int(v), nil
+}
+
+// BoundedIntFromUint64 converts an API-supplied uint64 to int, rejecting
+// values that would not fit in 32 bits.
+func BoundedIntFromUint64(v uint64, name string) (int, error) {
+	if v > math.MaxInt32 {
+		return 0, fmt.Errorf("%s out of range: %d", name, v)
+	}
+	return int(v), nil
+}
+
+// ParseAssetUnit splits an API asset unit into policy ID and asset name.
+func ParseAssetUnit(unit string) (common.Blake2b224, cbor.ByteString, error) {
+	if len(unit) < common.Blake2b224Size*2 {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("asset unit is too short: %q", unit)
+	}
+	policyHex := unit[:common.Blake2b224Size*2]
+	nameHex := unit[common.Blake2b224Size*2:]
+
+	policyBytes, err := hex.DecodeString(policyHex)
+	if err != nil {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid policy ID hex %q: %w", policyHex, err)
+	}
+	if len(policyBytes) != common.Blake2b224Size {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid policy ID length: expected %d bytes, got %d", common.Blake2b224Size, len(policyBytes))
+	}
+	var policyId common.Blake2b224
+	copy(policyId[:], policyBytes)
+
+	nameBytes, err := hex.DecodeString(nameHex)
+	if err != nil {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid asset name hex %q: %w", nameHex, err)
+	}
+	if len(nameBytes) > 32 {
+		return common.Blake2b224{}, cbor.ByteString{}, fmt.Errorf("invalid asset name length: expected at most 32 bytes, got %d", len(nameBytes))
+	}
+	return policyId, cbor.NewByteString(nameBytes), nil
+}
+
+// ParseRedeemerTag parses a redeemer purpose string to a RedeemerTag.
+func ParseRedeemerTag(s string) (common.RedeemerTag, error) {
+	switch strings.ToLower(s) {
+	case "spend":
+		return common.RedeemerTagSpend, nil
+	case "mint":
+		return common.RedeemerTagMint, nil
+	case "cert", "publish":
+		return common.RedeemerTagCert, nil
+	case "reward", "withdraw":
+		return common.RedeemerTagReward, nil
+	default:
+		return 0, fmt.Errorf("unsupported redeemer tag %q", s)
+	}
+}
+
+// ParseFraction parses a fraction string (e.g. "1/2") to a float64.
+func ParseFraction(s string) (float64, error) {
+	parts := strings.Split(s, "/")
+	if len(parts) == 2 {
+		num, err := strconv.ParseFloat(parts[0], 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid numerator %q: %w", parts[0], err)
+		}
+		if math.IsNaN(num) || math.IsInf(num, 0) {
+			return 0, fmt.Errorf("invalid numerator (NaN/Inf) in fraction %q", s)
+		}
+		den, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid denominator %q: %w", parts[1], err)
+		}
+		if den == 0 || math.IsNaN(den) || math.IsInf(den, 0) {
+			return 0, fmt.Errorf("invalid denominator in fraction %q", s)
+		}
+		return num / den, nil
+	}
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number %q: %w", s, err)
+	}
+	if math.IsNaN(val) || math.IsInf(val, 0) {
+		return 0, fmt.Errorf("invalid number (NaN/Inf) %q", s)
+	}
+	return val, nil
+}
+
+// ScriptRefFromBytes builds a common.ScriptRef of the given script ref type
+// from raw script bytes. Native scripts are decoded from their CBOR
+// representation. When expectedHashHex is non-empty, the script hash is
+// recomputed for the claimed language and compared against it, failing closed
+// if a provider returns script bytes (or a language) that do not match the
+// hash it claims for them. An empty expectedHashHex skips verification for
+// providers that do not supply a script hash.
+func ScriptRefFromBytes(scriptType uint, scriptBytes []byte, expectedHashHex string) (*common.ScriptRef, error) {
+	var script common.Script
+	switch scriptType {
+	case common.ScriptRefTypeNativeScript:
+		var native common.NativeScript
+		if _, err := cbor.Decode(scriptBytes, &native); err != nil {
+			return nil, fmt.Errorf("failed to decode native script: %w", err)
+		}
+		script = native
+	case common.ScriptRefTypePlutusV1:
+		script = common.PlutusV1Script(scriptBytes)
+	case common.ScriptRefTypePlutusV2:
+		script = common.PlutusV2Script(scriptBytes)
+	case common.ScriptRefTypePlutusV3:
+		script = common.PlutusV3Script(scriptBytes)
+	case common.ScriptRefTypePlutusV4:
+		script = common.PlutusV4Script(scriptBytes)
+	default:
+		return nil, fmt.Errorf("unsupported script ref type %d", scriptType)
+	}
+	if expectedHashHex != "" {
+		expectedBytes, err := hex.DecodeString(expectedHashHex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid script hash hex %q: %w", expectedHashHex, err)
+		}
+		if len(expectedBytes) != common.Blake2b224Size {
+			return nil, fmt.Errorf("invalid script hash length: expected %d bytes, got %d", common.Blake2b224Size, len(expectedBytes))
+		}
+		var expected common.Blake2b224
+		copy(expected[:], expectedBytes)
+		if computed := script.Hash(); computed != expected {
+			return nil, fmt.Errorf("reference script hash mismatch: computed %s, provider claimed %s",
+				hex.EncodeToString(computed.Bytes()), expectedHashHex)
+		}
+	}
+	return &common.ScriptRef{Type: scriptType, Script: script}, nil
+}

--- a/internal/backendutil/backendutil_test.go
+++ b/internal/backendutil/backendutil_test.go
@@ -1,0 +1,229 @@
+package backendutil
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func TestParseFractionValid(t *testing.T) {
+	val, err := ParseFraction("1/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != 0.5 {
+		t.Errorf("expected 0.5, got %f", val)
+	}
+}
+
+func TestParseFractionPlainNumber(t *testing.T) {
+	val, err := ParseFraction("0.0577")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val < 0.0576 || val > 0.0578 {
+		t.Errorf("expected ~0.0577, got %f", val)
+	}
+}
+
+func TestParseFractionInvalidNumerator(t *testing.T) {
+	_, err := ParseFraction("abc/100")
+	if err == nil {
+		t.Error("expected error for invalid numerator")
+	}
+}
+
+func TestParseFractionInvalidDenominator(t *testing.T) {
+	_, err := ParseFraction("1/xyz")
+	if err == nil {
+		t.Error("expected error for invalid denominator")
+	}
+}
+
+func TestParseFractionDivisionByZero(t *testing.T) {
+	_, err := ParseFraction("1/0")
+	if err == nil {
+		t.Error("expected error for division by zero")
+	}
+}
+
+func TestParseFractionInvalidString(t *testing.T) {
+	_, err := ParseFraction("not-a-number")
+	if err == nil {
+		t.Error("expected error for invalid string")
+	}
+}
+
+func TestParseAssetUnit(t *testing.T) {
+	policyHex := "00000000000000000000000000000000000000000000000000000001"
+	assetNameHex := hex.EncodeToString([]byte("TOKEN"))
+	policyID, assetName, err := ParseAssetUnit(policyHex + assetNameHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(policyID.Bytes()); got != policyHex {
+		t.Fatalf("policy ID = %s, want %s", got, policyHex)
+	}
+	if want := cbor.NewByteString([]byte("TOKEN")); assetName != want {
+		t.Fatalf("asset name = %s, want %s", assetName.String(), want.String())
+	}
+}
+
+func TestParseAssetUnitRejectsInvalidInput(t *testing.T) {
+	tests := []string{
+		"abcd",
+		"0000000000000000000000000000000000000000000000000000000z",
+		"00000000000000000000000000000000000000000000000000000001zz",
+		"00000000000000000000000000000000000000000000000000000001" +
+			"000000000000000000000000000000000000000000000000000000000000000000",
+	}
+	for _, unit := range tests {
+		t.Run(unit, func(t *testing.T) {
+			if _, _, err := ParseAssetUnit(unit); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestParseAssetUnitAllowsEmptyAssetName(t *testing.T) {
+	policyHex := "00000000000000000000000000000000000000000000000000000001"
+	policyID, assetName, err := ParseAssetUnit(policyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expected common.Blake2b224
+	expected[27] = 1
+	if policyID != expected {
+		t.Fatalf("policy ID = %x, want %x", policyID.Bytes(), expected.Bytes())
+	}
+	if want := cbor.NewByteString(nil); assetName != want {
+		t.Fatalf("asset name = %s, want empty", assetName.String())
+	}
+}
+
+func TestBoundedInt(t *testing.T) {
+	if v, err := BoundedInt(12345, "x"); err != nil || v != 12345 {
+		t.Errorf("BoundedInt(12345) = %d, %v; want 12345, nil", v, err)
+	}
+	if _, err := BoundedInt(-1, "x"); err == nil {
+		t.Error("BoundedInt(-1) should error")
+	}
+	if _, err := BoundedInt(int64(1)<<32, "x"); err == nil {
+		t.Error("BoundedInt(2^32) should error")
+	}
+}
+
+func TestBoundedIntFromUint64(t *testing.T) {
+	if v, err := BoundedIntFromUint64(12345, "x"); err != nil || v != 12345 {
+		t.Errorf("BoundedIntFromUint64(12345) = %d, %v; want 12345, nil", v, err)
+	}
+	if _, err := BoundedIntFromUint64(uint64(1)<<32, "x"); err == nil {
+		t.Error("BoundedIntFromUint64(2^32) should error")
+	}
+}
+
+func TestScriptRefFromBytesVerifiesHash(t *testing.T) {
+	script := common.PlutusV2Script([]byte{0x01, 0x02, 0x03})
+	correctHash := hex.EncodeToString(script.Hash().Bytes())
+
+	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, script, correctHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Type != common.ScriptRefTypePlutusV2 {
+		t.Fatalf("script ref type = %d, want %d", ref.Type, common.ScriptRefTypePlutusV2)
+	}
+	if _, ok := ref.Script.(common.PlutusV2Script); !ok {
+		t.Fatalf("expected PlutusV2 script, got %T", ref.Script)
+	}
+}
+
+func TestScriptRefFromBytesPlutusV4(t *testing.T) {
+	script := common.PlutusV4Script([]byte{0x01, 0x02, 0x03})
+	correctHash := hex.EncodeToString(script.Hash().Bytes())
+
+	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV4, script, correctHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Type != common.ScriptRefTypePlutusV4 {
+		t.Fatalf("script ref type = %d, want %d", ref.Type, common.ScriptRefTypePlutusV4)
+	}
+	if _, ok := ref.Script.(common.PlutusV4Script); !ok {
+		t.Fatalf("expected PlutusV4 script, got %T", ref.Script)
+	}
+}
+
+func TestScriptRefFromBytesRejectsHashMismatch(t *testing.T) {
+	script := common.PlutusV2Script([]byte{0x01, 0x02, 0x03})
+	// The same bytes hashed as PlutusV1 produce a different script hash.
+	wrongHash := hex.EncodeToString(common.PlutusV1Script(script).Hash().Bytes())
+	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, script, wrongHash); err == nil {
+		t.Fatal("expected script hash mismatch error")
+	}
+}
+
+func TestScriptRefFromBytesRejectsClaimedLanguageMismatch(t *testing.T) {
+	// Provider claims PlutusV1 for bytes whose hash was computed as PlutusV2.
+	scriptBytes := []byte{0x01, 0x02, 0x03}
+	v2Hash := hex.EncodeToString(common.PlutusV2Script(scriptBytes).Hash().Bytes())
+	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV1, scriptBytes, v2Hash); err == nil {
+		t.Fatal("expected script hash mismatch error for wrong language claim")
+	}
+}
+
+func TestScriptRefFromBytesSkipsVerificationWithoutHash(t *testing.T) {
+	ref, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV3, []byte{0x0a}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ref.Script.(common.PlutusV3Script); !ok {
+		t.Fatalf("expected PlutusV3 script, got %T", ref.Script)
+	}
+}
+
+func TestScriptRefFromBytesRejectsInvalidHashHex(t *testing.T) {
+	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, []byte{0x01}, "zz"); err == nil {
+		t.Fatal("expected invalid hash hex error")
+	}
+	if _, err := ScriptRefFromBytes(common.ScriptRefTypePlutusV2, []byte{0x01}, "abcd"); err == nil {
+		t.Fatal("expected invalid hash length error")
+	}
+}
+
+func TestScriptRefFromBytesRejectsUnsupportedType(t *testing.T) {
+	if _, err := ScriptRefFromBytes(99, []byte{0x01}, ""); err == nil {
+		t.Fatal("expected unsupported script ref type error")
+	}
+}
+
+func TestScriptRefFromBytesNativeScript(t *testing.T) {
+	// Native script: ScriptPubkey = [0, key_hash]
+	keyHash := make([]byte, 28)
+	keyHash[0] = 0xAA
+	scriptCbor, err := cbor.Encode([]any{0, keyHash})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := ScriptRefFromBytes(common.ScriptRefTypeNativeScript, scriptCbor, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	native, ok := ref.Script.(common.NativeScript)
+	if !ok {
+		t.Fatalf("expected native script, got %T", ref.Script)
+	}
+
+	// Round-trip the computed hash through verification.
+	correctHash := hex.EncodeToString(native.Hash().Bytes())
+	if _, err := ScriptRefFromBytes(common.ScriptRefTypeNativeScript, scriptCbor, correctHash); err != nil {
+		t.Fatalf("expected native script hash to verify: %v", err)
+	}
+	wrongHash := hex.EncodeToString(make([]byte, common.Blake2b224Size))
+	if _, err := ScriptRefFromBytes(common.ScriptRefTypeNativeScript, scriptCbor, wrongHash); err == nil {
+		t.Fatal("expected native script hash mismatch error")
+	}
+}

--- a/metadata_auxdata_test.go
+++ b/metadata_auxdata_test.go
@@ -1,0 +1,239 @@
+package apollo
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// isCborNull reports whether b is a single CBOR null or undefined value, which
+// is what gouroboros emits for auxiliary data with no stored encoding.
+func isCborNull(b []byte) bool {
+	return len(b) == 1 && (b[0] == 0xf6 || b[0] == 0xf7)
+}
+
+// splitTx decodes a serialized transaction into its four top-level CBOR
+// elements: [body, witness_set, is_valid, auxiliary_data].
+func splitTx(t *testing.T, txCbor []byte) []cbor.RawMessage {
+	t.Helper()
+	var elems []cbor.RawMessage
+	if _, err := cbor.Decode(txCbor, &elems); err != nil {
+		t.Fatalf("decode transaction: %v", err)
+	}
+	if len(elems) != 4 {
+		t.Fatalf("expected a 4-element transaction, got %d", len(elems))
+	}
+	return elems
+}
+
+// buildWithMetadata completes a minimal transfer carrying metadata.
+func buildWithMetadata(t *testing.T, metadata map[uint64]any) *Apollo {
+	t.Helper()
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		SetShelleyMetadata(metadata)
+
+	a, err = a.Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+// TestMetadataIsSerializedIntoTheTransaction is the regression guard for
+// auxiliary data being emitted as CBOR null. gouroboros serializes auxiliary
+// data from TxMetadata.Cbor(), so a MetaMap built without SetCbor produces a
+// transaction whose auxiliary_data is null while the body still declares
+// auxiliary_data_hash -- the metadata is silently dropped and the transaction
+// cannot validate.
+func TestMetadataIsSerializedIntoTheTransaction(t *testing.T) {
+	a := buildWithMetadata(t, map[uint64]any{
+		674: map[string]any{"msg": "apollo"},
+	})
+
+	tx := a.GetTx()
+	declared := tx.Body.TxAuxDataHash
+	if declared == nil {
+		t.Fatal("body has no auxiliary_data_hash despite metadata being set")
+	}
+
+	full, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	aux := splitTx(t, full)[3]
+
+	if isCborNull(aux) {
+		t.Fatalf(
+			"auxiliary_data is CBOR null (%#x) but the body declares "+
+				"auxiliary_data_hash %x",
+			aux[0], declared[:],
+		)
+	}
+	if len(aux) == 0 {
+		t.Fatal("auxiliary_data is empty")
+	}
+
+	// The declared hash must be the hash of the bytes actually on the wire.
+	if got := common.Blake2b256Hash(aux); got != *declared {
+		t.Errorf(
+			"blake2b256(wire auxiliary_data) = %x, body declares %x",
+			got[:], declared[:],
+		)
+	}
+
+	// And the wire bytes must be the metadata we asked for.
+	if got, want := hex.EncodeToString(aux), hex.EncodeToString(
+		tx.TxMetadata.Cbor(),
+	); got != want {
+		t.Errorf("wire auxiliary_data = %s, TxMetadata.Cbor() = %s", got, want)
+	}
+}
+
+// TestMetadataRoundTripsThroughSerialization confirms the emitted auxiliary
+// data decodes back to the metadata that was set, so the encoding is not
+// merely non-null but correct.
+func TestMetadataRoundTripsThroughSerialization(t *testing.T) {
+	a := buildWithMetadata(t, map[uint64]any{
+		674: map[string]any{"msg": "apollo"},
+		1:   int64(42),
+	})
+
+	full, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	aux := splitTx(t, full)[3]
+
+	// Shelley-era auxiliary data is a bare metadata map keyed by label.
+	// Decoding generically asserts the wire format itself rather than relying
+	// on any particular ledger-type decoder.
+	var decoded map[uint64]cbor.RawMessage
+	if _, err := cbor.Decode(aux, &decoded); err != nil {
+		t.Fatalf("auxiliary_data does not decode as a metadata map: %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("decoded %d metadata labels, want 2: %v", len(decoded), decoded)
+	}
+	for _, label := range []uint64{1, 674} {
+		if _, ok := decoded[label]; !ok {
+			t.Errorf("metadata label %d missing from auxiliary_data", label)
+		}
+	}
+
+	// Label 1 was set to the integer 42.
+	var got int64
+	if _, err := cbor.Decode(decoded[1], &got); err != nil {
+		t.Fatalf("decode label 1: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("metadata label 1 = %d, want 42", got)
+	}
+}
+
+// TestMetadataSizeIsCountedInTheFee guards the fee consequence of the same
+// bug: the size-estimation transactions also carried a MetaMap with no stored
+// CBOR, so the fee was computed as though auxiliary data were a single byte.
+func TestMetadataSizeIsCountedInTheFee(t *testing.T) {
+	small := buildWithMetadata(t, map[uint64]any{1: int64(1)})
+
+	// A metadata document large enough that its bytes dominate the delta.
+	big := make(map[uint64]any, 8)
+	for i := uint64(0); i < 8; i++ {
+		big[i] = map[string]any{
+			"msg": "0123456789012345678901234567890123456789012345678901234",
+		}
+	}
+	large := buildWithMetadata(t, big)
+
+	smallCbor, err := small.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	largeCbor, err := large.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp, err := small.Context.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	minFeeA := pp.MinFeeCoefficient
+
+	smallFee, largeFee := small.GetTx().Body.TxFee, large.GetTx().Body.TxFee
+	if len(largeCbor) <= len(smallCbor) {
+		t.Fatalf(
+			"larger metadata did not grow the transaction (%d -> %d)",
+			len(smallCbor), len(largeCbor),
+		)
+	}
+	if largeFee < smallFee {
+		t.Fatalf("fee shrank with more metadata: %d -> %d", smallFee, largeFee)
+	}
+	if minFeeA <= 0 {
+		t.Fatalf("MinFeeCoefficient is %d, want positive", minFeeA)
+	}
+	//nolint:gosec // length difference validated positive above
+	sizeDelta := uint64(len(largeCbor) - len(smallCbor))
+	feeDelta := largeFee - smallFee
+
+	t.Logf(
+		"size %d -> %d (delta %d), fee %d -> %d (delta %d), minFeeA %d",
+		len(smallCbor), len(largeCbor), sizeDelta,
+		smallFee, largeFee, feeDelta, minFeeA,
+	)
+
+	// The fee must cover the extra bytes at the per-byte coefficient.
+	//nolint:gosec // minFeeA validated positive above
+	if want := sizeDelta * uint64(minFeeA); feeDelta < want {
+		t.Errorf(
+			"fee grew by %d for %d extra bytes; needs at least %d "+
+				"(metadata size not counted in the fee)",
+			feeDelta, sizeDelta, want,
+		)
+	}
+}
+
+// TestEmptyMetadataStillSerializesConsistently covers SetShelleyMetadata with
+// an empty map: whatever auxiliary_data is emitted, the declared hash must
+// match it.
+func TestEmptyMetadataStillSerializesConsistently(t *testing.T) {
+	a := buildWithMetadata(t, map[uint64]any{})
+
+	tx := a.GetTx()
+	full, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	aux := splitTx(t, full)[3]
+
+	if tx.Body.TxAuxDataHash == nil {
+		// No hash declared: auxiliary_data must be absent/null too.
+		if !isCborNull(aux) {
+			t.Errorf(
+				"no auxiliary_data_hash declared but auxiliary_data = %s",
+				hex.EncodeToString(aux),
+			)
+		}
+		return
+	}
+	if got := common.Blake2b256Hash(aux); got != *tx.Body.TxAuxDataHash {
+		t.Errorf(
+			"blake2b256(wire auxiliary_data) = %x, body declares %x",
+			got[:], tx.Body.TxAuxDataHash[:],
+		)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -125,7 +125,7 @@ type Payment struct {
 
 // NewPayment creates a new Payment.
 func NewPayment(receiver string, lovelace int64, units []Unit) (*Payment, error) {
-	addr, err := common.NewAddress(receiver)
+	addr, err := ParseAddress(receiver)
 	if err != nil {
 		return nil, fmt.Errorf("invalid receiver address: %w", err)
 	}

--- a/network_validation_test.go
+++ b/network_validation_test.go
@@ -1,0 +1,232 @@
+package apollo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// networkTestContext returns a fixed chain context on the given network, with
+// the same protocol and genesis parameters the empty fixed context uses.
+func networkTestContext(t *testing.T, network uint8) *fixed.FixedChainContext {
+	t.Helper()
+	base := fixed.NewEmptyFixedChainContext()
+	pp, err := base.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gp, err := base.GenesisParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixed.NewFixedChainContext(pp, gp, network)
+}
+
+// networkTestBuilder returns a builder funded on the wallet's own network,
+// ready for Complete().
+func networkTestBuilder(
+	t *testing.T,
+	contextNetwork, walletNetwork uint8,
+) *Apollo {
+	t.Helper()
+	cc := networkTestContext(t, contextNetwork)
+	walletAddr := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		walletNetwork,
+	)
+	addTestUtxo(cc, walletAddr, 10_000_000, 0x01, 0)
+	return New(cc).
+		SetWallet(NewExternalWallet(walletAddr)).
+		SetTtl(50000000)
+}
+
+func requireNetworkMismatch(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a network mismatch error, got none")
+	}
+	if !strings.Contains(err.Error(), "network mismatch") {
+		t.Fatalf("expected a network mismatch error, got: %v", err)
+	}
+}
+
+// TestCompleteRejectsOutputAddressOnOtherNetwork covers a preprod payee
+// pasted into a mainnet builder, and the reverse.
+func TestCompleteRejectsOutputAddressOnOtherNetwork(t *testing.T) {
+	for _, network := range []uint8{
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	} {
+		foreign := common.AddressNetworkMainnet
+		if network == common.AddressNetworkMainnet {
+			foreign = common.AddressNetworkTestnet
+		}
+		payee := syntheticAddress(t, common.AddressTypeKeyKey, uint8(foreign))
+		a := networkTestBuilder(t, network, network).
+			PayToAddress(payee, 2_000_000)
+		_, err := a.Complete()
+		requireNetworkMismatch(t, err)
+	}
+}
+
+// TestCompleteRejectsChangeAddressOnOtherNetwork covers change silently
+// leaving for an address on the wrong network.
+func TestCompleteRejectsChangeAddressOnOtherNetwork(t *testing.T) {
+	change := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkMainnet,
+		common.AddressNetworkMainnet,
+	)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	_, err := a.
+		PayToAddress(payee, 2_000_000).
+		SetChangeAddress(change).
+		Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteRejectsWalletOnOtherNetwork covers the bursa default: a wallet
+// derived for mainnet pointed at a preprod context for testing.
+func TestCompleteRejectsWalletOnOtherNetwork(t *testing.T) {
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	_, err := a.PayToAddress(payee, 2_000_000).Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteRejectsInputAddressOnOtherNetwork covers coin selection sourced
+// from an address on the wrong network.
+func TestCompleteRejectsInputAddressOnOtherNetwork(t *testing.T) {
+	foreign := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkTestnet,
+		common.AddressNetworkTestnet,
+	)
+	_, err := a.
+		AddInputAddress(foreign).
+		PayToAddress(payee, 2_000_000).
+		Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteRejectsInputUtxoOnOtherNetwork covers a pinned input whose
+// output address is on the wrong network.
+func TestCompleteRejectsInputUtxoOnOtherNetwork(t *testing.T) {
+	foreignCtx := networkTestContext(t, common.AddressNetworkMainnet)
+	foreignAddr := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	addTestUtxo(foreignCtx, foreignAddr, 10_000_000, 0x09, 0)
+	foreignUtxos, err := foreignCtx.Utxos(foreignAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(foreignUtxos) != 1 {
+		t.Fatalf("expected 1 UTxO, got %d", len(foreignUtxos))
+	}
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	a := networkTestBuilder(
+		t,
+		common.AddressNetworkTestnet,
+		common.AddressNetworkTestnet,
+	)
+	_, err = a.
+		AddInput(foreignUtxos[0]).
+		PayToAddress(payee, 2_000_000).
+		Complete()
+	requireNetworkMismatch(t, err)
+}
+
+// TestCompleteAcceptsMatchingNetworks proves the check never blocks a caller
+// whose wallet, payee, change and context all agree - including the mainnet
+// case, where the wallet network is bursa's default.
+func TestCompleteAcceptsMatchingNetworks(t *testing.T) {
+	for _, network := range []uint8{
+		common.AddressNetworkTestnet,
+		common.AddressNetworkMainnet,
+	} {
+		a := networkTestBuilder(t, network, network)
+		payee := syntheticAddress(t, common.AddressTypeKeyKey, network)
+		change := syntheticAddress(t, common.AddressTypeKeyNone, network)
+		a, err := a.
+			PayToAddress(payee, 2_000_000).
+			SetChangeAddress(change).
+			Complete()
+		if err != nil {
+			t.Fatalf("network %d: unexpected error: %v", network, err)
+		}
+		tx := a.GetTx()
+		if tx == nil {
+			t.Fatalf("network %d: expected a transaction", network)
+		}
+		if tx.Body.TxNetworkId == nil {
+			t.Fatalf("network %d: expected a network id in the body", network)
+		}
+		if *tx.Body.TxNetworkId != network {
+			t.Fatalf("network %d: body network id = %d",
+				network, *tx.Body.TxNetworkId)
+		}
+		for i, out := range tx.Body.TxOutputs {
+			addr := out.Address()
+			if addr.NetworkId() != uint(network) {
+				t.Fatalf("network %d: output %d is on network %d",
+					network, i, addr.NetworkId())
+			}
+		}
+	}
+}
+
+// TestCompleteRejectsContextWithUnknownNetworkId covers a backend reporting a
+// network id Cardano does not have.
+func TestCompleteRejectsContextWithUnknownNetworkId(t *testing.T) {
+	a := networkTestBuilder(t, 7, common.AddressNetworkTestnet)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkTestnet,
+	)
+	_, err := a.PayToAddress(payee, 2_000_000).Complete()
+	if err == nil {
+		t.Fatal("expected an error for an unknown context network id")
+	}
+	if !strings.Contains(err.Error(), "invalid network") {
+		t.Fatalf("expected an invalid network error, got: %v", err)
+	}
+}

--- a/script_data_hash_ledger_test.go
+++ b/script_data_hash_ledger_test.go
@@ -1,0 +1,309 @@
+package apollo
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// stubLedgerState is the slice of common.LedgerState the UTxO rules under test
+// actually touch. The embedded interface is nil, so any rule reaching for
+// something else fails the test loudly instead of silently passing.
+type stubLedgerState struct {
+	common.LedgerState
+	utxos []common.Utxo
+}
+
+func (s *stubLedgerState) UtxoById(
+	id common.TransactionInput,
+) (common.Utxo, error) {
+	for _, utxo := range s.utxos {
+		if utxo.Id.Id() == id.Id() && utxo.Id.Index() == id.Index() {
+			return utxo, nil
+		}
+	}
+	return common.Utxo{}, errors.New("utxo not found")
+}
+
+func scriptDataTestParams() backend.ProtocolParameters {
+	return backend.ProtocolParameters{
+		MinFeeConstant:      155381,
+		MinFeeCoefficient:   44,
+		MaxTxSize:           16384,
+		CoinsPerUtxoByte:    "4310",
+		CollateralPercent:   150,
+		MaxCollateralInputs: 3,
+		MaxValSize:          "5000",
+		PriceMem:            0.0577,
+		PriceStep:           0.0000721,
+		MaxTxExMem:          "14000000",
+		MaxTxExSteps:        "10000000000",
+		KeyDeposits:         "2000000",
+		PoolDeposits:        "500000000",
+		CostModels: map[string][]int64{
+			"PlutusV2": {4, 5, 6},
+		},
+	}
+}
+
+// buildWitnessDatumTx builds a signed transaction that carries a witness
+// (non-inline) datum alongside a Plutus V2 mint script, and returns the
+// transaction as the ledger sees it plus the ledger state resolving its inputs.
+func buildWitnessDatumTx(
+	t *testing.T,
+	datum *common.Datum,
+) (*conway.ConwayTransaction, *stubLedgerState, common.Blake2b256) {
+	t.Helper()
+	gp := backend.GenesisParameters{NetworkMagic: 1}
+	cc := fixed.NewFixedChainContext(scriptDataTestParams(), gp, 0)
+	addr := testAddress(t)
+
+	var spendHash, collateralHash common.Blake2b256
+	spendHash[0] = 0x01
+	collateralHash[0] = 0x02
+	inputUtxo := makeTestUtxo(t, spendHash, 0, 20_000_000)
+	collateralUtxo := makeTestUtxo(t, collateralHash, 0, 5_000_000)
+
+	redeemer := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit(strings.Repeat("ab", 28), "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddInput(inputUtxo).
+		AddCollateral(collateralUtxo).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		Mint(unit, &redeemer, &common.ExUnits{Memory: 1, Steps: 1})
+
+	a, err := a.PayToContractWithDatumHash(addr, datum, 2_000_000)
+	if err != nil {
+		t.Fatalf("PayToContractWithDatumHash: %v", err)
+	}
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	txCbor, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatalf("GetTxCbor: %v", err)
+	}
+
+	// Decode the serialized transaction so that every ledger check runs
+	// against the on-wire bytes, exactly like a node receiving it.
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(txCbor, &tx); err != nil {
+		t.Fatalf("decode built tx: %v", err)
+	}
+	ls := &stubLedgerState{utxos: []common.Utxo{inputUtxo, collateralUtxo}}
+
+	// The datum hash the transaction declares on its script output.
+	var declared common.Blake2b256
+	var seen int
+	for _, output := range tx.Outputs() {
+		if h := output.DatumHash(); h != nil {
+			declared = *h
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("expected exactly 1 output datum hash, got %d", seen)
+	}
+	return &tx, ls, declared
+}
+
+func ledgerTestPparams() *conway.ConwayProtocolParameters {
+	return &conway.ConwayProtocolParameters{
+		CostModels: map[uint][]int64{1: {4, 5, 6}},
+	}
+}
+
+// TestScriptDataHashAcceptedByLedgerRules is the settling evidence for the
+// script data hash: gouroboros' own Conway UTxO rules recompute the script
+// integrity hash over the transaction's on-wire witness bytes and must accept
+// what Apollo built.
+func TestScriptDataHashAcceptedByLedgerRules(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	tx, ls, _ := buildWitnessDatumTx(t, &datum)
+
+	if len(tx.WitnessSet.WsPlutusData.Items()) != 1 {
+		t.Fatalf(
+			"expected 1 witness datum, got %d",
+			len(tx.WitnessSet.WsPlutusData.Items()),
+		)
+	}
+	onWire := hex.EncodeToString(tx.WitnessSet.WsPlutusData.Cbor())
+	if !strings.HasPrefix(onWire, "d90102") {
+		t.Fatalf("witness plutus_data is not a tag-258 set: %s", onWire)
+	}
+	if onWire != "d90102811863" {
+		t.Fatalf("unexpected on-wire plutus_data bytes: %s", onWire)
+	}
+
+	pp := ledgerTestPparams()
+	if err := conway.UtxoValidateScriptDataHash(tx, 0, ls, pp); err != nil {
+		t.Fatalf("gouroboros ledger rejected script data hash: %v", err)
+	}
+	if err := conway.UtxoValidateSupplementalDatums(tx, 0, ls, pp); err != nil {
+		t.Fatalf("gouroboros ledger rejected witness datum: %v", err)
+	}
+}
+
+// TestScriptDataHashPreimageUsesOnWireWitnessBytes pins the preimage halves to
+// the exact bytes of witness set fields 5 and 4, and shows that the bare-array
+// datum encoding that predates this fix hashes to something else.
+func TestScriptDataHashPreimageUsesOnWireWitnessBytes(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	tx, _, _ := buildWitnessDatumTx(t, &datum)
+
+	declared := tx.Body.TxScriptDataHash
+	if declared == nil {
+		t.Fatal("built transaction has no script data hash")
+	}
+
+	redeemersCbor := tx.WitnessSet.WsRedeemers.Cbor()
+	datumsCbor := tx.WitnessSet.WsPlutusData.Cbor()
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{1: {}},
+		map[uint][]int64{1: {4, 5, 6}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preimage := make(
+		[]byte,
+		0,
+		len(redeemersCbor)+len(datumsCbor)+len(langViews),
+	)
+	preimage = append(preimage, redeemersCbor...)
+	preimage = append(preimage, datumsCbor...)
+	preimage = append(preimage, langViews...)
+	want := common.Blake2b256Hash(preimage)
+	if *declared != want {
+		t.Fatalf(
+			"script data hash does not match on-wire preimage:\n"+
+				" declared %x\n on-wire %x\n datums %x",
+			declared.Bytes(),
+			want.Bytes(),
+			datumsCbor,
+		)
+	}
+
+	// The untagged datum array is what the preimage used to be built from.
+	bare, err := cbor.Encode(tx.WitnessSet.WsPlutusData.Items())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(bare) == hex.EncodeToString(datumsCbor) {
+		t.Fatal("bare array and tag-258 set encodings are identical")
+	}
+	stale := make([]byte, 0, len(redeemersCbor)+len(bare)+len(langViews))
+	stale = append(stale, redeemersCbor...)
+	stale = append(stale, bare...)
+	stale = append(stale, langViews...)
+	if *declared == common.Blake2b256Hash(stale) {
+		t.Fatalf(
+			"script data hash still matches the untagged-datums preimage %x",
+			bare,
+		)
+	}
+}
+
+// TestComputeScriptDataHashDatumsHalfIsTaggedSet asserts the exact preimage
+// bytes ComputeScriptDataHash uses for the datums half.
+func TestComputeScriptDataHashDatumsHalfIsTaggedSet(t *testing.T) {
+	datums := []common.Datum{
+		{Data: plutigoData.NewInteger(big.NewInt(99))},
+	}
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{}
+	got, err := ComputeScriptDataHash(redeemers, datums, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected a script data hash")
+	}
+
+	set := WitnessPlutusData(datums)
+	datumsCbor, err := cbor.Encode(&set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(datumsCbor) != "d90102811863" {
+		t.Fatalf(
+			"unexpected witness plutus_data bytes: %x",
+			datumsCbor,
+		)
+	}
+	emptyCostModels, err := cbor.Encode(map[uint][]int64{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	preimage := append([]byte{0xa0}, datumsCbor...)
+	preimage = append(preimage, emptyCostModels...)
+	want := common.Blake2b256Hash(preimage)
+	if *got != want {
+		t.Fatalf(
+			"ComputeScriptDataHash = %x, want %x",
+			got.Bytes(),
+			want.Bytes(),
+		)
+	}
+
+	bare, err := cbor.Encode(datums)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stalePreimage := append([]byte{0xa0}, bare...)
+	stalePreimage = append(stalePreimage, emptyCostModels...)
+	if *got == common.Blake2b256Hash(stalePreimage) {
+		t.Fatal("preimage still uses the untagged datum array")
+	}
+}
+
+// TestPayToContractWithDatumHashMatchesWitnessDatum checks the output's datum
+// hash against the hash the ledger derives from the datum's on-wire bytes.
+func TestPayToContractWithDatumHashMatchesWitnessDatum(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	tx, ls, declared := buildWitnessDatumTx(t, &datum)
+
+	witnessDatums := tx.WitnessSet.WsPlutusData.Items()
+	if len(witnessDatums) != 1 {
+		t.Fatalf("expected 1 witness datum, got %d", len(witnessDatums))
+	}
+	onWireHash := witnessDatums[0].Hash()
+	if declared != onWireHash {
+		t.Fatalf(
+			"output datum hash %x does not match on-wire witness datum hash %x",
+			declared.Bytes(),
+			onWireHash.Bytes(),
+		)
+	}
+
+	var found bool
+	for _, output := range tx.Outputs() {
+		if h := output.DatumHash(); h != nil && *h == declared {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no output carries datum hash %x", declared.Bytes())
+	}
+	if err := conway.UtxoValidateSupplementalDatums(
+		tx,
+		0,
+		ls,
+		ledgerTestPparams(),
+	); err != nil {
+		t.Fatalf("gouroboros ledger rejected witness datum: %v", err)
+	}
+}

--- a/selection_reserve_test.go
+++ b/selection_reserve_test.go
@@ -1,0 +1,124 @@
+package apollo
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWalletCanSpendCloseToItsBalance is the regression guard for the coin
+// selection fee reserve. Selection previously reserved the whole of MaxTxFee --
+// the fee for a maximum-size transaction, 876277 lovelace on these parameters --
+// so a wallet holding less than payment+876277 was refused with "insufficient
+// UTxOs to cover required value" even though it could comfortably afford the
+// transaction. The reserve is now derived from the shape being built, so the
+// requirement is payment plus the actual fee.
+func TestWalletCanSpendCloseToItsBalance(t *testing.T) {
+	const pay = 2_000_000
+
+	// A wallet holding the payment plus a little over the real fee must be able
+	// to send. The old reserve needed pay+876277.
+	const balance = pay + 200_000
+
+	a, err := buildTransfer(t, balance, pay)
+	if err != nil {
+		t.Fatalf("balance %d could not send %d: %v", balance, pay, err)
+	}
+	tx := a.GetTx()
+	if got := len(tx.Body.Inputs()); got != 1 {
+		t.Errorf("spent %d inputs, want 1", got)
+	}
+	// The fee must still cover the transaction's own size.
+	if minFee := minFeeForTx(t, a); tx.Body.TxFee < minFee {
+		t.Errorf("fee %d is below the minimum %d", tx.Body.TxFee, minFee)
+	}
+	assertValueConserved(t, a, balance)
+}
+
+// TestSpendableThresholdIsPaymentPlusFee walks up from an unaffordable balance
+// and pins where spending becomes possible: it must be governed by the real fee,
+// not by MaxTxFee.
+func TestSpendableThresholdIsPaymentPlusFee(t *testing.T) {
+	const pay = 2_000_000
+
+	var firstOK uint64
+	for balance := uint64(pay); balance <= pay+900_000; balance += 5_000 {
+		if _, err := buildTransfer(t, balance, pay); err == nil {
+			firstOK = balance
+			break
+		}
+	}
+	if firstOK == 0 {
+		t.Fatal("no balance up to payment+900000 could send the payment")
+	}
+
+	overhead := firstOK - pay
+	t.Logf("first spendable balance %d (overhead %d lovelace)", firstOK, overhead)
+
+	// The overhead must be in the region of a real transaction fee, not the
+	// maximum-size fee the old reserve assumed.
+	const maxTxFeeOnFixedParams = 876_277
+	if overhead >= maxTxFeeOnFixedParams {
+		t.Errorf(
+			"overhead is %d lovelace, still at or above the MaxTxFee reserve %d",
+			overhead, maxTxFeeOnFixedParams,
+		)
+	}
+	if overhead > 400_000 {
+		t.Errorf("overhead %d lovelace is larger than a plausible fee", overhead)
+	}
+}
+
+// TestGenuinelyInsufficientBalanceStillFails confirms the tighter reserve did
+// not turn a real shortfall into a silently wrong transaction.
+func TestGenuinelyInsufficientBalanceStillFails(t *testing.T) {
+	const pay = 2_000_000
+
+	// Below payment plus any possible fee, this cannot be funded.
+	if _, err := buildTransfer(t, pay+1_000, pay); err == nil {
+		t.Fatal("expected an error when the balance cannot cover payment plus fee")
+	} else if !strings.Contains(err.Error(), "coin selection failed") {
+		t.Errorf("unexpected error for an unfundable payment: %v", err)
+	}
+}
+
+// TestReserveGrowsForManyInputs exercises the path where the first estimated
+// reserve is too small because selection has to gather many UTxOs: the reserve
+// must grow and re-select rather than proceed underfunded.
+func TestReserveGrowsForManyInputs(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	// Many small UTxOs, so covering the payment needs a lot of them and the
+	// transaction is far larger than the pre-selection estimate assumed.
+	const utxoCount = 60
+	const perUtxo = 2_000_000
+	for i := range utxoCount {
+		addTestUtxo(cc, addr, perUtxo, byte(i+1), 0)
+	}
+
+	p, err := NewPayment(validTestAddrBech32, 100_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Complete()
+	if err != nil {
+		t.Fatalf("multi-input transfer failed to build: %v", err)
+	}
+
+	tx := a.GetTx()
+	inputs := len(tx.Body.Inputs())
+	if inputs < 2 {
+		t.Fatalf("spent %d inputs, expected many", inputs)
+	}
+	minFee := minFeeForTx(t, a)
+	t.Logf("inputs=%d fee=%d minFee=%d", inputs, tx.Body.TxFee, minFee)
+	if tx.Body.TxFee < minFee {
+		t.Errorf(
+			"fee %d is below the minimum %d for a %d-input transaction",
+			tx.Body.TxFee, minFee, inputs,
+		)
+	}
+}


### PR DESCRIPTION
Ten defects found during a pre-2.0 audit, each reproduced by a test that fails on `master`. All of them pass CI today, so none was visible to the existing suite.

## Transaction builder

**Metadata was silently discarded, and every metadata transaction was invalid.** `buildMetadata` returned a `*common.MetaMap` without storing its encoding, and gouroboros serializes auxiliary data from `TxMetadata.Cbor()` — empty for a freshly built map. So `auxiliary_data` went on the wire as CBOR null while the body still declared `auxiliary_data_hash`:

```
84a6...075820ef1d373f...0f00 a0 f5 f6
             ^ auxiliary_data_hash        ^ auxiliary_data = f6 (null)
```

**Ordinary payments failed across a ~1.15 ADA band of balances**, with no scripts involved. Two interdependent causes — neither is observable without fixing the other:

| | required balance to send 2 ADA | overhead |
|---|---|---|
| before | 3.15 ADA | 1,150,000 |
| after | **2.17 ADA** | **170,000** |

170,000 lovelace is the actual fee. Along the way this also fixes a bistability at the change output's min-UTxO threshold, where the cheaper of the two stable shapes underpays its own size — the fee is now monotone.

**Claiming staking rewards produced a transaction with an empty input set** (`InputSetEmptyUTxO`), because withdrawals and refunds are implicit inputs and could cover the selection target alone.

## Hashing

**The script data hash omitted the tag-258 set prefix the witness set itself carries**, so every transaction with witness (non-inline) datums plus a script was rejected. Verified by running a serialized transaction through `conway.UtxoValidateScriptDataHash` and `conway.UtxoValidateSupplementalDatums` — gouroboros' own ledger rules, which reject `master` and accept this branch.

**Datum hashes were computed over re-encoded CBOR** rather than the bytes being serialized. This one is constrained upstream: `common.Datum.MarshalCBOR` discards stored CBOR ([gouroboros#1929](https://github.com/blinklabs-io/gouroboros/issues/1929)), so non-canonical bytes cannot reach the wire at all. A non-canonical datum is therefore rejected with both hashes named, rather than signed into something unmatchable. If the upstream issue lands, this code follows the wire automatically.

## Backends

**The Ogmios backend read every lovelace protocol parameter as 0.** Ogmios has encoded these as `{"ada":{"lovelace":N}}` since v6.1.0; the decoder expected the v6.0 flat shape and `encoding/json` silently ignored the unknown key. `MinFeeConstant = 0` made every fee **155,381 lovelace short**. **`GenesisParams` also failed against every real v6 deployment** — `slotLength` is `{"milliseconds":N}`, `activeSlotsCoefficient` is a ratio string, and `startTime` was unmapped.

**The UTxO RPC backend could not build any Plutus transaction**, because the builder forwarded all resolved inputs as `additionalUtxos` unconditionally while that backend rejects them and declines the capability — which `backend/base.go` already documented callers must check.

## Addresses

**A bech32 checksum failure fell through to base58.** Shelley addresses are entirely base58-legal, so a corrupted mainnet address decoded to unrelated bytes — **6,635 of 7,091** single-character corruptions were accepted. Validation now requires a non-Byron address to re-encode to its input text, which establishes both a valid checksum and an HRP matching the header byte. Reported upstream as [gouroboros#1930](https://github.com/blinklabs-io/gouroboros/issues/1930) and [#1931](https://github.com/blinklabs-io/gouroboros/issues/1931).

**No network-tag validation existed**, so a mainnet wallet could build a transaction tagged for testnet.

## Breaking changes

Exported API that cannot be withdrawn after 2.0:

- `constants.Network` and `MAINNET`/`TESTNET`/`PREVIEW`/`PREPROD` — the enum made `MAINNET == 0` while Cardano network ids are mainnet = **1**, so `uint8(constants.MAINNET)` selected a testnet. Unreferenced module-wide.
- `constants.BlockfrostBaseUrlTestnet` — a network retired in 2023.
- `backend.AddressAmount` — exported with no references.
- Seven `backend` parsing helpers move to `internal/backendutil`; each was used only by in-tree backends.
- `GetBurns()` previously duplicated `GetMints()`. It now returns the absolute burn requirement.

## Behaviour changes for release notes

- Metadata now reaches the chain; transactions that previously "succeeded" locally were invalid.
- Addresses with trailing extra-data bytes and non-canonical bech32 forms are rejected as payees. All-uppercase bech32 still works.
- Cross-network addresses fail at `Complete()` instead of building.
- A datum whose stored CBOR is non-canonical errors rather than producing an unmatched hash.

## Verification

`go build`, `go vet`, `gofmt -l`, `go test -race -count=1 ./...` across all 11 packages, `golangci-lint run` (0 issues), and `GOOS=linux GOARCH=386 go build`.

## Follow-ups deliberately not included

- `resolveCredential` is a fifth bech32 entry point still calling `common.NewAddress` directly, behind `RegisterStake`/`DelegateStake`/`DelegateVote`. One line; produces a bad stake credential rather than a misdirected payment.
- Blockfrost's `/utils/txs/evaluate/utxos` fallback is now unreachable from the builder; having its `Capabilities()` report `CapabilityEvaluateTxAdditionalUtxos` would restore it.
- `PaymentI.ToTxOut()` returns `*babbage.BabbageTransactionOutput` and `GetTx()` returns `*conway.ConwayTransaction`, welding a public interface to one era. `NewOgmiosChainContext` leaks `*ogmigo.Client`/`*kugo.Client`. Both are frozen by the tag.
