### PR TITLE
test: verify signatures and native script encodings

### DIFF
--- a/native_script_cbor_test.go
+++ b/native_script_cbor_test.go
@@ -1,0 +1,258 @@
+package apollo
+
+import (
+	"bytes"
+	"encoding/hex"
+	"slices"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// The Conway native-script CDDL is:
+//
+//	native_script =
+//	  [ script_pubkey      = (0, addr_keyhash)
+//	  // script_all         = (1, [* native_script])
+//	  // script_any         = (2, [* native_script])
+//	  // script_n_of_k      = (3, int64, [* native_script])
+//	  // invalid_before     = (4, slot_no)
+//	  // invalid_hereafter  = (5, slot_no)
+//	  ]
+//
+// Every expectation below is built from that grammar with the CBOR header bytes
+// spelled out, never from Apollo's own output: a constructor emitting the wrong
+// leading type tag is a silent authorization change (All becoming Any drops a
+// multisig to a single signer) and must not be able to define its own oracle.
+
+// nativeScriptKeyHash returns a 28-byte addr_keyhash of a repeated byte.
+func nativeScriptKeyHash(fill byte) common.Blake2b224 {
+	var hash common.Blake2b224
+	copy(hash[:], bytes.Repeat([]byte{fill}, len(hash)))
+	return hash
+}
+
+// cddlPubkey encodes (0, addr_keyhash): array(2), uint(0), bstr(28).
+func cddlPubkey(keyHash common.Blake2b224) []byte {
+	return slices.Concat([]byte{0x82, 0x00, 0x58, 0x1c}, keyHash.Bytes())
+}
+
+// cddlScriptList encodes (tag, [* native_script]) over two sub-scripts, for
+// tag 1 (all) and 2 (any): array(2), uint(tag), array(2), scripts...
+func cddlScriptList(tag byte, first, second []byte) []byte {
+	return slices.Concat([]byte{0x82, tag, 0x82}, first, second)
+}
+
+// cddlNofK encodes (3, int64, [* native_script]) over two sub-scripts:
+// array(3), uint(3), uint(n), array(2), scripts...
+func cddlNofK(n byte, first, second []byte) []byte {
+	return slices.Concat([]byte{0x83, 0x03, n, 0x82}, first, second)
+}
+
+// nativeScriptCbor encodes a script the way Apollo's callers serialize it.
+func nativeScriptCbor(t *testing.T, ns common.NativeScript) []byte {
+	t.Helper()
+	scriptCbor, err := cbor.Encode(&ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scriptCbor
+}
+
+// nativeScriptTypeTag reads the leading integer of a native script. Native
+// scripts are [type, ...] arrays, so this is the authorization semantics of the
+// script, decoded without reference to any Apollo type.
+func nativeScriptTypeTag(t *testing.T, scriptCbor []byte) uint64 {
+	t.Helper()
+	var elements []cbor.RawMessage
+	if _, err := cbor.Decode(scriptCbor, &elements); err != nil {
+		t.Fatalf("native script is not a CBOR array: %v", err)
+	}
+	if len(elements) < 2 {
+		t.Fatalf("native script has %d elements, want at least 2",
+			len(elements))
+	}
+	var tag uint64
+	if _, err := cbor.Decode(elements[0], &tag); err != nil {
+		t.Fatalf("native script type tag is not an integer: %v", err)
+	}
+	return tag
+}
+
+// cddlScriptHash derives the script hash of the expected bytes: native script
+// hashes are blake2b-224 over a 0x00 language tag followed by the script CBOR.
+func cddlScriptHash(scriptCbor []byte) common.ScriptHash {
+	return common.ScriptHash(
+		common.Blake2b224Hash(slices.Concat([]byte{0x00}, scriptCbor)),
+	)
+}
+
+func TestNativeScriptConstructorsMatchCddl(t *testing.T) {
+	keyHashA := nativeScriptKeyHash(0xaa)
+	keyHashB := nativeScriptKeyHash(0xbb)
+	pubkeyA := cddlPubkey(keyHashA)
+	pubkeyB := cddlPubkey(keyHashB)
+
+	scriptA, err := NewNativeScriptPubkey(keyHashA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptB, err := NewNativeScriptPubkey(keyHashB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	members := []common.NativeScript{scriptA, scriptB}
+
+	tests := []struct {
+		name    string
+		build   func() (common.NativeScript, error)
+		wantTag uint64
+		want    []byte
+	}{
+		{
+			name:    "pubkey",
+			build:   func() (common.NativeScript, error) { return scriptA, nil },
+			wantTag: 0,
+			want:    pubkeyA,
+		},
+		{
+			name: "all",
+			build: func() (common.NativeScript, error) {
+				return NewNativeScriptAll(members)
+			},
+			wantTag: 1,
+			want:    cddlScriptList(0x01, pubkeyA, pubkeyB),
+		},
+		{
+			name: "any",
+			build: func() (common.NativeScript, error) {
+				return NewNativeScriptAny(members)
+			},
+			wantTag: 2,
+			want:    cddlScriptList(0x02, pubkeyA, pubkeyB),
+		},
+		{
+			name: "nofk",
+			build: func() (common.NativeScript, error) {
+				return NewNativeScriptNofK(2, members)
+			},
+			wantTag: 3,
+			want:    cddlNofK(0x02, pubkeyA, pubkeyB),
+		},
+		{
+			name: "invalid_before",
+			build: func() (common.NativeScript, error) {
+				return NewNativeScriptInvalidBefore(1000)
+			},
+			wantTag: 4,
+			// array(2), uint(4), uint16(1000)
+			want: []byte{0x82, 0x04, 0x19, 0x03, 0xe8},
+		},
+		{
+			name: "invalid_hereafter",
+			build: func() (common.NativeScript, error) {
+				return NewNativeScriptInvalidHereafter(2000)
+			},
+			wantTag: 5,
+			// array(2), uint(5), uint16(2000)
+			want: []byte{0x82, 0x05, 0x19, 0x07, 0xd0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ns, err := test.build()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := nativeScriptCbor(t, ns)
+			if !bytes.Equal(got, test.want) {
+				t.Errorf("CBOR mismatch:\n got %s\nwant %s",
+					hex.EncodeToString(got), hex.EncodeToString(test.want))
+			}
+			if tag := nativeScriptTypeTag(t, got); tag != test.wantTag {
+				t.Errorf("type tag %d, want %d", tag, test.wantTag)
+			}
+			if hash := ns.Hash(); hash != cddlScriptHash(test.want) {
+				t.Errorf("script hash %s, want %s",
+					hash, cddlScriptHash(test.want))
+			}
+		})
+	}
+}
+
+// TestNativeScriptAllIsNotAny pins the pair of constructors that are byte-wise
+// identical apart from the type tag. Emitting Any where All was asked for turns
+// an n-of-n multisig into a 1-of-n, so the two must never collide.
+func TestNativeScriptAllIsNotAny(t *testing.T) {
+	scriptA, err := NewNativeScriptPubkey(nativeScriptKeyHash(0x01))
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptB, err := NewNativeScriptPubkey(nativeScriptKeyHash(0x02))
+	if err != nil {
+		t.Fatal(err)
+	}
+	members := []common.NativeScript{scriptA, scriptB}
+
+	all, err := NewNativeScriptAll(members)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anyOf, err := NewNativeScriptAny(members)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allCbor := nativeScriptCbor(t, all)
+	anyCbor := nativeScriptCbor(t, anyOf)
+
+	if bytes.Equal(allCbor, anyCbor) {
+		t.Fatalf("all and any encode identically: %s",
+			hex.EncodeToString(allCbor))
+	}
+	if all.Hash() == anyOf.Hash() {
+		t.Fatalf("all and any share script hash %s", all.Hash())
+	}
+	if tag := nativeScriptTypeTag(t, allCbor); tag != 1 {
+		t.Errorf("all type tag %d, want 1", tag)
+	}
+	if tag := nativeScriptTypeTag(t, anyCbor); tag != 2 {
+		t.Errorf("any type tag %d, want 2", tag)
+	}
+}
+
+// TestNativeScriptTimelocksAreNotInterchangeable pins the other confusable
+// pair: swapping invalid_before and invalid_hereafter inverts a timelock, so
+// the same slot must yield different scripts under the two constructors.
+func TestNativeScriptTimelocksAreNotInterchangeable(t *testing.T) {
+	const slot = 42
+
+	before, err := NewNativeScriptInvalidBefore(slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hereafter, err := NewNativeScriptInvalidHereafter(slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeCbor := nativeScriptCbor(t, before)
+	hereafterCbor := nativeScriptCbor(t, hereafter)
+
+	// array(2), uint(4|5), uint(42)
+	if want := []byte{0x82, 0x04, 0x18, slot}; !bytes.Equal(
+		beforeCbor, want,
+	) {
+		t.Errorf("invalid_before CBOR %s, want %s",
+			hex.EncodeToString(beforeCbor), hex.EncodeToString(want))
+	}
+	if want := []byte{0x82, 0x05, 0x18, slot}; !bytes.Equal(
+		hereafterCbor, want,
+	) {
+		t.Errorf("invalid_hereafter CBOR %s, want %s",
+			hex.EncodeToString(hereafterCbor), hex.EncodeToString(want))
+	}
+	if before.Hash() == hereafter.Hash() {
+		t.Fatalf("timelocks share script hash %s", before.Hash())
+	}
+}

--- a/signature_verification_test.go
+++ b/signature_verification_test.go
@@ -3,7 +3,7 @@ package apollo
 import (
 	"bytes"
 	"crypto/ed25519"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/bursa"
@@ -49,7 +49,7 @@ func (c *submitCaptureContext) SubmitTx(
 		return common.Blake2b256{}, err
 	}
 	if len(elements) == 0 {
-		return common.Blake2b256{}, fmt.Errorf("submitted transaction has no body")
+		return common.Blake2b256{}, errors.New("submitted transaction has no body")
 	}
 	return common.Blake2b256Hash(elements[0]), nil
 }

--- a/signature_verification_test.go
+++ b/signature_verification_test.go
@@ -3,6 +3,7 @@ package apollo
 import (
 	"bytes"
 	"crypto/ed25519"
+	"fmt"
 	"testing"
 
 	"github.com/blinklabs-io/bursa"
@@ -43,7 +44,14 @@ func (c *submitCaptureContext) SubmitTx(
 	txCbor []byte,
 ) (common.Blake2b256, error) {
 	c.submitted = bytes.Clone(txCbor)
-	return common.Blake2b256Hash(txCbor), nil
+	var elements []cbor.RawMessage
+	if _, err := cbor.Decode(txCbor, &elements); err != nil {
+		return common.Blake2b256{}, err
+	}
+	if len(elements) == 0 {
+		return common.Blake2b256{}, fmt.Errorf("submitted transaction has no body")
+	}
+	return common.Blake2b256Hash(elements[0]), nil
 }
 
 // signAndSubmit builds a single-output transaction spending the wallet's own

--- a/signature_verification_test.go
+++ b/signature_verification_test.go
@@ -1,0 +1,286 @@
+package apollo
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	"github.com/Salvionied/apollo/v2/backend"
+	"github.com/Salvionied/apollo/v2/backend/fixed"
+)
+
+// signingTestMnemonic is the canonical all-zero-entropy BIP39 test vector. It
+// is published in the BIP39 specification itself, so it can never hold real
+// funds and is safe to hardcode.
+const signingTestMnemonic = "abandon abandon abandon abandon abandon " +
+	"abandon abandon abandon abandon abandon abandon about"
+
+// bodyFeeKey is the transaction_body map key for the fee, per the Conway CDDL
+// (0 inputs, 1 outputs, 2 fee, 3 ttl, ...).
+const bodyFeeKey = 2
+
+// submitCaptureContext records the exact bytes handed to SubmitTx. That is the
+// only place the transaction that would go on the wire can be observed, so the
+// signature checks below run against those bytes rather than against builder
+// state. It performs no network I/O.
+type submitCaptureContext struct {
+	*fixed.FixedChainContext
+	submitted []byte
+}
+
+// Capabilities adds submission to the fixed context's in-memory operations.
+func (c *submitCaptureContext) Capabilities() backend.CapabilitySet {
+	return c.FixedChainContext.Capabilities() |
+		backend.CapabilitySet(backend.CapabilitySubmitTx)
+}
+
+func (c *submitCaptureContext) SubmitTx(
+	txCbor []byte,
+) (common.Blake2b256, error) {
+	c.submitted = bytes.Clone(txCbor)
+	return common.Blake2b256Hash(txCbor), nil
+}
+
+// signAndSubmit builds a single-output transaction spending the wallet's own
+// UTxO, signs it, submits it, and returns the submitted CBOR.
+func signAndSubmit(t *testing.T, w Wallet) []byte {
+	t.Helper()
+	cc := &submitCaptureContext{
+		FixedChainContext: networkTestContext(
+			t,
+			common.AddressNetworkMainnet,
+		),
+	}
+	addTestUtxo(cc.FixedChainContext, w.Address(), 10_000_000, 0x01, 0)
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	a, err := New(cc).
+		SetWallet(w).
+		SetTtl(50_000_000).
+		PayToAddress(payee, 2_000_000).
+		Complete()
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if a, err = a.Sign(); err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	if _, err := a.Submit(); err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if len(cc.submitted) == 0 {
+		t.Fatal("no transaction CBOR reached SubmitTx")
+	}
+	return cc.submitted
+}
+
+// txTopLevelElements splits a transaction into its raw top-level CBOR elements
+// ([body, witness_set, is_valid, auxiliary_data]) without interpreting them,
+// so element 0 is exactly the byte string the ledger hashes to get the tx id.
+func txTopLevelElements(t *testing.T, txCbor []byte) []cbor.RawMessage {
+	t.Helper()
+	var elements []cbor.RawMessage
+	if _, err := cbor.Decode(txCbor, &elements); err != nil {
+		t.Fatalf("failed to split transaction into elements: %v", err)
+	}
+	if len(elements) != 4 {
+		t.Fatalf("expected 4 top-level tx elements, got %d", len(elements))
+	}
+	return elements
+}
+
+// submittedVkeyWitnesses decodes the vkey witnesses (witness set key 0) out of
+// the raw witness-set element.
+func submittedVkeyWitnesses(
+	t *testing.T,
+	witnessSetCbor []byte,
+) []common.VkeyWitness {
+	t.Helper()
+	var witnessSet map[uint64]cbor.RawMessage
+	if _, err := cbor.Decode(witnessSetCbor, &witnessSet); err != nil {
+		t.Fatalf("failed to decode submitted witness set: %v", err)
+	}
+	raw, ok := witnessSet[0]
+	if !ok {
+		t.Fatal("submitted witness set has no vkey witnesses (key 0)")
+	}
+	var witnesses cbor.SetType[common.VkeyWitness]
+	if _, err := cbor.Decode(raw, &witnesses); err != nil {
+		t.Fatalf("failed to decode submitted vkey witnesses: %v", err)
+	}
+	items := witnesses.Items()
+	if len(items) == 0 {
+		t.Fatal("submitted transaction carries no vkey witnesses")
+	}
+	return items
+}
+
+// assertSignsSubmittedBodyHash verifies every submitted witness independently
+// of Apollo: the signature must be a valid Ed25519 signature over
+// blake2b-256(body element), the vkey must hash to wantKeyHash, and the
+// signature must not verify over anything else. The negative controls matter:
+// without them the test would only prove that something was signed, not that
+// the transaction body was.
+func assertSignsSubmittedBodyHash(
+	t *testing.T,
+	txCbor []byte,
+	wantKeyHash common.Blake2b224,
+) {
+	t.Helper()
+	elements := txTopLevelElements(t, txCbor)
+	body := []byte(elements[0])
+	bodyHash := common.Blake2b256Hash(body)
+
+	for i, witness := range submittedVkeyWitnesses(t, elements[1]) {
+		if len(witness.Vkey) != ed25519.PublicKeySize {
+			t.Fatalf("witness %d vkey is %d bytes, want %d",
+				i, len(witness.Vkey), ed25519.PublicKeySize)
+		}
+		if len(witness.Signature) != ed25519.SignatureSize {
+			t.Fatalf("witness %d signature is %d bytes, want %d",
+				i, len(witness.Signature), ed25519.SignatureSize)
+		}
+		vkey := ed25519.PublicKey(witness.Vkey)
+		if !ed25519.Verify(vkey, bodyHash.Bytes(), witness.Signature) {
+			t.Fatalf(
+				"witness %d does not sign blake2b-256 of the submitted body (%s)",
+				i, bodyHash,
+			)
+		}
+		// A wallet handing back the stake key as the payment vkey produces a
+		// witness that verifies but that no input can be spent with.
+		if got := common.Blake2b224Hash(witness.Vkey); got != wantKeyHash {
+			t.Fatalf("witness %d vkey hashes to %s, want %s",
+				i, got, wantKeyHash)
+		}
+		if ed25519.Verify(vkey, txCbor, witness.Signature) {
+			t.Fatalf("witness %d signs the whole transaction, not the body hash",
+				i)
+		}
+		if ed25519.Verify(vkey, body, witness.Signature) {
+			t.Fatalf("witness %d signs the un-hashed body, not its hash", i)
+		}
+	}
+}
+
+// testPaymentKey derives a CIP-1852 payment key from the public test mnemonic.
+func testPaymentKey(t *testing.T, addressID uint32) bip32.XPrv {
+	t.Helper()
+	rootKey, err := bursa.GetRootKeyFromMnemonic(signingTestMnemonic, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountKey, err := bursa.GetAccountKey(rootKey, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paymentKey, err := bursa.GetPaymentKey(accountKey, addressID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return paymentKey
+}
+
+// TestBursaWalletSignsSubmittedBodyHash covers BursaWallet.SignTxBody end to
+// end: build, sign, submit, then verify the witness against the bytes on the
+// wire.
+func TestBursaWalletSignsSubmittedBodyHash(t *testing.T) {
+	w, err := NewBursaWallet(signingTestMnemonic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The vkey assertion below only catches a stake-for-payment key mix-up if
+	// the two hashes actually differ for this wallet.
+	if w.PubKeyHash() == w.StakePubKeyHash() {
+		t.Fatal("test wallet payment and stake key hashes must differ")
+	}
+	assertSignsSubmittedBodyHash(t, signAndSubmit(t, w), w.PubKeyHash())
+}
+
+// TestKeyPairWalletSignsSubmittedBodyHash covers KeyPairWallet.SignTxBody with
+// an enterprise address controlled by the raw extended key.
+func TestKeyPairWalletSignsSubmittedBodyHash(t *testing.T) {
+	key := testPaymentKey(t, 1)
+	keyHash := common.Blake2b224Hash(key.Public().PublicKey())
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyNone,
+		common.AddressNetworkMainnet,
+		keyHash.Bytes(),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, err := NewKeyPairWallet(addr, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w.PubKeyHash() != keyHash {
+		t.Fatalf("wallet key hash %s does not control address %s",
+			w.PubKeyHash(), addr)
+	}
+	assertSignsSubmittedBodyHash(t, signAndSubmit(t, w), w.PubKeyHash())
+}
+
+// TestSignatureDoesNotSurviveBodyTampering re-encodes the submitted body and
+// bumps the fee, the classic post-signing tamper. The unmodified re-encode is
+// checked first so a failure of the tampered case cannot be explained by the
+// re-encoding itself.
+func TestSignatureDoesNotSurviveBodyTampering(t *testing.T) {
+	w, err := NewBursaWallet(signingTestMnemonic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txCbor := signAndSubmit(t, w)
+	elements := txTopLevelElements(t, txCbor)
+	witness := submittedVkeyWitnesses(t, elements[1])[0]
+	vkey := ed25519.PublicKey(witness.Vkey)
+
+	signedHash := common.Blake2b256Hash(elements[0])
+	if !ed25519.Verify(vkey, signedHash.Bytes(), witness.Signature) {
+		t.Fatalf("witness does not sign the submitted body hash (%s)",
+			signedHash)
+	}
+
+	var body map[uint64]cbor.RawMessage
+	if _, err := cbor.Decode(elements[0], &body); err != nil {
+		t.Fatalf("failed to decode submitted body fields: %v", err)
+	}
+	reencoded, err := cbor.Encode(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := common.Blake2b256Hash(reencoded)
+	if !ed25519.Verify(vkey, hash.Bytes(), witness.Signature) {
+		t.Fatal("re-encoding the untouched body changed the signed hash")
+	}
+
+	originalFee, ok := body[bodyFeeKey]
+	if !ok {
+		t.Fatal("submitted body has no fee field")
+	}
+	tamperedFee, err := cbor.Encode(uint64(9_999_999))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(originalFee, tamperedFee) {
+		t.Fatal("tampered fee matches the original fee")
+	}
+	body[bodyFeeKey] = tamperedFee
+	tampered, err := cbor.Encode(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tamperedHash := common.Blake2b256Hash(tampered)
+	if ed25519.Verify(vkey, tamperedHash.Bytes(), witness.Signature) {
+		t.Fatal("signature still verifies after the fee was tampered with")
+	}
+}


### PR DESCRIPTION
Closes the two test-coverage holes that mutation testing proved were open on `master`: injecting either bug left the entire suite green across all 10 packages.

**A wallet that signs a constant instead of the transaction body hash.** `Sign()` was at ~11% coverage, both `SignTxBody` implementations at 0%, and no test in the repo verified an Ed25519 signature.

**`NewNativeScriptAll` emitting an `Any` script.** A native multisig that should require every signer silently requires only one — a total authorization bypass. The same class covers swapping `InvalidBefore`/`InvalidHereafter`, which inverts a timelock.

## Approach

Signature tests assert against the **submitted** bytes, not builder state: a capture context records what `SubmitTx` received, then the body element is hashed independently with blake2b-256, witnesses are decoded out of the witness set, and each is checked with `crypto/ed25519.Verify`. Two negative controls pin *what* is signed — the signature must **not** verify over the whole transaction bytes, nor over the un-hashed body. The vkey's hash is compared to `PubKeyHash()`, so a wallet returning the stake key is caught too.

Native-script expectations are assembled from the Conway CDDL with header bytes spelled out, never from Apollo's own output, and each case asserts the full CBOR, the independently decoded type tag, and the script hash.

## Mutation kills

| Mutation | Caught by |
|---|---|
| Bursa wallet signs a constant | body-hash verification + tampering test |
| KeyPair wallet signs a constant | body-hash verification |
| `NewNativeScriptAll` `Type: 1`→`2` | CBOR bytes, type tag, script hash, and the all-vs-any test |
| `InvalidBefore`→`InvalidHereafter` | bytes, tag, and shared-script-hash check |
| Wallet returns the **stake** key as vkey | signature no longer verifies under the returned vkey |
| Stake key both signs **and** is the vkey (internally consistent) | only the vkey-hash assertion fires |
| `NewNativeScriptNofK` hardcodes `N: 1` (threshold bypass) | CBOR bytes + script hash |

The last three were devised beyond the brief. Coverage of the targeted functions is now 100% for both `SignTxBody` implementations and all six `NewNativeScript*` constructors.

No production bug was found — current `master` is correct for signing and for all six constructors. This PR is test-only.

Key material is the canonical all-zero-entropy BIP39 vector published in the spec. No network calls. No new module dependencies.
