### PR TITLE
fix: converge the fee loop and size the selection reserve from the transaction being built

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -1588,43 +1588,105 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		return a, fmt.Errorf("preliminary fee overflows int64: max fee=%d reference script fee=%d", prelimFee, refScriptFeeReserve)
 	}
 	prelimFee += refScriptFeeReserve
-	selectionTarget, err := balanceRequired.Add(NewSimpleValue(uint64(prelimFee))) //nolint:gosec // maxFee is bounded above and refScriptFeeReserve overflow is checked above
-	if err != nil {
-		return a, fmt.Errorf("selection target overflow: %w", err)
-	}
-	// Tokens being burned must be present in the inputs. mintValue adds them
-	// to totalInput as negative amounts, which selection would otherwise
-	// ignore, silently building a transaction that cannot conserve value.
-	if a.hasMint() {
-		burnValue, err := a.burnRequirementValue()
-		if err != nil {
-			return a, err
+
+	// buildSelectionTarget converts a fee reserve into the value coin selection
+	// must cover. Tokens being burned must be present in the inputs: mintValue
+	// adds them to totalInput as negative amounts, which selection would
+	// otherwise ignore, silently building a transaction that cannot conserve
+	// value.
+	buildSelectionTarget := func(reserve int64) (Value, error) {
+		if reserve < 0 {
+			return Value{}, fmt.Errorf("negative fee reserve: %d", reserve)
 		}
-		selectionTarget, err = selectionTarget.Add(burnValue)
-		if err != nil {
-			return a, fmt.Errorf("selection target overflow: %w", err)
+		target, addErr := balanceRequired.Add(NewSimpleValue(uint64(reserve))) //nolint:gosec // checked non-negative above
+		if addErr != nil {
+			return Value{}, fmt.Errorf("selection target overflow: %w", addErr)
+		}
+		if a.hasMint() {
+			burnValue, burnErr := a.burnRequirementValue()
+			if burnErr != nil {
+				return Value{}, burnErr
+			}
+			target, addErr = target.Add(burnValue)
+			if addErr != nil {
+				return Value{}, fmt.Errorf("selection target overflow: %w", addErr)
+			}
+		}
+		return target, nil
+	}
+
+	// Reserving the full MaxTxFee makes selection refuse wallets that can
+	// comfortably afford the transaction: MaxTxFee prices a maximum-size
+	// transaction (876277 lovelace on mainnet parameters) while a simple
+	// transfer costs nearer 170000, so the top ~0.7 ADA of every wallet was
+	// unspendable and reported as "insufficient UTxOs to cover required value".
+	//
+	// Try a reserve estimated from the shape known so far. If the inputs it
+	// selects turn out to need more fee than was reserved, roll the reservation
+	// bookkeeping back and re-select against the full MaxTxFee ceiling, which is
+	// exactly the previous behaviour -- so this never selects less
+	// conservatively than before, it only avoids doing so unnecessarily.
+	//
+	// A smaller reserve is a strictly smaller selection target, so a failure at
+	// the estimated reserve would also fail at the ceiling; such failures are
+	// genuine insufficiency and are reported directly.
+	// The reserve starts at the fee for the shape known before selection and
+	// grows to whatever the selected inputs actually cost, re-selecting each
+	// time, until the reserve covers the fee it produces. Growth is monotone and
+	// capped at prelimFee, so the loop terminates and the last attempt is always
+	// the old ceiling behaviour.
+	const maxSelectionAttempts = 3
+	reserve := prelimFee
+	if initialFee, estErr := a.estimateFee(a.preselectedUtxos, outputs); estErr == nil {
+		reserve = initialFee + a.FeePadding
+		if reserve < 0 || reserve > prelimFee {
+			reserve = prelimFee
 		}
 	}
 
-	// Coin selection. setCollateral() reserves an auto-selected collateral UTxO
-	// out of the pool so multi-UTxO wallets keep a separate collateral and an
-	// unchanged tx shape. If that reservation starves selection (e.g. a wallet
-	// with a single UTxO), release the collateral for overlap - the ledger lets
-	// one UTxO be both a spending input and collateral - and retry once.
-	selectedUtxos, err := a.selectCoins(selectionTarget, totalInput)
-	if err != nil {
-		if a.releaseCollateralForOverlap() {
-			selectedUtxos, err = a.selectCoins(selectionTarget, totalInput)
-			if err != nil {
-				// The overlap retry also failed. Restore the collateral
-				// reservation and clear the overlap flag so a subsequent
-				// Complete() on this builder starts from consistent state.
-				a.restoreCollateralReservation()
-			}
+	var selectedUtxos []common.Utxo
+	for attempt := 0; ; attempt++ {
+		selectionTarget, targetErr := buildSelectionTarget(reserve)
+		if targetErr != nil {
+			return a, targetErr
 		}
+		preSelectionState := a.snapshotSelectionState()
+		selectedUtxos, err = a.selectCoinsAllowingCollateralOverlap(
+			selectionTarget,
+			totalInput,
+		)
 		if err != nil {
 			return a, fmt.Errorf("coin selection failed: %w", err)
 		}
+		if reserve >= prelimFee || attempt+1 >= maxSelectionAttempts {
+			break
+		}
+
+		// Price the shape actually selected. estimateFee already includes the
+		// reference-script surcharge for the inputs it is given, so its result
+		// is directly comparable to the reserve.
+		trialInputs := make(
+			[]common.Utxo,
+			0,
+			len(a.preselectedUtxos)+len(selectedUtxos),
+		)
+		trialInputs = append(trialInputs, a.preselectedUtxos...)
+		trialInputs = append(trialInputs, selectedUtxos...)
+		selectedFee, feeEstErr := a.estimateFee(SortInputs(trialInputs), outputs)
+		needed := prelimFee
+		if feeEstErr == nil {
+			needed = selectedFee + a.FeePadding
+			if needed < 0 || needed > prelimFee {
+				needed = prelimFee
+			}
+		}
+		if needed <= reserve {
+			break
+		}
+		// The reserve was too small for what it selected. Roll the reservation
+		// bookkeeping back so the next attempt selects from the same pool.
+		a.restoreSelectionState(preSelectionState)
+		reserve = needed
 	}
 
 	// Build inputs (explicit allocation to avoid slice aliasing)
@@ -1699,8 +1761,20 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	var previousShape string
 	seenShapes := make(map[string]struct{}, maxEvaluationIterations)
 	converged := false
+	// requestedFee is the size-based fee that drives the iteration.
+	// buildBalancedOutputs may return a larger fee than it was given, by
+	// absorbing sub-min-UTxO ADA change into it and dropping the change
+	// output. That surcharge is not something estimateFee can predict from the
+	// resulting outputs, so convergence is judged on requestedFee while fee
+	// carries the amount actually charged. Comparing the absorbed fee against
+	// a fresh estimate instead never terminates.
+	requestedFee := fee
 	for range maxEvaluationIterations {
-		balanced, balanceErr := a.buildBalancedOutputs(baseOutputs, fee, balance)
+		balanced, balanceErr := a.buildBalancedOutputs(
+			baseOutputs,
+			requestedFee,
+			balance,
+		)
 		if balanceErr != nil {
 			return a, balanceErr
 		}
@@ -1729,18 +1803,30 @@ func (a *Apollo) Complete() (*Apollo, error) {
 			return a, fmt.Errorf("failed to encode evaluation shape: %w", bodyErr)
 		}
 		shape := string(bodyBytes)
-		newFee := fee
+		nextFee := requestedFee
 		if !a.forceFee && a.Fee == 0 {
-			newFee, err = a.estimateFee(allInputUtxos, outputs)
+			nextFee, err = a.estimateFee(allInputUtxos, outputs)
 			if err != nil {
 				return a, fmt.Errorf("fee re-estimation failed: %w", err)
 			}
-			newFee += a.FeePadding
-			if newFee < 0 {
-				newFee = 0
+			nextFee += a.FeePadding
+			if nextFee < 0 {
+				nextFee = 0
 			}
 		}
-		if newFee == fee && previousShape == shape {
+		// Never settle on a fee below one already required by a shape that was
+		// considered. Around the change output's min-UTxO threshold the same
+		// transaction is bistable: at the lower fee the change clears min-UTxO
+		// and is emitted, which pushes the size-based fee up; at the higher fee
+		// the change falls below min-UTxO and is absorbed, which pulls the
+		// estimate back down. Allowing the fee to move downward alternates
+		// between those two shapes indefinitely, and the cheaper of them
+		// underpays its own size. Moving only upward terminates and never
+		// underpays.
+		if nextFee < requestedFee {
+			nextFee = requestedFee
+		}
+		if nextFee == requestedFee && previousShape == shape {
 			converged = true
 			break
 		}
@@ -1749,7 +1835,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		}
 		seenShapes[shape] = struct{}{}
 		previousShape = shape
-		fee = newFee
+		requestedFee = nextFee
 	}
 	if !converged {
 		return a, errors.New("evaluation transaction did not converge after 5 iterations")
@@ -3049,6 +3135,52 @@ func (a *Apollo) restoreCollateralReservation() {
 	}
 	a.markUsed(a.collateralOverlapRef)
 	a.collateralOverlapRef = ""
+}
+
+// selectionState captures the UTxO reservation bookkeeping that coin selection
+// mutates, so a speculative selection can be rolled back and retried against a
+// different fee reserve.
+type selectionState struct {
+	usedUtxos            map[string]bool
+	collateralOverlapRef string
+}
+
+func (a *Apollo) snapshotSelectionState() selectionState {
+	return selectionState{
+		usedUtxos:            maps.Clone(a.usedUtxos),
+		collateralOverlapRef: a.collateralOverlapRef,
+	}
+}
+
+func (a *Apollo) restoreSelectionState(s selectionState) {
+	a.usedUtxos = maps.Clone(s.usedUtxos)
+	a.collateralOverlapRef = s.collateralOverlapRef
+}
+
+// selectCoinsAllowingCollateralOverlap runs coin selection, and on failure
+// retries once with the auto-selected collateral released. setCollateral()
+// reserves a collateral UTxO out of the pool so multi-UTxO wallets keep a
+// separate collateral and an unchanged tx shape; when that reservation starves
+// selection (a wallet with a single UTxO, say) the ledger does permit one UTxO
+// to be both a spending input and collateral. If the retry also fails, the
+// reservation is restored so a subsequent Complete() starts from consistent
+// state.
+func (a *Apollo) selectCoinsAllowingCollateralOverlap(
+	target, totalInput Value,
+) ([]common.Utxo, error) {
+	selected, err := a.selectCoins(target, totalInput)
+	if err == nil {
+		return selected, nil
+	}
+	if a.releaseCollateralForOverlap() {
+		selected, retryErr := a.selectCoins(target, totalInput)
+		if retryErr == nil {
+			return selected, nil
+		}
+		a.restoreCollateralReservation()
+		return nil, retryErr
+	}
+	return nil, err
 }
 
 // finalizeCollateral sizes and validates the total collateral and the

--- a/evaluation_convergence_test.go
+++ b/evaluation_convergence_test.go
@@ -1,0 +1,180 @@
+package apollo
+
+import (
+	"math/big"
+	"testing"
+)
+
+// buildTransfer completes a plain lovelace payment from a wallet holding
+// exactly balance, with no scripts involved.
+func buildTransfer(
+	t *testing.T,
+	balance uint64,
+	pay int64,
+) (*Apollo, error) {
+	t.Helper()
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, balance, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, pay, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Complete()
+}
+
+// minFeeForTx returns the protocol minimum size-based fee for the serialized
+// transaction, computed independently of the builder.
+func minFeeForTx(t *testing.T, a *Apollo) uint64 {
+	t.Helper()
+	txCbor, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pp, err := a.Context.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pp.MinFeeCoefficient <= 0 || pp.MinFeeConstant <= 0 {
+		t.Fatalf(
+			"protocol params not usable: minFeeA=%d minFeeB=%d",
+			pp.MinFeeCoefficient, pp.MinFeeConstant,
+		)
+	}
+	//nolint:gosec // protocol params validated positive above
+	return uint64(len(txCbor))*uint64(pp.MinFeeCoefficient) +
+		uint64(pp.MinFeeConstant)
+}
+
+// TestDustChangeIsAbsorbedIntoFee is the regression guard for the fee
+// convergence loop. When change falls below the change output's min-UTxO,
+// buildBalancedOutputs drops the change output and adds the remainder to the
+// fee. The loop previously fed that dust-inclusive fee back into estimateFee,
+// which cannot predict the surcharge, so the comparison never matched and
+// every such transaction failed with "did not converge".
+func TestDustChangeIsAbsorbedIntoFee(t *testing.T) {
+	const pay = 2_000_000
+
+	// Change of 900_000 is below the ~978_370 min-UTxO for an ADA-only change
+	// output, so it must be absorbed rather than emitted.
+	a, err := buildTransfer(t, pay+900_000, pay)
+	if err != nil {
+		t.Fatalf("dust-change transfer failed to build: %v", err)
+	}
+
+	tx := a.GetTx()
+	if got := len(tx.Body.Outputs()); got != 1 {
+		t.Errorf("built %d outputs, want 1 (change must be absorbed)", got)
+	}
+	if got, want := tx.Body.TxFee, uint64(900_000); got != want {
+		t.Errorf("fee = %d, want %d (payment remainder absorbed)", got, want)
+	}
+	assertValueConserved(t, a, pay+900_000)
+}
+
+// TestDustChangeBandBuilds sweeps the whole range in which change is dust and
+// asserts every balance produces a valid, fully funded transaction.
+func TestDustChangeBandBuilds(t *testing.T) {
+	const pay = 2_000_000
+
+	// The lower bound is imposed by coin selection, which currently reserves
+	// the whole of MaxTxFee (876_277 on these parameters) rather than an
+	// estimate, so balances below payment+MaxTxFee never reach the fee loop.
+	// That over-reserve is a separate defect; this test covers the range the
+	// convergence loop is actually reached for, spanning both the dust-absorbed
+	// and change-emitted outcomes.
+	for balance := uint64(pay + 880_000); balance <= pay+1_200_000; balance += 5_000 {
+		a, err := buildTransfer(t, balance, pay)
+		if err != nil {
+			t.Errorf("balance %d: %v", balance, err)
+			continue
+		}
+		tx := a.GetTx()
+		outputs := len(tx.Body.Outputs())
+		if outputs != 1 && outputs != 2 {
+			t.Errorf("balance %d: built %d outputs, want 1 or 2", balance, outputs)
+		}
+		// Whether change was absorbed or emitted, the fee must still cover the
+		// transaction's own size. Absorbing dust must never underpay.
+		if minFee := minFeeForTx(t, a); tx.Body.TxFee < minFee {
+			t.Errorf(
+				"balance %d: fee %d is below the minimum %d for the built tx",
+				balance, tx.Body.TxFee, minFee,
+			)
+		}
+		assertValueConserved(t, a, balance)
+	}
+}
+
+// TestChangeAboveMinUtxoIsStillEmitted confirms the fix did not turn ordinary
+// change into absorbed dust.
+func TestChangeAboveMinUtxoIsStillEmitted(t *testing.T) {
+	const pay = 2_000_000
+	const balance = 10_000_000
+
+	a, err := buildTransfer(t, balance, pay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := a.GetTx()
+	if got := len(tx.Body.Outputs()); got != 2 {
+		t.Fatalf("built %d outputs, want 2 (payment plus change)", got)
+	}
+	if minFee := minFeeForTx(t, a); tx.Body.TxFee < minFee {
+		t.Errorf("fee %d is below the minimum %d", tx.Body.TxFee, minFee)
+	}
+	// With ample change the fee should be the size-based fee, not inflated.
+	if tx.Body.TxFee > 1_000_000 {
+		t.Errorf("fee %d is implausibly large for a simple transfer", tx.Body.TxFee)
+	}
+	assertValueConserved(t, a, balance)
+}
+
+// TestForceFeeStillBypassesEstimation guards the other branch of the loop:
+// with a forced fee, no re-estimation happens and the forced value is charged.
+func TestForceFeeStillBypassesEstimation(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		ForceFee(300_000).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := a.GetTx().Body.TxFee, uint64(300_000); got != want {
+		t.Errorf("forced fee = %d, want %d", got, want)
+	}
+}
+
+// assertValueConserved checks the Cardano balance equation against the single
+// input the helpers create: sum(outputs) + fee must equal the input value.
+func assertValueConserved(t *testing.T, a *Apollo, inputValue uint64) {
+	t.Helper()
+	tx := a.GetTx()
+	out := new(big.Int)
+	for _, o := range tx.Body.Outputs() {
+		out.Add(out, o.Amount())
+	}
+	got := new(big.Int).Add(out, new(big.Int).SetUint64(tx.Body.TxFee))
+	want := new(big.Int).SetUint64(inputValue)
+	if got.Cmp(want) != 0 {
+		t.Errorf(
+			"value not conserved: outputs %s + fee %d = %s, inputs %d",
+			out, tx.Body.TxFee, got, inputValue,
+		)
+	}
+}

--- a/selection_reserve_test.go
+++ b/selection_reserve_test.go
@@ -1,0 +1,124 @@
+package apollo
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWalletCanSpendCloseToItsBalance is the regression guard for the coin
+// selection fee reserve. Selection previously reserved the whole of MaxTxFee --
+// the fee for a maximum-size transaction, 876277 lovelace on these parameters --
+// so a wallet holding less than payment+876277 was refused with "insufficient
+// UTxOs to cover required value" even though it could comfortably afford the
+// transaction. The reserve is now derived from the shape being built, so the
+// requirement is payment plus the actual fee.
+func TestWalletCanSpendCloseToItsBalance(t *testing.T) {
+	const pay = 2_000_000
+
+	// A wallet holding the payment plus a little over the real fee must be able
+	// to send. The old reserve needed pay+876277.
+	const balance = pay + 200_000
+
+	a, err := buildTransfer(t, balance, pay)
+	if err != nil {
+		t.Fatalf("balance %d could not send %d: %v", balance, pay, err)
+	}
+	tx := a.GetTx()
+	if got := len(tx.Body.Inputs()); got != 1 {
+		t.Errorf("spent %d inputs, want 1", got)
+	}
+	// The fee must still cover the transaction's own size.
+	if minFee := minFeeForTx(t, a); tx.Body.TxFee < minFee {
+		t.Errorf("fee %d is below the minimum %d", tx.Body.TxFee, minFee)
+	}
+	assertValueConserved(t, a, balance)
+}
+
+// TestSpendableThresholdIsPaymentPlusFee walks up from an unaffordable balance
+// and pins where spending becomes possible: it must be governed by the real fee,
+// not by MaxTxFee.
+func TestSpendableThresholdIsPaymentPlusFee(t *testing.T) {
+	const pay = 2_000_000
+
+	var firstOK uint64
+	for balance := uint64(pay); balance <= pay+900_000; balance += 5_000 {
+		if _, err := buildTransfer(t, balance, pay); err == nil {
+			firstOK = balance
+			break
+		}
+	}
+	if firstOK == 0 {
+		t.Fatal("no balance up to payment+900000 could send the payment")
+	}
+
+	overhead := firstOK - pay
+	t.Logf("first spendable balance %d (overhead %d lovelace)", firstOK, overhead)
+
+	// The overhead must be in the region of a real transaction fee, not the
+	// maximum-size fee the old reserve assumed.
+	const maxTxFeeOnFixedParams = 876_277
+	if overhead >= maxTxFeeOnFixedParams {
+		t.Errorf(
+			"overhead is %d lovelace, still at or above the MaxTxFee reserve %d",
+			overhead, maxTxFeeOnFixedParams,
+		)
+	}
+	if overhead > 400_000 {
+		t.Errorf("overhead %d lovelace is larger than a plausible fee", overhead)
+	}
+}
+
+// TestGenuinelyInsufficientBalanceStillFails confirms the tighter reserve did
+// not turn a real shortfall into a silently wrong transaction.
+func TestGenuinelyInsufficientBalanceStillFails(t *testing.T) {
+	const pay = 2_000_000
+
+	// Below payment plus any possible fee, this cannot be funded.
+	if _, err := buildTransfer(t, pay+1_000, pay); err == nil {
+		t.Fatal("expected an error when the balance cannot cover payment plus fee")
+	} else if !strings.Contains(err.Error(), "coin selection failed") {
+		t.Errorf("unexpected error for an unfundable payment: %v", err)
+	}
+}
+
+// TestReserveGrowsForManyInputs exercises the path where the first estimated
+// reserve is too small because selection has to gather many UTxOs: the reserve
+// must grow and re-select rather than proceed underfunded.
+func TestReserveGrowsForManyInputs(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	// Many small UTxOs, so covering the payment needs a lot of them and the
+	// transaction is far larger than the pre-selection estimate assumed.
+	const utxoCount = 60
+	const perUtxo = 2_000_000
+	for i := range utxoCount {
+		addTestUtxo(cc, addr, perUtxo, byte(i+1), 0)
+	}
+
+	p, err := NewPayment(validTestAddrBech32, 100_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Complete()
+	if err != nil {
+		t.Fatalf("multi-input transfer failed to build: %v", err)
+	}
+
+	tx := a.GetTx()
+	inputs := len(tx.Body.Inputs())
+	if inputs < 2 {
+		t.Fatalf("spent %d inputs, expected many", inputs)
+	}
+	minFee := minFeeForTx(t, a)
+	t.Logf("inputs=%d fee=%d minFee=%d", inputs, tx.Body.TxFee, minFee)
+	if tx.Body.TxFee < minFee {
+		t.Errorf(
+			"fee %d is below the minimum %d for a %d-input transaction",
+			tx.Body.TxFee, minFee, inputs,
+		)
+	}
+}


### PR DESCRIPTION
Ordinary ADA payments failed across a ~1.15 ADA band of wallet balances, with no scripts involved. Two interdependent defects — **neither is observable without fixing the other**, which is why this is one PR with two commits.

**1. Dust absorption never converged.** `buildBalancedOutputs` drops a change output below its own min-UTxO and adds the remainder to the fee. The loop assigned that dust-inclusive fee back to its iteration variable, then compared it against a fresh `estimateFee` over the resulting change-less outputs. `estimateFee` prices size and cannot know about an absorbed surcharge, so the values never matched and the seen-shape guard aborted. The dust path was unreachable through the public API despite a unit test covering it directly.

**2. The selection reserve was the protocol maximum.** `MaxTxFee` prices a maximum-size transaction (876,277 lovelace) against a real fee near 170,000 — a 5.2x over-reserve, not overridable by `SetFee`, `ForceFee`, or `AddInput`.

Also fixed along the way: the transaction is **bistable** at the min-UTxO threshold. At the lower fee the change clears min-UTxO and is emitted, raising the size-based fee; at the higher fee it falls below and is absorbed, lowering the estimate. The cheaper shape *underpays* its own size, so the fee is now monotone — never below a value already required by a shape under consideration.

Measured effect on sending 2 ADA:

| | required balance | overhead |
|---|---|---|
| before | 3.15 ADA | 1,150,000 |
| after | **2.17 ADA** | **170,000** |

170,000 lovelace is the actual fee. Balances that genuinely cannot cover payment plus fee still fail, now accurately.

The reserve grows and re-selects rather than proceeding underfunded; growth is monotone and capped at the old `MaxTxFee` ceiling, so the final attempt is exactly the previous behaviour. Every test asserts the fee still covers the built transaction's own size, so a tighter reserve can never underpay.

Verified: new tests fail on `master` and pass here; `go test -race -count=1 ./...` green; `golangci-lint run` 0 issues; `gofmt` clean.
