### PR TITLE
fix: hash the witness bytes actually serialized for script data and datums

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -318,8 +318,16 @@ func (a *Apollo) AddCollateral(utxo common.Utxo) *Apollo {
 }
 
 // AddDatum adds a datum to the witness set.
+//
+// The datum's wire bytes are pinned onto it (see DatumWireCbor), so a datum
+// whose original CBOR cannot be reproduced on the wire is rejected here rather
+// than being silently rehashed into a transaction the ledger would refuse.
 func (a *Apollo) AddDatum(datum *common.Datum) *Apollo {
 	if datum != nil {
+		if _, err := DatumWireCbor(datum); err != nil {
+			a.setErrOnce(fmt.Errorf("AddDatum: %w", err))
+			return a
+		}
 		a.datums = append(a.datums, *datum)
 	}
 	return a
@@ -456,11 +464,12 @@ func (a *Apollo) PayToContractWithDatumHash(addr common.Address, datum *common.D
 		Units:    units,
 	}
 	if datum != nil {
-		datumCbor, err := cbor.Encode(datum)
+		// Hash the bytes the datum will occupy in the witness set, so the
+		// output's datum hash matches the datum the ledger sees.
+		hash, err := DatumHash(datum)
 		if err != nil {
-			return a, fmt.Errorf("failed to encode datum: %w", err)
+			return a, err
 		}
-		hash := common.Blake2b256Hash(datumCbor)
 		p.DatumHash = hash.Bytes()
 		a.datums = append(a.datums, *datum)
 	}
@@ -2532,14 +2541,12 @@ func (a *Apollo) buildWitnessSet(inputs []common.Utxo) conway.ConwayTransactionW
 		ws.WsNativeScripts = cbor.NewSetType(a.nativescripts, true)
 	}
 	if len(a.datums) > 0 {
-		ws.WsPlutusData = cbor.NewSetType(a.datums, true)
+		ws.WsPlutusData = WitnessPlutusData(a.datums)
 	}
 
 	redeemerMap := a.buildRedeemerMap(inputs)
 	if len(redeemerMap) > 0 {
-		ws.WsRedeemers = conway.ConwayRedeemers{
-			Redeemers: redeemerMap,
-		}
+		ws.WsRedeemers = WitnessRedeemers(redeemerMap)
 	}
 
 	return ws

--- a/datum_hash_test.go
+++ b/datum_hash_test.go
@@ -1,0 +1,259 @@
+package apollo
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+)
+
+// blake2bOfNothing is what common.Datum.Hash returns for a datum that was
+// built in Go rather than decoded from CBOR: its stored CBOR is empty, so the
+// method hashes the empty string. Any datum hash equal to this is a bug.
+const blake2bOfNothing = "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787" +
+	"faab45cdf12fe3a8"
+
+func decodeDatum(t *testing.T, cborHex string) common.Datum {
+	t.Helper()
+	raw, err := hex.DecodeString(cborHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var datum common.Datum
+	if err := datum.UnmarshalCBOR(raw); err != nil {
+		t.Fatalf("decode datum %s: %v", cborHex, err)
+	}
+	return datum
+}
+
+// TestDatumHashUsesWireBytesForBuiltDatum covers the trap that
+// common.Datum.Hash falls into for a datum that was never decoded.
+func TestDatumHashUsesWireBytesForBuiltDatum(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	if len(datum.Cbor()) != 0 {
+		t.Fatalf("expected no stored CBOR, got %x", datum.Cbor())
+	}
+	if got := datum.Hash().String(); got != blake2bOfNothing {
+		t.Fatalf(
+			"common.Datum.Hash on a built datum = %s, want %s",
+			got,
+			blake2bOfNothing,
+		)
+	}
+
+	got, err := DatumHash(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(wire) != "1863" {
+		t.Fatalf("unexpected wire bytes %x", wire)
+	}
+	want := common.Blake2b256Hash(wire)
+	if got != want {
+		t.Fatalf("DatumHash = %x, want %x", got.Bytes(), want.Bytes())
+	}
+	if got.String() == blake2bOfNothing {
+		t.Fatal("DatumHash returned the hash of the empty string")
+	}
+	// DatumWireCbor pins the wire bytes, so the obvious method now agrees.
+	if datum.Hash() != want {
+		t.Fatalf(
+			"common.Datum.Hash = %x after pinning, want %x",
+			datum.Hash().Bytes(),
+			want.Bytes(),
+		)
+	}
+}
+
+func TestDatumWireCborKeepsCanonicalStoredBytes(t *testing.T) {
+	datum := decodeDatum(t, "d8799f4161ff")
+	got, err := DatumWireCbor(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != "d8799f4161ff" {
+		t.Fatalf("DatumWireCbor = %x, want d8799f4161ff", got)
+	}
+	hash, err := DatumHash(&datum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != datum.Hash() {
+		t.Fatalf(
+			"DatumHash %x disagrees with common.Datum.Hash %x",
+			hash.Bytes(),
+			datum.Hash().Bytes(),
+		)
+	}
+}
+
+// TestDatumWireCborRejectsNonCanonicalStoredBytes covers datum encodings that
+// plutigo cannot reproduce. Hashing the stored bytes while the witness set
+// carries the re-encoded bytes is what silently locks funds, so Apollo refuses
+// the datum instead.
+func TestDatumWireCborRejectsNonCanonicalStoredBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cborHex  string
+		wantWire string
+	}{
+		{
+			name: "definite byte string above the 64 byte chunk limit",
+			cborHex: "d8799f5864" +
+				strings.Repeat("ab", 100) + "ff",
+			wantWire: "d8799f5f5840" + strings.Repeat("ab", 64) +
+				"5824" + strings.Repeat("ab", 36) + "ffff",
+		},
+		{
+			name:     "non-minimal integer",
+			cborHex:  "1801",
+			wantWire: "01",
+		},
+		{
+			name:     "two byte integer holding a small value",
+			cborHex:  "190001",
+			wantWire: "01",
+		},
+		{
+			name:     "bignum tag around a small value",
+			cborHex:  "c24101",
+			wantWire: "01",
+		},
+		{
+			name:     "indefinite length byte string",
+			cborHex:  "5f4161ff",
+			wantWire: "4161",
+		},
+		{
+			name:     "indefinite length constr fields",
+			cborHex:  "d8669f18809f01ffff",
+			wantWire: "d8668218809f01ff",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			datum := decodeDatum(t, test.cborHex)
+			wire, err := cbor.Encode(&datum)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hex.EncodeToString(wire) != test.wantWire {
+				t.Fatalf(
+					"wire bytes = %x, want %s",
+					wire,
+					test.wantWire,
+				)
+			}
+			storedHash := common.Blake2b256Hash(datum.Cbor())
+			wireHash := common.Blake2b256Hash(wire)
+			if storedHash == wireHash {
+				t.Fatalf(
+					"stored and wire bytes hash alike (%x); not a divergent case",
+					storedHash.Bytes(),
+				)
+			}
+
+			if _, err := DatumWireCbor(&datum); err == nil {
+				t.Fatal("expected DatumWireCbor to reject the datum")
+			} else {
+				if !strings.Contains(err.Error(), storedHash.String()) {
+					t.Errorf(
+						"error does not name the original hash %s: %v",
+						storedHash.String(),
+						err,
+					)
+				}
+				if !strings.Contains(err.Error(), wireHash.String()) {
+					t.Errorf(
+						"error does not name the wire hash %s: %v",
+						wireHash.String(),
+						err,
+					)
+				}
+			}
+
+			if _, err := DatumHash(&datum); err == nil {
+				t.Fatal("expected DatumHash to reject the datum")
+			}
+		})
+	}
+}
+
+func TestAddDatumRejectsNonCanonicalStoredBytes(t *testing.T) {
+	datum := decodeDatum(t, "d8799f5864"+strings.Repeat("ab", 100)+"ff")
+	cc := setupFixedContext()
+	a := New(cc).AddDatum(&datum)
+	if len(a.datums) != 0 {
+		t.Fatalf("expected the datum to be rejected, got %d", len(a.datums))
+	}
+	if _, err := a.Complete(); err == nil {
+		t.Fatal("expected Complete to report the datum error")
+	} else if !strings.Contains(err.Error(), "AddDatum") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestPayToContractWithDatumHashPreservesDatumIdentity requires that Apollo
+// either declares the hash the caller's datum bytes actually have, or refuses
+// the payment. Silently declaring some other hash creates an output at a script
+// address whose datum the counterparty cannot match, locking the funds.
+func TestPayToContractWithDatumHashPreservesDatumIdentity(t *testing.T) {
+	datum := decodeDatum(t, "d8799f5864"+strings.Repeat("ab", 100)+"ff")
+	want := common.Blake2b256Hash(datum.Cbor())
+
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	a, err := New(cc).PayToContractWithDatumHash(addr, &datum, 2_000_000)
+	if err != nil {
+		// Refusing a datum whose bytes cannot be preserved is correct.
+		return
+	}
+	if len(a.payments) != 1 {
+		t.Fatalf("expected 1 payment, got %d", len(a.payments))
+	}
+	txOut, err := a.payments[0].ToTxOut()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := txOut.DatumHash()
+	if got == nil {
+		t.Fatal("output carries no datum hash")
+	}
+	if *got != want {
+		t.Fatalf(
+			"output declares datum hash %x for a datum whose bytes hash to %x",
+			got.Bytes(),
+			want.Bytes(),
+		)
+	}
+}
+
+func TestPayToContractWithDatumHashRejectsNonCanonicalDatum(t *testing.T) {
+	datum := decodeDatum(t, "d8799f5864"+strings.Repeat("ab", 100)+"ff")
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	_, err := New(cc).PayToContractWithDatumHash(addr, &datum, 2_000_000)
+	if err == nil {
+		t.Fatal("expected PayToContractWithDatumHash to reject the datum")
+	}
+	if !strings.Contains(err.Error(), "canonical Plutus form") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDatumWireCborRejectsNil(t *testing.T) {
+	if _, err := DatumWireCbor(nil); err == nil {
+		t.Fatal("expected an error for a nil datum")
+	}
+	if _, err := DatumHash(nil); err == nil {
+		t.Fatal("expected an error for a nil datum")
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 )
 
@@ -490,8 +491,99 @@ func NewVkeyWitnessFromSkey(
 	}
 }
 
+// DatumWireCbor returns the CBOR bytes datum will occupy in the witness set
+// and records them on the datum so that common.Datum.Hash, the witness set,
+// and every hash Apollo derives from the datum all agree.
+//
+// A datum decoded from CBOR keeps its original bytes, and those bytes are what
+// the datum hash on chain was computed over. gouroboros re-encodes datums
+// through plutigo whenever it marshals them, and plutigo emits the canonical
+// Plutus form (minimal integers, definite-length collections, byte strings
+// chunked above 64 bytes), so a datum whose stored CBOR is not already
+// canonical cannot be put back on the wire byte for byte. Hashing the stored
+// bytes anyway would declare a datum hash that no longer matches the datum in
+// the witness set, so the ledger would reject the transaction with
+// NotAllowedSupplementalDatums or MissingRequiredDatums. Apollo reports that
+// up front instead. Callers willing to accept the canonical re-encoding, and
+// the different datum hash that comes with it, can clear the stored bytes with
+// datum.SetCbor(nil); callers that only need an output to carry a datum hash
+// somebody else computed can use PayToContractAsHash, which does not put the
+// datum in the witness set at all.
+func DatumWireCbor(datum *common.Datum) ([]byte, error) {
+	if datum == nil {
+		return nil, errors.New("datum is nil")
+	}
+	encoded, err := cbor.Encode(datum)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode datum: %w", err)
+	}
+	stored := datum.Cbor()
+	if len(stored) == 0 {
+		datum.SetCbor(encoded)
+		return encoded, nil
+	}
+	if !bytes.Equal(stored, encoded) {
+		return nil, fmt.Errorf(
+			"datum CBOR is not in canonical Plutus form and cannot be "+
+				"preserved: its original bytes hash to %s but the witness "+
+				"set would carry bytes hashing to %s; clear the original "+
+				"bytes with SetCbor(nil) to accept the canonical form, or "+
+				"use PayToContractAsHash to reference the original hash "+
+				"without the datum",
+			common.Blake2b256Hash(stored).String(),
+			common.Blake2b256Hash(encoded).String(),
+		)
+	}
+	return stored, nil
+}
+
+// DatumHash returns the blake2b-256 hash of the CBOR bytes datum occupies in
+// the witness set, which is the datum hash the ledger matches an output's
+// datum hash against.
+//
+// Prefer this over common.Datum.Hash: that method hashes the datum's stored
+// CBOR, which is empty for a datum built in Go rather than decoded from CBOR,
+// so it silently returns blake2b-256 of the empty string. DatumHash also
+// records the wire bytes on datum, after which common.Datum.Hash agrees.
+func DatumHash(datum *common.Datum) (common.Blake2b256, error) {
+	datumCbor, err := DatumWireCbor(datum)
+	if err != nil {
+		return common.Blake2b256{}, err
+	}
+	return common.Blake2b256Hash(datumCbor), nil
+}
+
+// WitnessPlutusData builds witness set field 4 (plutus_data) for the given
+// witness datums exactly as it goes on the wire.
+//
+// Conway's CDDL types the field as nonempty_set<plutus_data>, which permits
+// both a tag-258 set and a bare array. Apollo emits the tag-258 form for every
+// set it writes, so the tag is part of the field bytes the ledger hashes.
+// buildWitnessSet and ComputeScriptDataHash both go through this constructor
+// so the script integrity preimage cannot drift from the serialized field.
+func WitnessPlutusData(datums []common.Datum) cbor.SetType[common.Datum] {
+	return cbor.NewSetType(datums, true)
+}
+
+// WitnessRedeemers builds witness set field 5 (redeemers) for the given
+// redeemer map exactly as it goes on the wire. As with WitnessPlutusData, both
+// the witness set and the script integrity preimage are derived from it.
+func WitnessRedeemers(
+	redeemers map[common.RedeemerKey]common.RedeemerValue,
+) conway.ConwayRedeemers {
+	return conway.ConwayRedeemers{Redeemers: redeemers}
+}
+
 // ComputeScriptDataHash computes the script data hash per the ledger rules:
 // blake2b-256(redeemers_cbor || datums_cbor || lang_views_cbor).
+//
+// The ledger recomputes this hash over the original on-wire bytes of witness
+// set fields 5 and 4, so both halves of the preimage are produced by
+// serializing the very field values buildWitnessSet puts in the witness set,
+// rather than by re-deriving equivalent-looking CBOR. Re-deriving is how the
+// tag-258 set prefix on field 4 came to be missing from the preimage while
+// present on the wire, which made the ledger reject every transaction that
+// carried witness datums with ScriptIntegrityHashMismatch.
 //
 // When there are no witness datums, datums_cbor is omitted entirely (Alonzo,
 // Babbage, and Conway). Encoding an empty datum array here produces
@@ -506,21 +598,21 @@ func ComputeScriptDataHash(
 		return nil, nil
 	}
 
-	var redeemerBytes []byte
-	var err error
-	if len(redeemers) > 0 {
-		redeemerBytes, err = cbor.Encode(redeemers)
-	} else {
-		// Empty Conway redeemer map must be 0xa0, not CBOR null.
-		redeemerBytes, err = cbor.Encode(map[common.RedeemerKey]common.RedeemerValue{})
+	// An absent field 5 hashes as the empty Conway redeemer map 0xa0, which is
+	// what a nil map must not encode to (CBOR null).
+	if redeemers == nil {
+		redeemers = map[common.RedeemerKey]common.RedeemerValue{}
 	}
+	redeemerField := WitnessRedeemers(redeemers)
+	redeemerBytes, err := cbor.Encode(&redeemerField)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode redeemers: %w", err)
 	}
 
 	var datumBytes []byte
 	if len(datums) > 0 {
-		datumBytes, err = cbor.Encode(datums)
+		datumField := WitnessPlutusData(datums)
+		datumBytes, err = cbor.Encode(&datumField)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode datums: %w", err)
 		}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"bytes"
 	"math/big"
 	"strings"
 	"testing"
@@ -601,9 +602,19 @@ func TestComputeScriptDataHashIncludesNonEmptyDatums(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	datumBytes, err := cbor.Encode(datums)
+	// The datums half of the preimage is the plutus_data witness field as it is
+	// serialized, tag-258 set prefix included, not a bare CBOR array.
+	datumField := WitnessPlutusData(datums)
+	datumBytes, err := cbor.Encode(&datumField)
 	if err != nil {
 		t.Fatal(err)
+	}
+	bareDatumBytes, err := cbor.Encode(datums)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(datumBytes, bareDatumBytes) {
+		t.Fatal("witness field and bare array encodings are identical")
 	}
 	langViews, err := common.EncodeLangViews(
 		map[uint]struct{}{1: {}},
@@ -615,6 +626,10 @@ func TestComputeScriptDataHashIncludesNonEmptyDatums(t *testing.T) {
 	want := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), datumBytes...), langViews...))
 	if *got != want {
 		t.Fatalf("hash mismatch:\n got %x\nwant %x", got.Bytes(), want.Bytes())
+	}
+	stale := common.Blake2b256Hash(append(append(append([]byte{}, redeemerBytes...), bareDatumBytes...), langViews...))
+	if *got == stale {
+		t.Fatal("preimage still uses the untagged datum array")
 	}
 }
 

--- a/script_data_hash_ledger_test.go
+++ b/script_data_hash_ledger_test.go
@@ -1,0 +1,309 @@
+package apollo
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	plutigoData "github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// stubLedgerState is the slice of common.LedgerState the UTxO rules under test
+// actually touch. The embedded interface is nil, so any rule reaching for
+// something else fails the test loudly instead of silently passing.
+type stubLedgerState struct {
+	common.LedgerState
+	utxos []common.Utxo
+}
+
+func (s *stubLedgerState) UtxoById(
+	id common.TransactionInput,
+) (common.Utxo, error) {
+	for _, utxo := range s.utxos {
+		if utxo.Id.Id() == id.Id() && utxo.Id.Index() == id.Index() {
+			return utxo, nil
+		}
+	}
+	return common.Utxo{}, errors.New("utxo not found")
+}
+
+func scriptDataTestParams() backend.ProtocolParameters {
+	return backend.ProtocolParameters{
+		MinFeeConstant:      155381,
+		MinFeeCoefficient:   44,
+		MaxTxSize:           16384,
+		CoinsPerUtxoByte:    "4310",
+		CollateralPercent:   150,
+		MaxCollateralInputs: 3,
+		MaxValSize:          "5000",
+		PriceMem:            0.0577,
+		PriceStep:           0.0000721,
+		MaxTxExMem:          "14000000",
+		MaxTxExSteps:        "10000000000",
+		KeyDeposits:         "2000000",
+		PoolDeposits:        "500000000",
+		CostModels: map[string][]int64{
+			"PlutusV2": {4, 5, 6},
+		},
+	}
+}
+
+// buildWitnessDatumTx builds a signed transaction that carries a witness
+// (non-inline) datum alongside a Plutus V2 mint script, and returns the
+// transaction as the ledger sees it plus the ledger state resolving its inputs.
+func buildWitnessDatumTx(
+	t *testing.T,
+	datum *common.Datum,
+) (*conway.ConwayTransaction, *stubLedgerState, common.Blake2b256) {
+	t.Helper()
+	gp := backend.GenesisParameters{NetworkMagic: 1}
+	cc := fixed.NewFixedChainContext(scriptDataTestParams(), gp, 0)
+	addr := testAddress(t)
+
+	var spendHash, collateralHash common.Blake2b256
+	spendHash[0] = 0x01
+	collateralHash[0] = 0x02
+	inputUtxo := makeTestUtxo(t, spendHash, 0, 20_000_000)
+	collateralUtxo := makeTestUtxo(t, collateralHash, 0, 5_000_000)
+
+	redeemer := common.Datum{Data: plutigoData.NewInteger(big.NewInt(1))}
+	script := common.PlutusV2Script([]byte{0x01, 0x02})
+	unit := NewUnit(strings.Repeat("ab", 28), "746f6b656e", 1)
+
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddInput(inputUtxo).
+		AddCollateral(collateralUtxo).
+		AttachScript(script).
+		DisableExecutionUnitsEstimation().
+		Mint(unit, &redeemer, &common.ExUnits{Memory: 1, Steps: 1})
+
+	a, err := a.PayToContractWithDatumHash(addr, datum, 2_000_000)
+	if err != nil {
+		t.Fatalf("PayToContractWithDatumHash: %v", err)
+	}
+	if _, err := a.Complete(); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	txCbor, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatalf("GetTxCbor: %v", err)
+	}
+
+	// Decode the serialized transaction so that every ledger check runs
+	// against the on-wire bytes, exactly like a node receiving it.
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(txCbor, &tx); err != nil {
+		t.Fatalf("decode built tx: %v", err)
+	}
+	ls := &stubLedgerState{utxos: []common.Utxo{inputUtxo, collateralUtxo}}
+
+	// The datum hash the transaction declares on its script output.
+	var declared common.Blake2b256
+	var seen int
+	for _, output := range tx.Outputs() {
+		if h := output.DatumHash(); h != nil {
+			declared = *h
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("expected exactly 1 output datum hash, got %d", seen)
+	}
+	return &tx, ls, declared
+}
+
+func ledgerTestPparams() *conway.ConwayProtocolParameters {
+	return &conway.ConwayProtocolParameters{
+		CostModels: map[uint][]int64{1: {4, 5, 6}},
+	}
+}
+
+// TestScriptDataHashAcceptedByLedgerRules is the settling evidence for the
+// script data hash: gouroboros' own Conway UTxO rules recompute the script
+// integrity hash over the transaction's on-wire witness bytes and must accept
+// what Apollo built.
+func TestScriptDataHashAcceptedByLedgerRules(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	tx, ls, _ := buildWitnessDatumTx(t, &datum)
+
+	if len(tx.WitnessSet.WsPlutusData.Items()) != 1 {
+		t.Fatalf(
+			"expected 1 witness datum, got %d",
+			len(tx.WitnessSet.WsPlutusData.Items()),
+		)
+	}
+	onWire := hex.EncodeToString(tx.WitnessSet.WsPlutusData.Cbor())
+	if !strings.HasPrefix(onWire, "d90102") {
+		t.Fatalf("witness plutus_data is not a tag-258 set: %s", onWire)
+	}
+	if onWire != "d90102811863" {
+		t.Fatalf("unexpected on-wire plutus_data bytes: %s", onWire)
+	}
+
+	pp := ledgerTestPparams()
+	if err := conway.UtxoValidateScriptDataHash(tx, 0, ls, pp); err != nil {
+		t.Fatalf("gouroboros ledger rejected script data hash: %v", err)
+	}
+	if err := conway.UtxoValidateSupplementalDatums(tx, 0, ls, pp); err != nil {
+		t.Fatalf("gouroboros ledger rejected witness datum: %v", err)
+	}
+}
+
+// TestScriptDataHashPreimageUsesOnWireWitnessBytes pins the preimage halves to
+// the exact bytes of witness set fields 5 and 4, and shows that the bare-array
+// datum encoding that predates this fix hashes to something else.
+func TestScriptDataHashPreimageUsesOnWireWitnessBytes(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	tx, _, _ := buildWitnessDatumTx(t, &datum)
+
+	declared := tx.Body.TxScriptDataHash
+	if declared == nil {
+		t.Fatal("built transaction has no script data hash")
+	}
+
+	redeemersCbor := tx.WitnessSet.WsRedeemers.Cbor()
+	datumsCbor := tx.WitnessSet.WsPlutusData.Cbor()
+	langViews, err := common.EncodeLangViews(
+		map[uint]struct{}{1: {}},
+		map[uint][]int64{1: {4, 5, 6}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preimage := make(
+		[]byte,
+		0,
+		len(redeemersCbor)+len(datumsCbor)+len(langViews),
+	)
+	preimage = append(preimage, redeemersCbor...)
+	preimage = append(preimage, datumsCbor...)
+	preimage = append(preimage, langViews...)
+	want := common.Blake2b256Hash(preimage)
+	if *declared != want {
+		t.Fatalf(
+			"script data hash does not match on-wire preimage:\n"+
+				" declared %x\n on-wire %x\n datums %x",
+			declared.Bytes(),
+			want.Bytes(),
+			datumsCbor,
+		)
+	}
+
+	// The untagged datum array is what the preimage used to be built from.
+	bare, err := cbor.Encode(tx.WitnessSet.WsPlutusData.Items())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(bare) == hex.EncodeToString(datumsCbor) {
+		t.Fatal("bare array and tag-258 set encodings are identical")
+	}
+	stale := make([]byte, 0, len(redeemersCbor)+len(bare)+len(langViews))
+	stale = append(stale, redeemersCbor...)
+	stale = append(stale, bare...)
+	stale = append(stale, langViews...)
+	if *declared == common.Blake2b256Hash(stale) {
+		t.Fatalf(
+			"script data hash still matches the untagged-datums preimage %x",
+			bare,
+		)
+	}
+}
+
+// TestComputeScriptDataHashDatumsHalfIsTaggedSet asserts the exact preimage
+// bytes ComputeScriptDataHash uses for the datums half.
+func TestComputeScriptDataHashDatumsHalfIsTaggedSet(t *testing.T) {
+	datums := []common.Datum{
+		{Data: plutigoData.NewInteger(big.NewInt(99))},
+	}
+	redeemers := map[common.RedeemerKey]common.RedeemerValue{}
+	got, err := ComputeScriptDataHash(redeemers, datums, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected a script data hash")
+	}
+
+	set := WitnessPlutusData(datums)
+	datumsCbor, err := cbor.Encode(&set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(datumsCbor) != "d90102811863" {
+		t.Fatalf(
+			"unexpected witness plutus_data bytes: %x",
+			datumsCbor,
+		)
+	}
+	emptyCostModels, err := cbor.Encode(map[uint][]int64{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	preimage := append([]byte{0xa0}, datumsCbor...)
+	preimage = append(preimage, emptyCostModels...)
+	want := common.Blake2b256Hash(preimage)
+	if *got != want {
+		t.Fatalf(
+			"ComputeScriptDataHash = %x, want %x",
+			got.Bytes(),
+			want.Bytes(),
+		)
+	}
+
+	bare, err := cbor.Encode(datums)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stalePreimage := append([]byte{0xa0}, bare...)
+	stalePreimage = append(stalePreimage, emptyCostModels...)
+	if *got == common.Blake2b256Hash(stalePreimage) {
+		t.Fatal("preimage still uses the untagged datum array")
+	}
+}
+
+// TestPayToContractWithDatumHashMatchesWitnessDatum checks the output's datum
+// hash against the hash the ledger derives from the datum's on-wire bytes.
+func TestPayToContractWithDatumHashMatchesWitnessDatum(t *testing.T) {
+	datum := common.Datum{Data: plutigoData.NewInteger(big.NewInt(99))}
+	tx, ls, declared := buildWitnessDatumTx(t, &datum)
+
+	witnessDatums := tx.WitnessSet.WsPlutusData.Items()
+	if len(witnessDatums) != 1 {
+		t.Fatalf("expected 1 witness datum, got %d", len(witnessDatums))
+	}
+	onWireHash := witnessDatums[0].Hash()
+	if declared != onWireHash {
+		t.Fatalf(
+			"output datum hash %x does not match on-wire witness datum hash %x",
+			declared.Bytes(),
+			onWireHash.Bytes(),
+		)
+	}
+
+	var found bool
+	for _, output := range tx.Outputs() {
+		if h := output.DatumHash(); h != nil && *h == declared {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no output carries datum hash %x", declared.Bytes())
+	}
+	if err := conway.UtxoValidateSupplementalDatums(
+		tx,
+		0,
+		ls,
+		ledgerTestPparams(),
+	); err != nil {
+		t.Fatalf("gouroboros ledger rejected witness datum: %v", err)
+	}
+}


### PR DESCRIPTION
Two defects with the same root cause: hashing bytes that are re-derived instead of the bytes that go on the wire. Both silently lock or reject real funds.

**1. Script data hash omitted the tag-258 set prefix Apollo itself writes.** `ComputeScriptDataHash` built its preimage with `cbor.Encode(datums)` — a bare array — while `buildWitnessSet` serialized field 4 (`plutus_data`) as a tag-258 set. The ledger recomputes the integrity hash over the original on-wire bytes, so **every transaction with witness (non-inline) datums plus a script was rejected**. Apollo's own dependency rejected Apollo's transaction:

```
gouroboros ledger rejected script data hash: mismatch:
  declared 307f697a9a17c2808c23539b60258096eb216f7edc6847c4a06941f8df6eee96
  computed da51a8e31dd69a5239e3c52e7754c75533f4486a3fd90efdc7057fcdfc73d803
```

Both preimage halves now marshal through shared constructors (`WitnessPlutusData`, `WitnessRedeemers`) that `buildWitnessSet` also uses, so wire and preimage cannot drift again.

The tag is kept rather than dropped. Per the CDDL shipped in the dependency, `nonempty_set<a0> = #6.258([+ a0]) / [+ a0]` — both forms are valid in Conway *and* Dijkstra, so validity does not decide it. Apollo already tags every other set, and gouroboros only enforces duplicate-checking on tagged fields, so dropping it would be valid but semantically weaker.

**2. Datum hashes were computed over re-encoded CBOR.** `common.Datum` stores its original bytes and `Datum.Hash()` uses them, but the builder re-encoded, and plutigo normalizes on re-encode. A datum sourced from chain hashed differently, so an output could be created at a script address under a hash the dApp's off-chain code would not recognize.

This is limited by an upstream defect: `common.Datum.MarshalCBOR` returns `data.Encode(d.Data)` and ignores stored CBOR, so non-canonical original bytes **cannot reach the wire** — filed as [gouroboros#1929](https://github.com/blinklabs-io/gouroboros/issues/1929). Hashing the stored bytes while the wire carries the re-encoding would just trade `MissingRequiredDatums` for `NotAllowedSupplementalDatums`. So `DatumWireCbor` hashes the bytes that will actually be marshaled, and **errors naming both hashes** when a datum's stored bytes are non-canonical rather than signing something nobody can match. Escape hatches are named in the error text. If the upstream issue lands, this code follows the wire automatically.

Verification runs a real serialized Apollo transaction through `conway.UtxoValidateScriptDataHash` **and** `conway.UtxoValidateSupplementalDatums` — gouroboros' own ledger rules — which reject `master` and accept this branch.

Note: the pre-existing `TestComputeScriptDataHashIncludesNonEmptyDatums` recomputed its expectation with the same `cbor.Encode(datums)` call the buggy code used, so it was tautological and could never have caught this. It is updated with a guard against re-pinning the bare array.

Verified: new tests fail on `master` and pass here; `go test -race -count=1 ./...` green; `golangci-lint run` 0 issues; `gofmt` clean.
