### PR TITLE
fix: require at least one spending input

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -1928,8 +1928,37 @@ func (a *Apollo) sumUtxoValues(utxos []common.Utxo) (Value, error) {
 	return total, nil
 }
 
+// pickSingleInput chooses one UTxO to spend when the balance equation is
+// already satisfied by implicit inputs and the transaction only needs a
+// non-empty input set. A pure-ADA UTxO is preferred so the change output is not
+// forced to carry native assets, and candidates are considered in canonical
+// order so the choice is deterministic.
+func pickSingleInput(available []common.Utxo) (common.Utxo, error) {
+	if len(available) == 0 {
+		return common.Utxo{}, errors.New(
+			"no available UTxO to spend: a transaction must spend at least one input",
+		)
+	}
+	sorted := SortUtxos(available)
+	for _, utxo := range sorted {
+		assets := utxo.Output.Assets()
+		if assets == nil || len(assets.Policies()) == 0 {
+			return utxo, nil
+		}
+	}
+	return sorted[0], nil
+}
+
 func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error) {
-	if currentInput.GreaterOrEqual(required) {
+	// Withdrawals, mints, and certificate deposit refunds are implicit inputs
+	// in the balance equation, so currentInput can already cover the target
+	// with no UTxO being spent at all. The ledger still requires a non-empty
+	// input set (InputSetEmptyUTxO), and a transaction that spends nothing also
+	// carries no payment-key witness and has nothing establishing its
+	// uniqueness. If the caller pinned an input we are already satisfied;
+	// otherwise selection must contribute one even though no value is needed.
+	covered := currentInput.GreaterOrEqual(required)
+	if covered && len(a.preselectedUtxos) > 0 {
 		return nil, nil
 	}
 
@@ -1957,13 +1986,27 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 		}
 	}
 
-	selector := a.coinSelector
-	if selector == nil {
-		selector = defaultCoinSelector
-	}
-	selected, err := selector.Select(available, remaining)
-	if err != nil {
-		return nil, err
+	var selected []common.Utxo
+	if covered {
+		// The value is already satisfied, so spend exactly one UTxO purely to
+		// satisfy the non-empty input set rule. Prefer a pure-ADA UTxO so the
+		// change output does not have to carry native assets it did not need
+		// to, and pick deterministically so construction stays reproducible.
+		pick, pickErr := pickSingleInput(available)
+		if pickErr != nil {
+			return nil, pickErr
+		}
+		selected = []common.Utxo{pick}
+	} else {
+		selector := a.coinSelector
+		if selector == nil {
+			selector = defaultCoinSelector
+		}
+		var selErr error
+		selected, selErr = selector.Select(available, remaining)
+		if selErr != nil {
+			return nil, selErr
+		}
 	}
 	availableByRef := make(map[string]common.Utxo, len(available))
 	for _, utxo := range available {

--- a/input_set_test.go
+++ b/input_set_test.go
@@ -1,0 +1,141 @@
+package apollo
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// stakeAddressFor builds a reward address controlled by the same stake
+// credential as addr, suitable for AddWithdrawal.
+func stakeAddressFor(t *testing.T, addr common.Address) common.Address {
+	t.Helper()
+	stake, err := common.NewAddressFromParts(
+		common.AddressTypeNoneKey,
+		uint8(addr.NetworkId()), //nolint:gosec // network id is 0 or 1
+		nil,
+		addr.StakeKeyHash().Bytes(),
+	)
+	if err != nil {
+		t.Fatalf("build reward address: %v", err)
+	}
+	return stake
+}
+
+// TestWithdrawalTransactionSpendsAtLeastOneInput is the regression guard for a
+// transaction built with an empty input set.
+//
+// Withdrawals are implicit inputs in Cardano's balance equation, so a reward
+// claim large enough to cover the whole selection target made coin selection
+// return no UTxOs at all. The resulting body had inputs = [], which the ledger
+// rejects with InputSetEmptyUTxO. It also carried no payment-key witness and
+// nothing establishing the transaction's uniqueness.
+func TestWithdrawalTransactionSpendsAtLeastOneInput(t *testing.T) {
+	for _, reward := range []uint64{
+		500_000,     // below the selection reserve: selection ran before
+		5_000_000,   // above it: selection short-circuited
+		50_000_000,  // far above it
+		500_000_000, // far above the wallet balance itself
+	} {
+		cc := setupFixedContext()
+		addr := testAddress(t)
+		addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+		a, err := New(cc).
+			SetWallet(NewExternalWallet(addr)).
+			SetTtl(50_000_000).
+			AddWithdrawal(stakeAddressFor(t, addr), reward, nil, nil).
+			Complete()
+		if err != nil {
+			t.Errorf("reward %d: Complete failed: %v", reward, err)
+			continue
+		}
+
+		inputs := a.GetTx().Body.Inputs()
+		if len(inputs) == 0 {
+			t.Errorf(
+				"reward %d: built a transaction with an empty input set "+
+					"(InputSetEmptyUTxO)",
+				reward,
+			)
+			continue
+		}
+		t.Logf(
+			"reward %d -> inputs=%d outputs=%d fee=%d",
+			reward, len(inputs), len(a.GetTx().Body.Outputs()),
+			a.GetTx().Body.TxFee,
+		)
+	}
+}
+
+// TestWithdrawalOnlyTransactionConservesValue checks that forcing an input into
+// a withdrawal-funded transaction still balances: the spent UTxO plus the
+// reward must equal the outputs plus the fee.
+func TestWithdrawalOnlyTransactionConservesValue(t *testing.T) {
+	const balance = 10_000_000
+	const reward = 50_000_000
+
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, balance, 0x01, 0)
+
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		SetTtl(50_000_000).
+		AddWithdrawal(stakeAddressFor(t, addr), reward, nil, nil).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := a.GetTx()
+	inputs := tx.Body.Inputs()
+	if len(inputs) != 1 {
+		t.Fatalf("spent %d inputs, want 1", len(inputs))
+	}
+
+	var out uint64
+	for _, o := range tx.Body.Outputs() {
+		out += o.Amount().Uint64()
+	}
+	// One spent UTxO of `balance`, plus the withdrawal, funds outputs and fee.
+	if got, want := out+tx.Body.TxFee, uint64(balance+reward); got != want {
+		t.Errorf(
+			"value not conserved: outputs %d + fee %d = %d, want %d",
+			out, tx.Body.TxFee, got, want,
+		)
+	}
+	if got := len(tx.Body.Withdrawals()); got != 1 {
+		t.Errorf("body has %d withdrawals, want 1", got)
+	}
+}
+
+// TestPreselectedInputSatisfiesTheInputSet confirms the guarantee is satisfied
+// by a caller-pinned input without selection contributing another one.
+func TestPreselectedInputSatisfiesTheInputSet(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+	addTestUtxo(cc, addr, 10_000_000, 0x02, 0)
+
+	utxos, err := cc.Utxos(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) < 1 {
+		t.Fatal("fixture produced no UTxOs")
+	}
+
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		SetTtl(50_000_000).
+		AddInput(utxos[0]).
+		AddWithdrawal(stakeAddressFor(t, addr), 50_000_000, nil, nil).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(a.GetTx().Body.Inputs()); got != 1 {
+		t.Errorf("spent %d inputs, want exactly the 1 preselected", got)
+	}
+}


### PR DESCRIPTION
Claiming staking rewards produced a transaction with an **empty input set**.

Withdrawals, mints, and certificate deposit refunds are implicit inputs in the balance equation, and `Complete()` folds them into `totalInput` before coin selection. When they covered the target on their own, `selectCoins` short-circuited and returned no UTxOs:

```
reward=  5000000 -> inputs=0 outputs=1 fee=165677
reward= 50000000 -> inputs=0 outputs=1 fee=165677
reward=500000000 -> inputs=0 outputs=1 fee=165677
```

The ledger rejects that with `InputSetEmptyUTxO`. Such a transaction also carries no payment-key witness and nothing establishing its uniqueness. Deposit refunds from stake deregistration reach the same state by the same route.

The existing `TestCompleteWithWithdrawal` uses a 500,000 withdrawal — below the selection reserve, so selection still ran — and never asserted the input count.

`selectCoins` now distinguishes "the value is already covered" from "no input is needed". A caller-pinned input satisfies the requirement unchanged; otherwise selection contributes exactly one UTxO. `pickSingleInput` prefers a pure-ADA UTxO so the change output is not forced to carry native assets it did not need, considers candidates in canonical order for reproducibility, and errors clearly when the pool is empty.

Verified: new tests fail on `master` and pass here; `go test -race -count=1 ./...` green; `golangci-lint run` 0 issues; `gofmt` clean.
