### PR TITLE
fix: enforce max_val_size, size fees for real signers, validate credential addresses

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -516,9 +516,13 @@ func (a *Apollo) resolveCredential(v any) (common.Credential, error) {
 	case common.Address:
 		return GetStakeCredentialFromAddress(val)
 	case string:
-		addr, err := common.NewAddress(val)
+		// ParseAddress rather than common.NewAddress: the latter treats a
+		// bech32 checksum failure as a reason to try base58, and Shelley
+		// addresses are entirely base58-legal, so a corrupted address would
+		// decode to an unrelated credential instead of failing.
+		addr, err := ParseAddress(val)
 		if err != nil {
-			return common.Credential{}, fmt.Errorf("invalid bech32 address: %w", err)
+			return common.Credential{}, fmt.Errorf("invalid address: %w", err)
 		}
 		return GetStakeCredentialFromAddress(addr)
 	case nil:
@@ -1948,8 +1952,49 @@ func (a *Apollo) Complete() (*Apollo, error) {
 			return a, fmt.Errorf("transaction size %d exceeds max_tx_size %d", len(txBytes), pp.MaxTxSize)
 		}
 	}
+	if err := validateOutputValueSizes(a.tx.Body.TxOutputs, pp); err != nil {
+		return a, err
+	}
 
 	return a, nil
+}
+
+// validateOutputValueSizes rejects any output whose serialized value exceeds
+// max_val_size.
+//
+// The ledger bounds the value portion of an output, not the whole output, so a
+// wallet holding many native assets can produce a change output the node
+// refuses even though the transaction as a whole is within max_tx_size.
+// Reporting it here names the offending output instead of leaving the caller
+// with an OutputTooBigUTxO rejection after submission.
+func validateOutputValueSizes(
+	outputs []babbage.BabbageTransactionOutput,
+	pp backend.ProtocolParameters,
+) error {
+	if pp.MaxValSize == "" {
+		return nil
+	}
+	maxValSize, err := strconv.ParseInt(pp.MaxValSize, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid max_val_size %q: %w", pp.MaxValSize, err)
+	}
+	if maxValSize <= 0 {
+		return nil
+	}
+	for i := range outputs {
+		valueBytes, err := cbor.Encode(outputs[i].OutputAmount)
+		if err != nil {
+			return fmt.Errorf("failed to encode output %d value: %w", i, err)
+		}
+		if int64(len(valueBytes)) > maxValSize {
+			return fmt.Errorf(
+				"output %d value size %d exceeds max_val_size %d; "+
+					"split the native assets across more outputs",
+				i, len(valueBytes), maxValSize,
+			)
+		}
+	}
+	return nil
 }
 
 // Sign signs the transaction with the wallet.
@@ -1988,6 +2033,17 @@ func (a *Apollo) Sign() (*Apollo, error) {
 }
 
 // GetTx returns the built transaction.
+//
+// Apollo builds Conway transactions, so the concrete Conway type is returned:
+// it gives callers every body and witness-set field, including ones no
+// era-neutral interface exposes, such as the network id. When Apollo gains
+// support for a later era, a sibling accessor is added for it rather than this
+// one changing meaning.
+//
+// The returned transaction is constructed rather than decoded, so its Cbor() is
+// empty: gouroboros populates stored CBOR only when unmarshalling. Use
+// GetTxCbor for the encoding, which is produced fresh on each call and so
+// cannot go stale when Sign adds witnesses.
 func (a *Apollo) GetTx() *conway.ConwayTransaction {
 	return a.tx
 }
@@ -2046,7 +2102,11 @@ func (a *Apollo) buildOutputs() ([]babbage.BabbageTransactionOutput, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to build payment output: %w", err)
 		}
-		outputs = append(outputs, *txOut)
+		babbageOut, err := babbageOutputOf(txOut)
+		if err != nil {
+			return nil, err
+		}
+		outputs = append(outputs, *babbageOut)
 	}
 	return outputs, nil
 }
@@ -2211,6 +2271,61 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 	return canonical, nil
 }
 
+// estimatedWitnessCount reports how many vkey witnesses the transaction is
+// expected to carry, for fee sizing.
+//
+// Counting only the wallet plus explicitly registered required signers
+// undercounts whenever the inputs span more than one payment credential or a
+// withdrawal or certificate needs a stake-key signature. Each missing witness
+// is around 102 bytes, and the converged fee has no slack, so an undercount
+// becomes FeeTooSmallUTxO at submission -- which is what made multi-signature
+// flows fail.
+//
+// Credentials are counted as a set, since one signature covers every input
+// under the same key. Script credentials are excluded: they are satisfied by a
+// script witness, not a vkey witness. The result never drops below the previous
+// estimate, so this can only raise a fee, never lower one.
+func (a *Apollo) estimatedWitnessCount(inputs []common.Utxo) int {
+	signers := make(map[common.Blake2b224]struct{})
+	if a.wallet != nil {
+		signers[a.wallet.PubKeyHash()] = struct{}{}
+	}
+	for _, hash := range a.requiredSigners {
+		signers[hash] = struct{}{}
+	}
+	addPaymentKey := func(utxos []common.Utxo) {
+		for _, utxo := range utxos {
+			if utxo.Output == nil {
+				continue
+			}
+			addr := utxo.Output.Address()
+			switch addr.Type() {
+			case common.AddressTypeKeyKey,
+				common.AddressTypeKeyScript,
+				common.AddressTypeKeyPointer,
+				common.AddressTypeKeyNone:
+				if hash := addr.PaymentKeyHash(); hash != (common.Blake2b224{}) {
+					signers[hash] = struct{}{}
+				}
+			}
+		}
+	}
+	addPaymentKey(inputs)
+	addPaymentKey(a.collaterals)
+	// A withdrawal is authorised by the stake credential of its reward address.
+	for _, entry := range a.withdrawals {
+		if hash := entry.Address.StakeKeyHash(); hash != (common.Blake2b224{}) {
+			signers[hash] = struct{}{}
+		}
+	}
+	count := len(signers)
+	// Never estimate below the previous behaviour.
+	if previous := 1 + len(a.requiredSigners); count < previous {
+		count = previous
+	}
+	return count
+}
+
 func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTransactionOutput) (int64, error) {
 	pp, err := backend.ProtocolParamsContext(a.requestContext, a.Context)
 	if err != nil {
@@ -2233,11 +2348,9 @@ func (a *Apollo) estimateFee(inputs []common.Utxo, outputs []babbage.BabbageTran
 		return 0, err
 	}
 	ws := a.buildWitnessSet(inputs)
-	// Add fake vkey witnesses for size estimation (1 for wallet + 1 per required signer).
-	// Note: this count may underestimate if additional signers (e.g., multi-sig
-	// participants) are added after Complete(). Callers can use SetFeePadding()
-	// to account for extra witnesses.
-	witnessCount := 1 + len(a.requiredSigners)
+	// Add placeholder vkey witnesses so the size estimate accounts for the
+	// signatures the transaction will carry.
+	witnessCount := a.estimatedWitnessCount(inputs)
 	fakeWitnesses := make([]common.VkeyWitness, witnessCount)
 	for i := range fakeWitnesses {
 		fakeWitnesses[i] = common.VkeyWitness{

--- a/apollo.go
+++ b/apollo.go
@@ -2318,6 +2318,41 @@ func (a *Apollo) estimatedWitnessCount(inputs []common.Utxo) int {
 			signers[hash] = struct{}{}
 		}
 	}
+	// Stake certificates are authorised by their stake credential. Script
+	// credentials are satisfied by a script witness and must not add a vkey
+	// witness to the estimate.
+	addStakeCredential := func(credential common.Credential) {
+		if credential.CredType == common.CredentialTypeAddrKeyHash &&
+			credential.Credential != (common.Blake2b224{}) {
+			signers[credential.Credential] = struct{}{}
+		}
+	}
+	for _, wrapper := range a.certificates {
+		switch certificate := wrapper.Certificate.(type) {
+		case *common.StakeRegistrationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.StakeDeregistrationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.StakeDelegationCertificate:
+			if certificate.StakeCredential != nil {
+				addStakeCredential(*certificate.StakeCredential)
+			}
+		case *common.RegistrationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.DeregistrationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.VoteDelegationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.StakeVoteDelegationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.StakeRegistrationDelegationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.VoteRegistrationDelegationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		case *common.StakeVoteRegistrationDelegationCertificate:
+			addStakeCredential(certificate.StakeCredential)
+		}
+	}
 	count := len(signers)
 	// Never estimate below the previous behaviour.
 	if previous := 1 + len(a.requiredSigners); count < previous {

--- a/builder_hardening_test.go
+++ b/builder_hardening_test.go
@@ -31,7 +31,7 @@ type cloneableTestPayment struct {
 }
 
 func (p *cloneableTestPayment) EnsureMinUTXO(backend.ChainContext) error { return nil }
-func (p *cloneableTestPayment) ToTxOut() (*babbage.BabbageTransactionOutput, error) {
+func (p *cloneableTestPayment) ToTxOut() (common.TransactionOutput, error) {
 	return nil, errors.New("not used")
 }
 func (p *cloneableTestPayment) ToValue() (Value, error) { return Value{}, nil }

--- a/era_neutral_test.go
+++ b/era_neutral_test.go
@@ -1,0 +1,44 @@
+package apollo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+)
+
+// Compile-time assertions on the accessor shapes.
+//
+// GetTx deliberately returns the concrete Conway transaction: Apollo builds
+// Conway, and callers need fields no era-neutral interface exposes. ToTxOut is
+// deliberately era-neutral because PaymentI is implemented by third parties, so
+// changing its signature for a later era would break every implementation.
+var (
+	_ func(*Apollo) *conway.ConwayTransaction          = (*Apollo).GetTx
+	_ func(*Payment) (common.TransactionOutput, error) = (*Payment).ToTxOut
+)
+
+// foreignOutput is a minimal common.TransactionOutput that is not a Babbage
+// output.
+type foreignOutput struct {
+	common.TransactionOutput
+}
+
+// TestForeignOutputRejectedWithClearError covers the cost of making
+// PaymentI.ToTxOut era-neutral: a third-party payment may now return an output
+// Apollo cannot place in a Conway body, and that must be a clear error rather
+// than a panic or a silently wrong transaction.
+func TestForeignOutputRejectedWithClearError(t *testing.T) {
+	_, err := babbageOutputOf(&foreignOutput{})
+	if err == nil {
+		t.Fatal("expected a non-Babbage output to be rejected")
+	}
+	if !strings.Contains(err.Error(), "Babbage") {
+		t.Errorf("error does not explain the format requirement: %v", err)
+	}
+
+	if _, err := babbageOutputOf(nil); err == nil {
+		t.Error("expected a nil output to be rejected")
+	}
+}

--- a/fee_guards_test.go
+++ b/fee_guards_test.go
@@ -1,0 +1,284 @@
+package apollo
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// TestOutputValueSizeIsEnforced is the regression guard for max_val_size.
+//
+// The ledger bounds the value portion of an output, not the whole output, so a
+// wallet holding many native assets could build a change output the node
+// refuses with OutputTooBigUTxO while the transaction stayed within
+// max_tx_size. Apollo parsed max_val_size in every backend and enforced it
+// nowhere.
+func TestOutputValueSizeIsEnforced(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+
+	// A UTxO carrying enough distinct assets that the resulting change value
+	// cannot fit inside max_val_size (5000 bytes on the fixed context's
+	// parameters).
+	utxo := manyAssetUtxo(t, addr, 400)
+	cc.AddUtxo(addr, utxo)
+
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddInput(utxo).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Complete()
+	if err == nil {
+		t.Fatal("expected an oversized output value to be rejected")
+	}
+	if !strings.Contains(err.Error(), "max_val_size") {
+		t.Errorf("error does not mention max_val_size: %v", err)
+	}
+}
+
+// TestOrdinaryOutputValuePasses confirms the new check does not reject normal
+// transactions.
+func TestOrdinaryOutputValuePasses(t *testing.T) {
+	if _, err := buildTransfer(t, 10_000_000, 2_000_000); err != nil {
+		t.Fatalf("a plain transfer was rejected: %v", err)
+	}
+}
+
+// TestWitnessCountCoversDistinctInputCredentials is the regression guard for the
+// fee undercount. Estimating one witness plus the registered required signers
+// ignores inputs spanning several payment credentials, and each missing witness
+// is around 102 bytes against a fee with no slack.
+func TestWitnessCountCoversDistinctInputCredentials(t *testing.T) {
+	cc := setupFixedContext()
+	first := testAddress(t)
+	second := testAddressVariant(t, 0xcc)
+
+	addTestUtxo(cc, first, 5_000_000, 0x01, 0)
+	addTestUtxo(cc, second, 5_000_000, 0x02, 0)
+
+	firstUtxos, err := cc.Utxos(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondUtxos, err := cc.Utxos(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(cc).SetWallet(NewExternalWallet(first)).SetTtl(50_000_000)
+	for _, u := range append(firstUtxos, secondUtxos...) {
+		a = a.AddInput(u)
+	}
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err = a.AddPayment(p).Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two distinct payment credentials are spent, so two signatures are needed.
+	inputs := append(append([]common.Utxo{}, firstUtxos...), secondUtxos...)
+	if got := a.estimatedWitnessCount(inputs); got < 2 {
+		t.Errorf(
+			"estimatedWitnessCount = %d for inputs under 2 distinct payment "+
+				"credentials, want at least 2",
+			got,
+		)
+	}
+
+	// And the fee must cover a transaction carrying that many witnesses.
+	assertFeeCoversWitnesses(t, a, 2)
+}
+
+// TestWitnessCountCoversWithdrawalStakeKey covers the other undercounted case: a
+// withdrawal is authorised by the stake credential of its reward address, which
+// needs its own signature.
+func TestWitnessCountCoversWithdrawalStakeKey(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	a, err := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		SetTtl(50_000_000).
+		AddWithdrawal(stakeAddressFor(t, addr), 1_000_000, nil, nil).
+		Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The payment key and the stake key are distinct credentials.
+	if got := a.estimatedWitnessCount(nil); got < 2 {
+		t.Errorf(
+			"estimatedWitnessCount = %d with a withdrawal, want at least 2",
+			got,
+		)
+	}
+	assertFeeCoversWitnesses(t, a, 2)
+}
+
+// TestWitnessCountNeverBelowPrevious pins the safety property: the new estimate
+// can raise a fee but never lower one.
+func TestWitnessCountNeverBelowPrevious(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	a := New(cc).SetWallet(NewExternalWallet(addr))
+	for _, hash := range []common.Blake2b224{{0x01}, {0x02}, {0x03}} {
+		a = a.AddRequiredSigner(hash)
+	}
+	if got, want := a.estimatedWitnessCount(nil), 1+3; got < want {
+		t.Errorf("estimatedWitnessCount = %d, want at least %d", got, want)
+	}
+}
+
+// assertFeeCoversWitnesses checks the committed fee covers the transaction's own
+// size once it carries witnessCount signatures.
+func assertFeeCoversWitnesses(t *testing.T, a *Apollo, witnessCount int) {
+	t.Helper()
+	txCbor, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pp, err := a.Context.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A vkey witness is a 32-byte key plus a 64-byte signature, so roughly 102
+	// bytes once CBOR framing is included.
+	const witnessBytes = 102
+	//nolint:gosec // protocol params and sizes are small positive values
+	size := int64(len(txCbor)) + int64(witnessCount*witnessBytes)
+	minFee := size*pp.MinFeeCoefficient + pp.MinFeeConstant
+	fee := new(big.Int).SetUint64(a.GetTx().Body.TxFee)
+	if fee.Cmp(big.NewInt(minFee)) < 0 {
+		t.Errorf(
+			"fee %s does not cover %d bytes with %d witnesses (need %d)",
+			fee, size, witnessCount, minFee,
+		)
+	}
+}
+
+// TestResolveCredentialRejectsCorruptedAddress guards the fifth bech32 entry
+// point. resolveCredential backs the string form of RegisterStake,
+// DelegateStake and DelegateVote, and called common.NewAddress directly, which
+// falls back to base58 on a checksum failure.
+func TestResolveCredentialRejectsCorruptedAddress(t *testing.T) {
+	// A mainnet address specifically. Shelley mainnet addresses are composed
+	// entirely of base58-legal characters, so common.NewAddress re-decodes a
+	// corrupted one through its base58 fallback instead of reporting the
+	// checksum failure. Testnet addresses are incidentally immune because "_"
+	// is not in the base58 alphabet, so a testnet address cannot exercise this.
+	payment := make([]byte, common.AddressHashSize)
+	stake := make([]byte, common.AddressHashSize)
+	for i := range payment {
+		payment[i] = 0xaa
+		stake[i] = 0xbb
+	}
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyKey, 1, payment, stake,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := addr.String()
+	if !strings.HasPrefix(valid, "addr1") {
+		t.Fatalf("expected a mainnet address, got %s", valid)
+	}
+
+	a := New(setupFixedContext())
+	if _, err := a.resolveCredential(valid); err != nil {
+		t.Fatalf("a valid address was rejected: %v", err)
+	}
+
+	var accepted []string
+	for i := 10; i < len(valid); i++ {
+		for _, c := range "qpzry9x8gf2tvdw0s3jn54khce6mua7l" {
+			if rune(valid[i]) == c {
+				continue
+			}
+			corrupted := valid[:i] + string(c) + valid[i+1:]
+			if _, err := a.resolveCredential(corrupted); err == nil {
+				accepted = append(accepted, corrupted)
+			}
+		}
+	}
+	if len(accepted) > 0 {
+		t.Errorf(
+			"resolveCredential accepted %d corrupted addresses, first: %s",
+			len(accepted), accepted[0],
+		)
+	}
+}
+
+// testAddressVariant builds an address distinct from testAddress by changing the
+// payment credential, so a test can spend inputs under two credentials.
+func testAddressVariant(t *testing.T, fill byte) common.Address {
+	t.Helper()
+	base := testAddress(t)
+	payment := make([]byte, common.AddressHashSize)
+	for i := range payment {
+		payment[i] = fill
+	}
+	addr, err := common.NewAddressFromParts(
+		base.Type(),
+		//nolint:gosec // network id is 0 or 1
+		uint8(base.NetworkId()),
+		payment,
+		base.StakeKeyHash().Bytes(),
+	)
+	if err != nil {
+		t.Fatalf("build variant address: %v", err)
+	}
+	return addr
+}
+
+// manyAssetUtxo builds a UTxO holding count distinct native assets, each under
+// its own policy, so its value serializes past max_val_size.
+func manyAssetUtxo(t *testing.T, addr common.Address, count int) common.Utxo {
+	t.Helper()
+	policies := make(
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput,
+		count,
+	)
+	for i := range count {
+		var policy common.Blake2b224
+		policy[0] = byte(i % 256)
+		policy[1] = byte(i / 256)
+		policies[policy] = map[cbor.ByteString]common.MultiAssetTypeOutput{
+			cbor.NewByteString([]byte{byte(i % 256)}): big.NewInt(1),
+		}
+	}
+	assets := common.NewMultiAsset[common.MultiAssetTypeOutput](policies)
+	var txHash common.Blake2b256
+	txHash[0] = 0xfe
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount: mary.MaryTransactionOutputValue{
+			// Enough ADA that the change output clears its raised min-UTxO, so
+			// the size check is what rejects it rather than insufficient funds.
+			Amount: 500_000_000,
+			Assets: &assets,
+		},
+	}
+	return common.Utxo{
+		Id: shelley.ShelleyTransactionInput{
+			TxId:        txHash,
+			OutputIndex: 0,
+		},
+		Output: &output,
+	}
+}

--- a/fee_guards_test.go
+++ b/fee_guards_test.go
@@ -129,6 +129,34 @@ func TestWitnessCountCoversWithdrawalStakeKey(t *testing.T) {
 	assertFeeCoversWitnesses(t, a, 2)
 }
 
+// TestWitnessCountCoversCertificateStakeKey guards stake certificates, whose
+// key credentials also require a vkey witness even without a withdrawal.
+func TestWitnessCountCoversCertificateStakeKey(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+	stakeHash := common.Blake2b224{0x42}
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: stakeHash,
+	}
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		SetCertificates([]common.CertificateWrapper{{
+			Type: uint(common.CertificateTypeStakeDelegation),
+			Certificate: &common.StakeDelegationCertificate{
+				CertType:        uint(common.CertificateTypeStakeDelegation),
+				StakeCredential: &credential,
+			},
+		}})
+	if got := a.estimatedWitnessCount(nil); got < 2 {
+		t.Errorf(
+			"estimatedWitnessCount = %d with a certificate stake key, want at least 2",
+			got,
+		)
+	}
+}
+
 // TestWitnessCountNeverBelowPrevious pins the safety property: the new estimate
 // can raise a fee but never lower one.
 func TestWitnessCountNeverBelowPrevious(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -101,7 +102,14 @@ func (u *Unit) toMintValue() (Value, error) {
 // PaymentI is the interface for payment types.
 type PaymentI interface {
 	EnsureMinUTXO(cc backend.ChainContext) error
-	ToTxOut() (*babbage.BabbageTransactionOutput, error)
+	// ToTxOut builds the transaction output for this payment.
+	//
+	// The return type is era-neutral so that a future ledger era does not
+	// require changing this interface, which third parties implement. Apollo
+	// builds Conway bodies, whose outputs use the Babbage format, so the
+	// builder currently requires a *babbage.BabbageTransactionOutput and
+	// reports a clear error for anything else.
+	ToTxOut() (common.TransactionOutput, error)
 	ToValue() (Value, error)
 }
 
@@ -239,9 +247,9 @@ func (p *Payment) EnsureMinUTXO(cc backend.ChainContext) error {
 		return fmt.Errorf("failed to get protocol params: %w", err)
 	}
 	for range 3 {
-		txOut, err := p.ToTxOut()
+		txOut, err := p.babbageTxOut()
 		if err != nil {
-			return fmt.Errorf("failed to build tx output: %w", err)
+			return err
 		}
 		coins, err := MinLovelacePostAlonzo(txOut, pp.CoinsPerUtxoByteValue())
 		if err != nil {
@@ -253,9 +261,9 @@ func (p *Payment) EnsureMinUTXO(cc backend.ChainContext) error {
 		p.Lovelace = coins
 	}
 	// If we exhausted iterations without converging, verify one final time.
-	txOut, err := p.ToTxOut()
+	txOut, err := p.babbageTxOut()
 	if err != nil {
-		return fmt.Errorf("failed to build tx output: %w", err)
+		return err
 	}
 	coins, err := MinLovelacePostAlonzo(txOut, pp.CoinsPerUtxoByteValue())
 	if err != nil {
@@ -267,8 +275,46 @@ func (p *Payment) EnsureMinUTXO(cc backend.ChainContext) error {
 	return nil
 }
 
-// ToTxOut converts a Payment to a BabbageTransactionOutput.
-func (p *Payment) ToTxOut() (*babbage.BabbageTransactionOutput, error) {
+// babbageTxOut returns this payment's output in the Babbage format the Conway
+// body requires, or an error naming the type it got instead.
+func (p *Payment) babbageTxOut() (*babbage.BabbageTransactionOutput, error) {
+	txOut, err := p.ToTxOut()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build tx output: %w", err)
+	}
+	return babbageOutputOf(txOut)
+}
+
+// babbageOutputOf narrows an era-neutral output to the Babbage format used by
+// Conway transaction bodies.
+//
+// PaymentI.ToTxOut is deliberately era-neutral so the interface survives a new
+// ledger era, but Apollo builds Conway bodies today, so anything other than a
+// Babbage-format output cannot be placed in one. A third-party PaymentI that
+// returns some other implementation gets this error rather than a panic.
+func babbageOutputOf(
+	txOut common.TransactionOutput,
+) (*babbage.BabbageTransactionOutput, error) {
+	if txOut == nil {
+		return nil, errors.New("payment produced no transaction output")
+	}
+	out, ok := txOut.(*babbage.BabbageTransactionOutput)
+	if !ok {
+		return nil, fmt.Errorf(
+			"payment produced a %T output; Apollo builds Conway bodies, which "+
+				"require the Babbage output format",
+			txOut,
+		)
+	}
+	return out, nil
+}
+
+// ToTxOut converts a Payment to a transaction output.
+//
+// The concrete type is *babbage.BabbageTransactionOutput, which is the output
+// format Conway bodies use; the declared type is era-neutral so the PaymentI
+// contract survives a new era.
+func (p *Payment) ToTxOut() (common.TransactionOutput, error) {
 	val, err := p.ToValue()
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute payment value: %w", err)

--- a/models_test.go
+++ b/models_test.go
@@ -120,8 +120,20 @@ func TestPaymentToTxOut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if txOut.OutputAmount.Amount != 3000000 {
-		t.Errorf("expected 3000000, got %d", txOut.OutputAmount.Amount)
+	if got := txOut.Amount().Uint64(); got != 3000000 {
+		t.Errorf("expected 3000000, got %d", got)
+	}
+	// ToTxOut is declared era-neutral; Conway bodies still need the Babbage
+	// format, so pin the concrete type too.
+	babbageOut, err := babbageOutputOf(txOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if babbageOut.OutputAmount.Amount != 3000000 {
+		t.Errorf(
+			"babbage amount = %d, want 3000000",
+			babbageOut.OutputAmount.Amount,
+		)
 	}
 }
 


### PR DESCRIPTION
Four fixes, each with a test confirmed to fail without it.

## `max_val_size` was parsed everywhere and enforced nowhere

The ledger bounds the **value portion** of an output, not the whole output, so a wallet holding many native assets could build a change output the node refuses with `OutputTooBigUTxO` while the transaction stayed inside `max_tx_size`. `Complete()` now checks each output's serialized value and names the offending output.

## Fee estimation undercounted witnesses

It counted one witness plus the explicitly registered required signers, which misses inputs spanning several payment credentials and withdrawals needing a stake-key signature. Each missing witness is ~102 bytes, and the converged fee has **no slack**, so the shortfall becomes `FeeTooSmallUTxO`:

| Case | Committed fee | Minimum needed |
|---|---|---|
| Two payment credentials | 170121 | **174433** |
| Withdrawal | 167261 | **171573** |

`estimatedWitnessCount` now derives the count from the wallet, registered signers, the distinct payment credentials across spending and collateral inputs, and the stake credentials behind withdrawals — counted as a **set**, since one signature covers every input under the same key. Script credentials are excluded because a script witness satisfies those. The result never drops below the previous estimate, so this can raise a fee but never lower one.

## `resolveCredential` bypassed address validation

It backs the string form of `RegisterStake`, `DelegateStake` and `DelegateVote`, and still called `common.NewAddress` directly — the fifth bech32 entry point, missed when the other four were fixed. `common.NewAddress` treats a checksum failure as a reason to try base58, and Shelley mainnet addresses are entirely base58-legal, so a corrupted address decoded to an unrelated stake credential: **2697 of 2883** single-character corruptions were accepted. It now uses `ParseAddress`, and `apollo.go` no longer calls `common.NewAddress` at all.

Worth noting for reviewers: a **testnet** address cannot exercise this, because `_` is not in the base58 alphabet. My first version of the test used one and passed with the fix reverted — vacuous. The flaw only appears where real funds are.

## `PaymentI.ToTxOut` is now era-neutral

It returned `*babbage.BabbageTransactionOutput`. `PaymentI` is a public interface **third parties implement**, so an era-specific signature there could only be changed by a major version once 2.0 freezes it — every implementation would break. It now returns `common.TransactionOutput`; `babbageOutputOf` narrows the value where Conway bodies need it and reports a clear error for anything else rather than panicking.

`GetTx()` deliberately keeps returning the concrete `*conway.ConwayTransaction`. It is a method on a concrete type, so a later era is served by *adding* a sibling accessor — and callers need body fields such as the network id that no era-neutral interface exposes. Compile-time assertions pin both shapes.
