### PR TITLE
fix: run the 386 gate against tests, report the Blockfrost capability, document every package

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -37,7 +37,7 @@ jobs:
       - run: go test -race ./...
 
   quality:
-    name: format, tidy, vet, and 386 build
+    name: format, tidy, vet, and 386 test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,11 +50,19 @@ jobs:
         run: go mod tidy -diff
       - name: Vet
         run: go vet ./...
-      - name: Compile Linux 386
+      # Vet, not just build: go build skips _test.go files, so a test tree that
+      # does not compile on a 32-bit platform would slip through. 386 binaries
+      # run natively on the amd64 runner, so the tests can also be executed.
+      - name: Vet Linux 386
         env:
           GOOS: linux
           GOARCH: "386"
-        run: go build ./...
+        run: go vet ./...
+      - name: Test Linux 386
+        env:
+          GOOS: linux
+          GOARCH: "386"
+        run: go test -count=1 ./...
 
   vulnerability:
     name: vulnerability scan

--- a/backend/blockfrost/blockfrost.go
+++ b/backend/blockfrost/blockfrost.go
@@ -42,12 +42,17 @@ type BlockFrostChainContext struct {
 }
 
 // Capabilities reports the ChainContext feature set implemented by Blockfrost.
-// The hosted evaluate-with-UTxOs endpoint cannot resolve every additional UTxO
-// shape, notably asset-bearing off-chain outputs, so it is not advertised as a
-// general chained-input evaluator.
+//
+// CapabilityEvaluateTxAdditionalUtxos is included: EvaluateTx does honour the
+// argument, by retrying the plain evaluate endpoint for indexing lag and then
+// posting the resolved set to /utils/txs/evaluate/utxos. The hosted endpoint
+// cannot decode asset-bearing entries, so those skip the fallback, but that
+// degrades to an explicit evaluation error rather than a silently ignored
+// argument or an understated budget. Declining the capability instead made the
+// fallback unreachable, because callers gate on it and pass nil when it is
+// absent, which broke chained and indexing-lagged inputs outright.
 func (b *BlockFrostChainContext) Capabilities() backend.CapabilitySet {
-	return backend.CapabilitySet(backend.AllCapabilities) &^
-		backend.CapabilitySet(backend.CapabilityEvaluateTxAdditionalUtxos)
+	return backend.CapabilitySet(backend.AllCapabilities)
 }
 
 const (
@@ -807,7 +812,7 @@ func (b *BlockFrostChainContext) UtxoByRefContext(
 	}
 
 	for _, raw := range txUtxos.Outputs {
-		if int64(raw.OutputIndex) == int64(index) {
+		if raw.OutputIndex == int64(index) {
 			if raw.TxHash == "" {
 				raw.TxHash = fallbackHash
 			}
@@ -1045,8 +1050,11 @@ type bfGenesisParams struct {
 }
 
 type bfAddressUTxO struct {
-	TxHash              string            `json:"tx_hash"`
-	OutputIndex         int               `json:"output_index"`
+	TxHash string `json:"tx_hash"`
+	// OutputIndex is int64 rather than int so the range guards in toUtxo stay
+	// meaningful on 32-bit platforms, where int tops out at 2^31-1 and could
+	// never hold an out-of-range uint32 to reject in the first place.
+	OutputIndex         int64             `json:"output_index"`
 	Address             string            `json:"address"`
 	Amount              []bfAddressAmount `json:"amount"`
 	DataHash            string            `json:"data_hash"`
@@ -1073,12 +1081,12 @@ func (raw *bfAddressUTxO) toUtxo(address common.Address) (common.Utxo, error) {
 	if raw.OutputIndex < 0 {
 		return common.Utxo{}, fmt.Errorf("negative output index: %d", raw.OutputIndex)
 	}
-	if uint64(raw.OutputIndex) > uint64(math.MaxUint32) {
+	if raw.OutputIndex > math.MaxUint32 {
 		return common.Utxo{}, fmt.Errorf("output index %d exceeds uint32 range", raw.OutputIndex)
 	}
 	input := shelley.ShelleyTransactionInput{
 		TxId:        txId,
-		OutputIndex: uint32(raw.OutputIndex),
+		OutputIndex: uint32(raw.OutputIndex), //nolint:gosec // range checked above
 	}
 
 	// Parse amounts

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -54,8 +54,11 @@ func TestBlockfrostCapabilities(t *testing.T) {
 	if !backend.Supports(ctx, backend.CapabilityEvaluateTx|backend.CapabilityScriptCbor) {
 		t.Fatalf("Blockfrost capabilities = %b, want evaluation and script lookup", ctx.Capabilities())
 	}
-	if backend.Supports(ctx, backend.CapabilityEvaluateTxAdditionalUtxos) {
-		t.Fatal("Blockfrost must not report general additional-UTxO evaluation support")
+	// EvaluateTx honours additionalUtxos via the /evaluate/utxos fallback, and
+	// callers pass nil to backends that do not report the capability, so
+	// declining it would make that fallback unreachable.
+	if !backend.Supports(ctx, backend.CapabilityEvaluateTxAdditionalUtxos) {
+		t.Fatal("Blockfrost must report additional-UTxO evaluation support")
 	}
 }
 
@@ -187,7 +190,7 @@ func TestUtxosHydratesReferenceScriptsConcurrentlyInResponseOrder(t *testing.T) 
 		scripts[scriptHashHex] = script
 		rawUtxos[index] = bfAddressUTxO{
 			TxHash:              txHash,
-			OutputIndex:         index,
+			OutputIndex:         int64(index),
 			Address:             addr.String(),
 			Amount:              []bfAddressAmount{{Unit: "lovelace", Quantity: "1000000"}},
 			ReferenceScriptHash: scriptHashHex,
@@ -570,13 +573,44 @@ func TestAddressUTxOToUtxoRejectsNegativeAssetQuantity(t *testing.T) {
 	}
 }
 
-func TestAddressUTxOToUtxoRejectsOutputIndexOverflow(t *testing.T) {
+// TestAddressUTxOToUtxoRejectsOutputIndexOutOfRange pins both range guards in
+// toUtxo. bfAddressUTxO.OutputIndex is int64 rather than int precisely so this
+// test is expressible everywhere: with an int field the overflow literal does
+// not compile at GOARCH=386, and the guard it exercises would be dead code
+// there because a 32-bit int cannot hold a value above the uint32 range.
+func TestAddressUTxOToUtxoRejectsOutputIndexOutOfRange(t *testing.T) {
 	addr := testAddress(t)
-	raw := bfAddressUTxO{
-		TxHash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		OutputIndex: int(math.MaxUint32) + 1,
-		Address:     addr.String(),
-		Amount:      []bfAddressAmount{{Unit: "lovelace", Quantity: "1000000"}},
+	for _, index := range []int64{-1, int64(math.MaxUint32) + 1} {
+		raw := bfAddressUTxO{
+			TxHash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			OutputIndex: index,
+			Address:     addr.String(),
+			Amount:      []bfAddressAmount{{Unit: "lovelace", Quantity: "1000000"}},
+		}
+		if _, err := raw.toUtxo(addr); err == nil {
+			t.Fatalf("expected rejection of output index %d", index)
+		}
+	}
+}
+
+// TestAddressUTxODecodesOutputIndexAboveUint32 covers the guard through the
+// path a real Blockfrost response takes. The out-of-range output_index must
+// survive JSON decoding and then be rejected by toUtxo on every architecture;
+// an int field would instead fail inside json.Unmarshal on 32-bit builds, so
+// the domain guard would never run and the error would be a decode error.
+func TestAddressUTxODecodesOutputIndexAboveUint32(t *testing.T) {
+	addr := testAddress(t)
+	body := []byte(`{
+		"tx_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"output_index": 4294967296,
+		"amount": [{"unit": "lovelace", "quantity": "1000000"}]
+	}`)
+	var raw bfAddressUTxO
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("failed to decode output_index above uint32 range: %v", err)
+	}
+	if want := int64(math.MaxUint32) + 1; raw.OutputIndex != want {
+		t.Fatalf("OutputIndex = %d, want %d", raw.OutputIndex, want)
 	}
 	if _, err := raw.toUtxo(addr); err == nil {
 		t.Fatal("expected output index overflow error")
@@ -1154,6 +1188,54 @@ func TestEvaluateTxFallsBackToUtxosOnMissingInputs(t *testing.T) {
 		if paths[i] != wantPaths[i] {
 			t.Fatalf("paths = %v, want %v", paths, wantPaths)
 		}
+	}
+	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {
+		t.Fatalf("unexpected ExUnits %+v", eu)
+	}
+}
+
+// TestEvaluateTxAdditionalUtxosReachableThroughCapabilityGate pins the link
+// between Capabilities() and the /evaluate/utxos fallback. Callers check
+// CapabilityEvaluateTxAdditionalUtxos and substitute nil when it is absent, so
+// declining the capability leaves the fallback dead code and chained or
+// indexing-lagged inputs fail with the original missing-inputs error. This
+// reproduces that gate rather than trusting the fallback test above, which
+// calls EvaluateTx directly and so passes either way.
+func TestEvaluateTxAdditionalUtxosReachableThroughCapabilityGate(t *testing.T) {
+	prevRetries, prevWait := evaluateSimpleRetries, evaluateSimpleRetryWait
+	evaluateSimpleRetries, evaluateSimpleRetryWait = 1, 0
+	defer func() {
+		evaluateSimpleRetries, evaluateSimpleRetryWait = prevRetries, prevWait
+	}()
+
+	usedFallback := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/utils/txs/evaluate":
+			_, _ = w.Write([]byte(`{"result":{"EvaluationFailure":{"UnknownInputs":["abc#0"]}}}`))
+		case "/api/v0/utils/txs/evaluate/utxos":
+			usedFallback = true
+			_, _ = w.Write([]byte(`{"result":{"EvaluationResult":{"spend:0":{"memory":1700,"steps":476468}}}}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	ctx := NewBlockFrostChainContext(server.URL, 0, "")
+
+	// Mirror the caller-side gate in Apollo's execution-unit estimation.
+	additionalUtxos := []common.Utxo{sampleAdaOnlyUtxo(t)}
+	if !backend.Supports(ctx, backend.CapabilityEvaluateTxAdditionalUtxos) {
+		additionalUtxos = nil
+	}
+	result, err := ctx.EvaluateTx([]byte{0x84}, additionalUtxos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !usedFallback {
+		t.Fatal("/evaluate/utxos not reached through the capability gate")
 	}
 	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
 	if eu := result[key]; eu.Memory != 1700 || eu.Steps != 476468 {

--- a/backend/blockfrost/blockfrost_test.go
+++ b/backend/blockfrost/blockfrost_test.go
@@ -1209,13 +1209,13 @@ func TestEvaluateTxAdditionalUtxosReachableThroughCapabilityGate(t *testing.T) {
 		evaluateSimpleRetries, evaluateSimpleRetryWait = prevRetries, prevWait
 	}()
 
-	usedFallback := false
+	var usedFallback atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v0/utils/txs/evaluate":
 			_, _ = w.Write([]byte(`{"result":{"EvaluationFailure":{"UnknownInputs":["abc#0"]}}}`))
 		case "/api/v0/utils/txs/evaluate/utxos":
-			usedFallback = true
+			usedFallback.Store(true)
 			_, _ = w.Write([]byte(`{"result":{"EvaluationResult":{"spend:0":{"memory":1700,"steps":476468}}}}`))
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)
@@ -1234,7 +1234,7 @@ func TestEvaluateTxAdditionalUtxosReachableThroughCapabilityGate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !usedFallback {
+	if !usedFallback.Load() {
 		t.Fatal("/evaluate/utxos not reached through the capability gate")
 	}
 	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}

--- a/backend/blockfrost/doc.go
+++ b/backend/blockfrost/doc.go
@@ -1,0 +1,3 @@
+// Package blockfrost implements the Apollo chain backend on top of the hosted
+// Blockfrost HTTP API.
+package blockfrost

--- a/backend/cache/doc.go
+++ b/backend/cache/doc.go
@@ -1,0 +1,4 @@
+// Package cache wraps any chain backend with time-based caching of the
+// responses that rarely change, notably protocol and genesis parameters, to
+// cut repeated provider requests during a build.
+package cache

--- a/backend/doc.go
+++ b/backend/doc.go
@@ -1,0 +1,5 @@
+// Package backend defines the ChainContext interface Apollo uses to reach a
+// Cardano chain, along with the protocol and genesis parameter types, the
+// optional context-aware and capability-reporting extensions, and helpers
+// shared by the concrete backend implementations.
+package backend

--- a/backend/fixed/doc.go
+++ b/backend/fixed/doc.go
@@ -1,0 +1,4 @@
+// Package fixed provides an in-memory chain backend with preset protocol
+// parameters and UTxOs. It makes transaction building deterministic and
+// offline, which is what Apollo's own tests and examples use it for.
+package fixed

--- a/backend/maestro/doc.go
+++ b/backend/maestro/doc.go
@@ -1,0 +1,3 @@
+// Package maestro implements the Apollo chain backend on top of the hosted
+// Maestro HTTP API.
+package maestro

--- a/backend/ogmios/doc.go
+++ b/backend/ogmios/doc.go
@@ -1,0 +1,4 @@
+// Package ogmios implements the Apollo chain backend on top of Ogmios for
+// node queries, submission, and script evaluation, paired with Kupo for
+// address and UTxO lookups.
+package ogmios

--- a/backend/utxorpc/doc.go
+++ b/backend/utxorpc/doc.go
@@ -1,0 +1,4 @@
+// Package utxorpc implements the Apollo chain backend on top of the UTxO RPC
+// protocol. It prefers the utxorpc.v1beta services and falls back to v1alpha
+// for servers that expose only the older ones.
+package utxorpc

--- a/constants/doc.go
+++ b/constants/doc.go
@@ -1,0 +1,3 @@
+// Package constants holds shared Cardano values used across Apollo, such as
+// the minimum lovelace per output and the per-network Blockfrost base URLs.
+package constants

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,79 @@
+// Package apollo builds Cardano transactions in pure Go.
+//
+// A build starts from a chain backend and an [Apollo] value returned by [New].
+// Fluent methods accumulate inputs, outputs, scripts, certificates, metadata,
+// and governance actions. [Apollo.Complete] then balances the transaction,
+// selects change, and derives fees and Plutus execution units from the
+// backend's protocol parameters; [Apollo.Sign] attaches witnesses and
+// [Apollo.Submit] publishes the result.
+//
+// Ledger types come from github.com/blinklabs-io/gouroboros, so addresses,
+// values, scripts, and transaction bodies are the same types the rest of the
+// Blink Labs stack uses. Builder methods that cannot fail return *Apollo for
+// chaining and record any error internally; Complete reports it.
+//
+// # Quickstart
+//
+//	package main
+//
+//	import (
+//		"encoding/hex"
+//		"fmt"
+//
+//		"github.com/blinklabs-io/gouroboros/ledger/common"
+//
+//		apollo "github.com/Salvionied/apollo/v2"
+//		"github.com/Salvionied/apollo/v2/backend/blockfrost"
+//		"github.com/Salvionied/apollo/v2/constants"
+//	)
+//
+//	func main() {
+//		chainContext := blockfrost.NewBlockFrostChainContext(
+//			constants.BlockfrostBaseUrlMainnet,
+//			1, // mainnet network ID
+//			"your_blockfrost_project_id",
+//		)
+//
+//		builder, err := apollo.New(chainContext).
+//			SetWalletFromMnemonic("your mnemonic here")
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		utxos, err := chainContext.Utxos(builder.GetWallet().Address())
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		receiver, err := common.NewAddress("addr1...")
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		builder, err = builder.AddLoadedUTxOs(utxos...).
+//			PayToAddress(receiver, 1_000_000).
+//			Complete()
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		builder, err = builder.Sign()
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		txId, err := builder.Submit()
+//		if err != nil {
+//			panic(err)
+//		}
+//		fmt.Println(hex.EncodeToString(txId.Bytes()))
+//	}
+//
+// # Backends
+//
+// Every backend implements ChainContext from
+// [github.com/Salvionied/apollo/v2/backend]: blockfrost, maestro, ogmios (with
+// Kupo), and utxorpc for live chains, plus fixed for deterministic tests and
+// cache as a TTL wrapper. Backends may also report which optional operations
+// they support, so check backend.CapabilityReporter before depending on one.
+package apollo

--- a/plutusencoder/doc.go
+++ b/plutusencoder/doc.go
@@ -1,0 +1,4 @@
+// Package plutusencoder marshals Go structs to and from Plutus data using
+// plutusType and plutusConstr struct tags, so datums and redeemers can be
+// declared as ordinary Go types instead of assembled by hand.
+package plutusencoder


### PR DESCRIPTION
Four items. The first is the substantive one.

## The linux/386 CI gate proved nothing

The job ran `go build ./...`, which excludes `_test.go` files, so it passed while the test tree did not compile at 386:

```
$ GOOS=linux GOARCH=386 go vet ./...
vet: backend/blockfrost/blockfrost_test.go:577:20: constant 4294967295 overflows int
```

The root cause was not the test but the field: `bfAddressUTxO.OutputIndex` was declared `int`, i.e. **architecture-dependent**. That made the production guard `uint64(raw.OutputIndex) > uint64(math.MaxUint32)` provably dead on 386, where `int` maxes at 2^31−1, and made its own test inexpressible there. Widened to `int64`, so both the negative and over-range guards are live on every architecture and behavior no longer varies by word size.

CI now runs `go vet` **and** the full test suite under `GOARCH=386` (386 binaries execute natively on amd64 runners). Verified locally: all 11 packages pass at 386. A negative control confirms removing the range guard fails the tests *at 386*, which is the property that could not hold before.

Also added a test that drives the value through `json.Unmarshal` first — that matters, because with an `int` field a real Blockfrost response carrying `output_index: 4294967296` would have failed inside the decoder on 386, so the domain guard would never have run.

**Cost:** the 386 test step adds roughly 100s to the quality job.

## Blockfrost declined a capability it actually supports

Since the builder began gating on `CapabilityEvaluateTxAdditionalUtxos`, Blockfrost's `/utils/txs/evaluate/utxos` fallback became **unreachable dead code** — a regression for users spending chained or indexing-lagged inputs. Blockfrost does honour the argument: it retries the plain endpoint for indexing lag, then posts the resolved set. Its one skip path (additional UTxOs carrying native assets) returns an **explicit evaluation error**, never a silently ignored argument or an understated budget, so it satisfies the documented contract. `Capabilities()` now reports it.

The new test reproduces the caller-side gate rather than calling `EvaluateTx` directly — the pre-existing fallback test passes either way, so it could not have caught this.

**Behaviour change to note:** the builder now forwards resolved spending inputs to Blockfrost, so `backend.ValidateAdditionalUtxo` runs on them where it previously did not. Consistent with ogmios and maestro, but it is a change on the failure path.

## `.gitignore` — no change needed

The premise was wrong. All five entries are already present. `git check-ignore .worktrees` appearing to fail was an artefact of running it where the directory did not exist: these are directory-only patterns, which cannot match a non-existent path. Confirmed end-to-end that `git add -A` will not stage any of them.

## Package documentation

Only `internal/backendutil` had a package comment, so `go doc` rendered a bare symbol index — and pkg.go.dev is where most Go users land first. Added `doc.go` to the other 10 packages; all 11 now report a doc. The root overview includes a quickstart verified by extracting the block into a temp module with a `replace` directive and building it, so what is published is exactly what compiled.
