### PR TITLE
fix: harden Apollo for 2.0 production release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ sample.txt
 /bin
 coverage.out
 coverage.html
+/.worktrees/
+/.claude/
+/.codex
+/.agents/
+/tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,17 @@ golangci-lint run
 
 **ChainContext** (`backend/base.go`):
 
-- `ProtocolParams()` - protocol parameters
-- `Utxos(address)` - query UTxOs
+- `ProtocolParams()` / `GenesisParams()` - protocol and genesis parameters
+- `NetworkId()` / `CurrentEpoch()` / `Tip()` - network and chain position
+- `MaxTxFee()` - maximum fee derived from protocol parameters
+- `Utxos(address)` / `UtxoByRef(txHash, index)` - query UTxOs
 - `SubmitTx(txCbor)` - submit a transaction
-- `EvaluateTx(txCbor)` - evaluate Plutus scripts
+- `EvaluateTx(txCbor, additionalUtxos)` - evaluate Plutus scripts
+- `ScriptCbor(scriptHash)` - resolve reference-script bytes
+
+Backends may implement `CapabilityReporter`; callers must check
+`CapabilityEvaluateTxAdditionalUtxos` before relying on evaluator-supplied
+UTxOs. `backend/cache` provides the cache wrapper.
 
 **Wallet** (`wallet.go`):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Hardened protocol-parameter parsing, governance redeemer tags, execution
+  budget checks, UTxO RPC pagination, and completed-transaction size checks.
+- Added safer handling for nil payments, zero-value builder state, and invalid
+  pool-registration margins.
+- Corrected the default Plutus container encoding and made examples executable.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Salvionied

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Salvionied
+* @MIxAxIM @wolf31o2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MIxAxIM @wolf31o2
+* @Salvionied @MIxAxIM @wolf31o2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Use Go 1.25.12 or newer. Before opening a pull request, run:
+
+```bash
+gofmt -w $(find . -name '*.go' -not -path './.worktrees/*')
+go test -race ./...
+```
+
+Keep transaction and CBOR changes covered by deterministic tests. Backend
+changes should include provider-response fixtures and should return errors
+instead of panicking or silently accepting malformed data.

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ format:
 golines:
 	golines -w --ignore-generated --chain-split-dots --max-len=80 --reformat-tags .
 
-test: mod-tidy
+test:
 	go test -v -race ./...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security policy
+
+Please do not report vulnerabilities in key derivation, transaction signing,
+address handling, or backend authentication in public issues.
+
+Until a dedicated private disclosure address is published, contact the
+maintainers privately through the repository owner or security contact listed
+on the project page. Include a reproducible test case, affected version, and
+the minimum conditions required to trigger the issue.
+
+Please allow maintainers reasonable time to investigate and prepare a fix
+before public disclosure.

--- a/apollo.go
+++ b/apollo.go
@@ -127,6 +127,24 @@ func New(cc backend.ChainContext) *Apollo {
 	return a
 }
 
+func (a *Apollo) initState() {
+	if a.requestContext == nil {
+		a.requestContext = context.Background()
+	}
+	if a.redeemers == nil {
+		a.redeemers = make(map[string]redeemerEntry)
+	}
+	if a.stakeRedeemers == nil {
+		a.stakeRedeemers = make(map[string]redeemerEntry)
+	}
+	if a.mintRedeemers == nil {
+		a.mintRedeemers = make(map[string]redeemerEntry)
+	}
+	if a.withdrawals == nil {
+		a.withdrawals = make(map[string]withdrawalEntry)
+	}
+}
+
 // WithContext sets the context used by subsequent chain-context operations.
 // A nil context is treated as context.Background. The context is retained by
 // the builder, so callers should not use a short-lived context for operations
@@ -177,6 +195,11 @@ func (a *Apollo) SetWalletFromMnemonicWithPassphrase(mnemonic string, passphrase
 
 // AddPayment adds a payment to the transaction.
 func (a *Apollo) AddPayment(payment PaymentI) *Apollo {
+	a.initState()
+	if isNilPayment(payment) {
+		a.setErrOnce(errors.New("payment must not be nil"))
+		return a
+	}
 	a.payments = append(a.payments, payment)
 	return a
 }
@@ -358,6 +381,7 @@ func (a *Apollo) AddReferenceInput(txHash string, index int) (*Apollo, error) {
 // Mint adds tokens to mint. If redeemer is provided, sets up script minting.
 // When exUnits is nil, execution units will be estimated automatically.
 func (a *Apollo) Mint(unit Unit, redeemer *common.Datum, exUnits *common.ExUnits) *Apollo {
+	a.initState()
 	// Redeemer indexes bind to mint policies in byte-wise sorted order; mixed-case
 	// hex would sort differently as a string than as bytes, misbinding redeemers.
 	unit.PolicyId = strings.ToLower(unit.PolicyId)
@@ -427,6 +451,7 @@ func (a *Apollo) DisableExecutionUnitsEstimation() *Apollo {
 
 // CollectFrom adds a script UTxO as input with a spending redeemer.
 func (a *Apollo) CollectFrom(utxo common.Utxo, redeemer common.Datum, exUnits common.ExUnits) *Apollo {
+	a.initState()
 	if err := validateUtxo(utxo); err != nil {
 		a.setErrOnce(fmt.Errorf("script input UTxO is invalid: %w", err))
 		return a
@@ -779,6 +804,9 @@ func (a *Apollo) RegisterAndDelegateStakeAndVote(credOrAddr any, poolHash common
 
 // RegisterPool adds a pool registration certificate.
 func (a *Apollo) RegisterPool(params common.PoolRegistrationCertificate) *Apollo {
+	if params.Margin.Rat == nil || params.Margin.Denom().Sign() == 0 {
+		a.setErrOnce(errors.New("RegisterPool: margin must not be nil or have a zero denominator"))
+	}
 	params.CertType = uint(common.CertificateTypePoolRegistration)
 	a.certificates = append(a.certificates, common.CertificateWrapper{
 		Type:        uint(common.CertificateTypePoolRegistration),
@@ -885,6 +913,7 @@ func (a *Apollo) DeregisterPool(poolHash common.Blake2b224, epoch uint64) *Apoll
 // AddWithdrawal adds a staking reward withdrawal to the transaction.
 // For script-based withdrawals, provide a redeemer and execution units.
 func (a *Apollo) AddWithdrawal(address common.Address, amount uint64, redeemerData *common.Datum, exUnits *common.ExUnits) *Apollo {
+	a.initState()
 	rewardAddress, err := withdrawalRewardAddress(address)
 	if err != nil {
 		a.setErrOnce(err)
@@ -1302,6 +1331,19 @@ func isNilChainContext(ctx backend.ChainContext) bool {
 	}
 }
 
+func isNilPayment(payment PaymentI) bool {
+	if payment == nil {
+		return true
+	}
+	value := reflect.ValueOf(payment)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
 func cloneCBORValue(src, dst any) error {
 	encoded, err := cbor.Encode(src)
 	if err != nil {
@@ -1478,6 +1520,7 @@ func (a *Apollo) GetWallet() Wallet {
 
 // Complete performs coin selection, fee estimation, and builds the transaction.
 func (a *Apollo) Complete() (*Apollo, error) {
+	a.initState()
 	if a.err != nil {
 		return a, a.err
 	}
@@ -1522,6 +1565,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 	// the backend when certificates are present, and fail closed on errors:
 	// a silently wrong deposit produces a value-non-conserving transaction.
 	stakeDeposit := int64(StakeDeposit)
+	poolDeposit := int64(0)
 	if len(a.certificates) > 0 {
 		pp, ppErr := backend.ProtocolParamsContext(a.requestContext, a.Context)
 		if ppErr != nil {
@@ -1532,8 +1576,12 @@ func (a *Apollo) Complete() (*Apollo, error) {
 			return a, fmt.Errorf("invalid key_deposit protocol parameter %q", pp.KeyDeposits)
 		}
 		stakeDeposit = d
+		poolDeposit, dErr = strconv.ParseInt(pp.PoolDeposits, 10, 64)
+		if dErr != nil || poolDeposit < 0 {
+			return a, fmt.Errorf("invalid pool_deposit protocol parameter %q", pp.PoolDeposits)
+		}
 	}
-	totalRequired, err = a.adjustForCertificateDeposits(totalRequired, stakeDeposit)
+	totalRequired, err = a.adjustForCertificateDeposits(totalRequired, stakeDeposit, poolDeposit)
 	if err != nil {
 		return a, fmt.Errorf("certificate deposit overflow: %w", err)
 	}
@@ -1579,7 +1627,7 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		}
 	}
 	// Certificate deregistration refunds are implicit inputs
-	refundValue := a.certificateRefundValue(stakeDeposit)
+	refundValue := a.certificateRefundValue(stakeDeposit, poolDeposit)
 	if refundValue.Coin > 0 {
 		totalInput, err = totalInput.Add(refundValue)
 		if err != nil {
@@ -1884,6 +1932,19 @@ func (a *Apollo) Complete() (*Apollo, error) {
 		}
 		if md != nil {
 			a.tx.TxMetadata = md
+		}
+	}
+	pp, ppErr := backend.ProtocolParamsContext(a.requestContext, a.Context)
+	if ppErr != nil {
+		return a, fmt.Errorf("failed to get protocol params for transaction size validation: %w", ppErr)
+	}
+	if pp.MaxTxSize > 0 {
+		txBytes, encErr := cbor.Encode(a.tx)
+		if encErr != nil {
+			return a, fmt.Errorf("failed to encode completed transaction: %w", encErr)
+		}
+		if len(txBytes) > pp.MaxTxSize {
+			return a, fmt.Errorf("transaction size %d exceeds max_tx_size %d", len(txBytes), pp.MaxTxSize)
 		}
 	}
 
@@ -2452,6 +2513,16 @@ func (a *Apollo) estimateExecutionUnits(
 		bufferedUnits := common.ExUnits{
 			Memory: bufferExUnits(evalUnits.Memory, 1+ExMemoryBuffer),
 			Steps:  bufferExUnits(evalUnits.Steps, 1+ExStepBuffer),
+		}
+		if pp, ppErr := backend.ProtocolParamsContext(a.requestContext, a.Context); ppErr == nil {
+			maxMem, memErr := strconv.ParseInt(pp.MaxTxExMem, 10, 64)
+			maxSteps, stepsErr := strconv.ParseInt(pp.MaxTxExSteps, 10, 64)
+			if memErr == nil && maxMem > 0 && bufferedUnits.Memory > maxMem {
+				return nil, fmt.Errorf("buffered execution memory %d exceeds max_tx_ex_mem %d", bufferedUnits.Memory, maxMem)
+			}
+			if stepsErr == nil && maxSteps > 0 && bufferedUnits.Steps > maxSteps {
+				return nil, fmt.Errorf("buffered execution steps %d exceeds max_tx_ex_steps %d", bufferedUnits.Steps, maxSteps)
+			}
 		}
 		switch evalKey.Tag {
 		case common.RedeemerTagSpend:
@@ -3496,8 +3567,8 @@ func (a *Apollo) validateCollateral() error {
 }
 
 // adjustForCertificateDeposits adjusts the total required value for certificate deposits.
-func (a *Apollo) adjustForCertificateDeposits(required Value, depositPerCert int64) (Value, error) {
-	adj := a.certificateDepositAdjustment(depositPerCert)
+func (a *Apollo) adjustForCertificateDeposits(required Value, stakeDeposit, poolDeposit int64) (Value, error) {
+	adj := a.certificateDepositAdjustment(stakeDeposit, poolDeposit)
 	if adj > 0 {
 		deposit := NewSimpleValue(uint64(adj))
 		return required.Add(deposit)
@@ -3507,8 +3578,8 @@ func (a *Apollo) adjustForCertificateDeposits(required Value, depositPerCert int
 
 // certificateRefundValue returns the total deposit refund from deregistration certificates.
 // These refunds are implicit inputs in Cardano's balance equation.
-func (a *Apollo) certificateRefundValue(depositPerCert int64) Value {
-	adj := a.certificateDepositAdjustment(depositPerCert)
+func (a *Apollo) certificateRefundValue(stakeDeposit, poolDeposit int64) Value {
+	adj := a.certificateDepositAdjustment(stakeDeposit, poolDeposit)
 	if adj < 0 {
 		return NewSimpleValue(uint64(-adj))
 	}
@@ -3517,19 +3588,40 @@ func (a *Apollo) certificateRefundValue(depositPerCert int64) Value {
 
 // certificateDepositAdjustment calculates the net deposit change from certificates.
 // Positive means deposits needed, negative means refunds.
-func (a *Apollo) certificateDepositAdjustment(depositPerCert int64) int64 {
+func (a *Apollo) certificateDepositAdjustment(stakeDeposit int64, poolDeposits ...int64) int64 {
+	poolDeposit := int64(0)
+	if len(poolDeposits) > 0 {
+		poolDeposit = poolDeposits[0]
+	}
 	var adjustment int64
 	for _, cert := range a.certificates {
 		switch cert.Type {
-		case uint(common.CertificateTypeStakeRegistration),
-			uint(common.CertificateTypeRegistration),
-			uint(common.CertificateTypeStakeRegistrationDelegation),
+		case uint(common.CertificateTypeStakeRegistration):
+			adjustment += stakeDeposit
+		case uint(common.CertificateTypePoolRegistration):
+			adjustment += poolDeposit
+		case uint(common.CertificateTypeStakeDeregistration):
+			adjustment -= stakeDeposit
+		case uint(common.CertificateTypeDeregistration):
+			if c, ok := cert.Certificate.(*common.DeregistrationCertificate); ok {
+				adjustment -= c.Amount
+			}
+		case uint(common.CertificateTypeRegistration):
+			if c, ok := cert.Certificate.(*common.RegistrationCertificate); ok {
+				adjustment += c.Amount
+			}
+		case uint(common.CertificateTypeStakeRegistrationDelegation),
 			uint(common.CertificateTypeVoteRegistrationDelegation),
 			uint(common.CertificateTypeStakeVoteRegistrationDelegation):
-			adjustment += depositPerCert
-		case uint(common.CertificateTypeStakeDeregistration),
-			uint(common.CertificateTypeDeregistration):
-			adjustment -= depositPerCert
+			// These certificates carry their explicit deposit in Amount.
+			switch c := cert.Certificate.(type) {
+			case *common.StakeRegistrationDelegationCertificate:
+				adjustment += c.Amount
+			case *common.VoteRegistrationDelegationCertificate:
+				adjustment += c.Amount
+			case *common.StakeVoteRegistrationDelegationCertificate:
+				adjustment += c.Amount
+			}
 		case uint(common.CertificateTypeRegistrationDrep):
 			if c, ok := cert.Certificate.(*common.RegistrationDrepCertificate); ok {
 				adjustment += c.Amount

--- a/apollo.go
+++ b/apollo.go
@@ -806,6 +806,7 @@ func (a *Apollo) RegisterAndDelegateStakeAndVote(credOrAddr any, poolHash common
 func (a *Apollo) RegisterPool(params common.PoolRegistrationCertificate) *Apollo {
 	if params.Margin.Rat == nil || params.Margin.Denom().Sign() == 0 {
 		a.setErrOnce(errors.New("RegisterPool: margin must not be nil or have a zero denominator"))
+		return a
 	}
 	params.CertType = uint(common.CertificateTypePoolRegistration)
 	a.certificates = append(a.certificates, common.CertificateWrapper{
@@ -2509,20 +2510,22 @@ func (a *Apollo) estimateExecutionUnits(
 	seenSpend := make(map[string]bool, len(a.redeemers))
 	seenMint := make(map[string]bool, len(a.mintRedeemers))
 	seenStake := make(map[string]bool, len(a.stakeRedeemers))
+	pp, ppErr := backend.ProtocolParamsContext(a.requestContext, a.Context)
+	if ppErr != nil {
+		return nil, fmt.Errorf("failed to get protocol params for execution-unit validation: %w", ppErr)
+	}
+	maxMem, memErr := strconv.ParseInt(pp.MaxTxExMem, 10, 64)
+	maxSteps, stepsErr := strconv.ParseInt(pp.MaxTxExSteps, 10, 64)
 	for evalKey, evalUnits := range evalResult {
 		bufferedUnits := common.ExUnits{
 			Memory: bufferExUnits(evalUnits.Memory, 1+ExMemoryBuffer),
 			Steps:  bufferExUnits(evalUnits.Steps, 1+ExStepBuffer),
 		}
-		if pp, ppErr := backend.ProtocolParamsContext(a.requestContext, a.Context); ppErr == nil {
-			maxMem, memErr := strconv.ParseInt(pp.MaxTxExMem, 10, 64)
-			maxSteps, stepsErr := strconv.ParseInt(pp.MaxTxExSteps, 10, 64)
-			if memErr == nil && maxMem > 0 && bufferedUnits.Memory > maxMem {
-				return nil, fmt.Errorf("buffered execution memory %d exceeds max_tx_ex_mem %d", bufferedUnits.Memory, maxMem)
-			}
-			if stepsErr == nil && maxSteps > 0 && bufferedUnits.Steps > maxSteps {
-				return nil, fmt.Errorf("buffered execution steps %d exceeds max_tx_ex_steps %d", bufferedUnits.Steps, maxSteps)
-			}
+		if memErr == nil && maxMem > 0 && bufferedUnits.Memory > maxMem {
+			return nil, fmt.Errorf("buffered execution memory %d exceeds max_tx_ex_mem %d", bufferedUnits.Memory, maxMem)
+		}
+		if stepsErr == nil && maxSteps > 0 && bufferedUnits.Steps > maxSteps {
+			return nil, fmt.Errorf("buffered execution steps %d exceeds max_tx_ex_steps %d", bufferedUnits.Steps, maxSteps)
 		}
 		switch evalKey.Tag {
 		case common.RedeemerTagSpend:

--- a/backend/base.go
+++ b/backend/base.go
@@ -376,7 +376,15 @@ func TierRefScriptFeeRational(totalRefScriptSize int, baseFeePerByte *big.Rat, s
 	}
 	// floor(acc): acc is non-negative, so integer division of num/denom truncates
 	// toward zero, i.e. floors.
-	return new(big.Int).Quo(acc.Num(), acc.Denom()).Int64()
+	result := new(big.Int).Quo(acc.Num(), acc.Denom())
+	if !result.IsInt64() {
+		// A negative fee would be catastrophic: callers could treat it as a
+		// credit and construct an underpriced transaction. The public helper
+		// predates error returns, so saturate at MaxInt64 and let fee validation
+		// reject the impossible result upstream.
+		return math.MaxInt64
+	}
+	return result.Int64()
 }
 
 func rationalFromFloat64(value float64) *big.Rat {

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -913,10 +913,10 @@ type bfProtocolParams struct {
 	MinPoolCost        string          `json:"min_pool_cost"`
 	PriceMem           float64         `json:"price_mem"`
 	PriceStep          float64         `json:"price_step"`
-	MaxTxExMem         string          `json:"max_tx_execution_units_memory"`
-	MaxTxExSteps       string          `json:"max_tx_execution_units_steps"`
-	MaxBlockExMem      string          `json:"max_block_execution_units_memory"`
-	MaxBlockExSteps    string          `json:"max_block_execution_units_steps"`
+	MaxTxExMem         string          `json:"max_tx_ex_mem"`
+	MaxTxExSteps       string          `json:"max_tx_ex_steps"`
+	MaxBlockExMem      string          `json:"max_block_ex_mem"`
+	MaxBlockExSteps    string          `json:"max_block_ex_steps"`
 	MaxValSize         string          `json:"max_val_size"`
 	CollateralPercent  int64           `json:"collateral_percent"`
 	MaxCollateralIn    int64           `json:"max_collateral_inputs"`

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -357,7 +357,7 @@ func (u *UtxoRpcChainContext) UtxosContext(ctx context.Context, address common.A
 		req.Msg.StartToken = next
 		resp, err = u.client.SearchUtxosWithContext(ctx, req)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to fetch UTxO RPC page after token %q: %w", next, err)
 		}
 	}
 	return nil, fmt.Errorf("UTxO RPC pagination exceeded %d pages", maxPages)

--- a/backend/utxorpc/utxorpc.go
+++ b/backend/utxorpc/utxorpc.go
@@ -336,14 +336,31 @@ func (u *UtxoRpcChainContext) UtxosContext(ctx context.Context, address common.A
 	}
 
 	var utxos []common.Utxo
-	for _, item := range resp.Msg.GetItems() {
-		utxo, err := utxoFromRpc(item)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse UTxO from RPC: %w", err)
+	seenTokens := make(map[string]struct{})
+	const maxPages = 10_000
+	for page := 0; page < maxPages; page++ {
+		for _, item := range resp.Msg.GetItems() {
+			utxo, err := utxoFromRpc(item)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse UTxO from RPC: %w", err)
+			}
+			utxos = append(utxos, utxo)
 		}
-		utxos = append(utxos, utxo)
+		next := resp.Msg.GetNextToken()
+		if next == "" {
+			return utxos, nil
+		}
+		if _, seen := seenTokens[next]; seen {
+			return nil, fmt.Errorf("UTxO RPC pagination repeated token %q", next)
+		}
+		seenTokens[next] = struct{}{}
+		req.Msg.StartToken = next
+		resp, err = u.client.SearchUtxosWithContext(ctx, req)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return utxos, nil
+	return nil, fmt.Errorf("UTxO RPC pagination exceeded %d pages", maxPages)
 }
 
 func (u *UtxoRpcChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package apollo_test
 
 import (
+	"fmt"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 
 	apollo "github.com/Salvionied/apollo/v2"
@@ -25,6 +26,8 @@ func Example() {
 		PayToAddress(address, 2_000_000)
 
 	_ = builder
+	fmt.Println(builder != nil)
+	// Output: true
 }
 
 // ExampleNewScriptRef verifies the error-returning reference-script API from an
@@ -37,4 +40,6 @@ func ExampleNewScriptRef() {
 	}
 
 	_ = scriptRef
+	fmt.Println(scriptRef != nil)
+	// Output: true
 }

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package apollo_test
 
 import (
 	"fmt"
+
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 
 	apollo "github.com/Salvionied/apollo/v2"

--- a/internal/backendutil/backendutil.go
+++ b/internal/backendutil/backendutil.go
@@ -84,6 +84,12 @@ func ParseRedeemerTag(s string) (common.RedeemerTag, error) {
 		return common.RedeemerTagCert, nil
 	case "reward", "withdraw":
 		return common.RedeemerTagReward, nil
+	case "vote", "voting":
+		return common.RedeemerTagVoting, nil
+	case "propose", "proposing":
+		return common.RedeemerTagProposing, nil
+	case "guard", "guarding":
+		return common.RedeemerTagGuarding, nil
 	default:
 		return 0, fmt.Errorf("unsupported redeemer tag %q", s)
 	}

--- a/internal/backendutil/backendutil_test.go
+++ b/internal/backendutil/backendutil_test.go
@@ -18,6 +18,22 @@ func TestParseFractionValid(t *testing.T) {
 	}
 }
 
+func TestParseRedeemerTagConwayPurposes(t *testing.T) {
+	tests := map[string]common.RedeemerTag{
+		"vote": common.RedeemerTagVoting, "voting": common.RedeemerTagVoting,
+		"propose": common.RedeemerTagProposing, "proposing": common.RedeemerTagProposing,
+		"guard": common.RedeemerTagGuarding, "guarding": common.RedeemerTagGuarding,
+	}
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			got, err := ParseRedeemerTag(input)
+			if err != nil || got != want {
+				t.Fatalf("ParseRedeemerTag(%q) = %v, %v; want %v, nil", input, got, err, want)
+			}
+		})
+	}
+}
+
 func TestParseFractionPlainNumber(t *testing.T) {
 	val, err := ParseFraction("0.0577")
 	if err != nil {

--- a/plutusencoder/plutus.go
+++ b/plutusencoder/plutus.go
@@ -73,8 +73,9 @@ func marshalValue(val reflect.Value) (data.PlutusData, error) {
 	case "Map":
 		return marshalMap(val, typ, constrTag, hasConstr)
 	default:
-		// IndefList, DefList, or no tag (default to DefList)
-		useIndef := containerType == "IndefList"
+		// IndefList, DefList, or no tag. The reference Plutus encoder uses
+		// indefinite-length lists for the unannotated container form.
+		useIndef := containerType != "DefList"
 		return marshalList(val, typ, constrTag, hasConstr, useIndef)
 	}
 }

--- a/staking_test.go
+++ b/staking_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -322,6 +323,7 @@ func TestRegisterPool(t *testing.T) {
 		Operator: operator,
 		Pledge:   1000000,
 		Cost:     340000000,
+		Margin:   common.GenesisRat{Rat: big.NewRat(1, 2)},
 	}
 
 	a.RegisterPool(params)

--- a/staking_test.go
+++ b/staking_test.go
@@ -406,6 +406,17 @@ func TestCertificateDepositAdjustmentDeregOnly(t *testing.T) {
 	}
 }
 
+func TestCertificateDepositAdjustmentUsesPoolAndExplicitAmounts(t *testing.T) {
+	a := New(setupFixedContext())
+	a.certificates = []common.CertificateWrapper{
+		{Type: uint(common.CertificateTypePoolRegistration), Certificate: &common.PoolRegistrationCertificate{}},
+		{Type: uint(common.CertificateTypeRegistration), Certificate: &common.RegistrationCertificate{Amount: 1234567}},
+	}
+	if got, want := a.certificateDepositAdjustment(2_000_000, 500_000_000), int64(501_234_567); got != want {
+		t.Fatalf("certificate deposit adjustment = %d, want %d", got, want)
+	}
+}
+
 func TestGetStakeCredentialFromAddress(t *testing.T) {
 	addr := testAddress(t)
 	cred, err := GetStakeCredentialFromAddress(addr)


### PR DESCRIPTION
## Summary

Hardens transaction construction and backend boundaries for the Apollo 2.0 production release.

## Included

- Conway governance redeemer purpose parsing
- Blockfrost execution-unit parameter parsing
- Plutus default indefinite-list encoding
- Reference-script fee overflow protection
- Buffered execution-unit limit enforcement
- Pool and explicit certificate deposit accounting
- UTxO RPC pagination and loop detection
- Final max_tx_size enforcement
- Nil-payment, zero-value builder, and invalid pool-margin safeguards
- Executable examples and release hygiene documentation
- make test no longer rewrites module files

## Verification

- gofmt and git diff --check
- go test -race . ./backend ./backend/utxorpc ./internal/backendutil ./plutusencoder

Existing provider tests requiring IPv6 listeners were unavailable in the execution environment.