### PR TITLE
refactor(ogmios)!: construct the chain context without naming client types

### DIFF
--- a/backend/ogmios/client.go
+++ b/backend/ogmios/client.go
@@ -1,0 +1,342 @@
+package ogmios
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/SundaeSwap-finance/kugo"
+	ogmigo "github.com/SundaeSwap-finance/ogmigo/v6"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// OgmiosClient is the Ogmios query surface OgmiosChainContext depends on.
+//
+// Apollo owns this interface: no method names a type from the library used to
+// talk to Ogmios, so that library's major version stays an implementation
+// detail of this package instead of part of Apollo's public API.
+// NewOgmiosChainContext builds the default implementation from connection
+// settings; NewOgmiosChainContextFromClients accepts any other, which is the
+// seam tests and custom transports use.
+//
+// Protocol parameters and the genesis configuration are returned as the raw
+// Ogmios JSON result because Apollo, not the client, owns their decoding: the
+// wire shapes have changed across Ogmios releases and the conversions live
+// here. The remaining results are Cardano domain values, which spares
+// implementations from mirroring an Ogmios wire type.
+type OgmiosClient interface {
+	// ProtocolParameters returns the queryLedgerState/protocolParameters
+	// result as sent by Ogmios.
+	ProtocolParameters(ctx context.Context) (json.RawMessage, error)
+	// GenesisConfig returns the queryNetwork/genesisConfiguration result for
+	// an era ("shelley", "byron", ...) as sent by Ogmios.
+	GenesisConfig(ctx context.Context, era string) (json.RawMessage, error)
+	// CurrentEpoch returns the epoch the ledger is in.
+	CurrentEpoch(ctx context.Context) (uint64, error)
+	// Tip returns the slot of the current chain tip. A chain sitting at
+	// origin has no slot and is an error.
+	Tip(ctx context.Context) (uint64, error)
+	// SubmitTx submits a serialized transaction and returns its hash.
+	SubmitTx(ctx context.Context, txCbor []byte) (common.Blake2b256, error)
+	// EvaluateTx returns the execution units each redeemer of a serialized
+	// transaction requires. additionalUtxos carries resolved UTxOs the
+	// evaluator cannot see on-chain.
+	EvaluateTx(
+		ctx context.Context,
+		txCbor []byte,
+		additionalUtxos []common.Utxo,
+	) (map[common.RedeemerKey]common.ExUnits, error)
+	// UtxoByRef resolves one UTxO by its output reference.
+	UtxoByRef(
+		ctx context.Context,
+		txHash common.Blake2b256,
+		index uint32,
+	) (*common.Utxo, error)
+}
+
+// KupoClient is the Kupo query surface OgmiosChainContext depends on. Ogmios
+// cannot answer address UTxO queries or resolve a script by hash, so a
+// context built without a Kupo client reports neither CapabilityUtxos nor
+// CapabilityScriptCbor. Like OgmiosClient, it names no third-party type.
+type KupoClient interface {
+	// UtxosAtAddress returns the unspent outputs at an address.
+	UtxosAtAddress(
+		ctx context.Context,
+		address common.Address,
+	) ([]common.Utxo, error)
+	// ScriptCbor returns the CBOR of the script with the given hash.
+	ScriptCbor(
+		ctx context.Context,
+		scriptHash common.Blake2b224,
+	) ([]byte, error)
+}
+
+// ogmiosWebsocketURL validates an Ogmios endpoint and returns the URL to
+// dial. Ogmios serves JSON-RPC over WebSocket, so an http or https URL is
+// accepted and dialed as ws or wss rather than rejected.
+func ogmiosWebsocketURL(endpoint string) (string, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return "", errors.New("ogmios endpoint is required")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf(
+			"invalid ogmios endpoint %q: %w", endpoint, err,
+		)
+	}
+	switch parsed.Scheme {
+	case "ws", "wss":
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		return "", fmt.Errorf(
+			"invalid ogmios endpoint %q: scheme must be ws, wss, http,"+
+				" or https", endpoint,
+		)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf(
+			"invalid ogmios endpoint %q: missing host", endpoint,
+		)
+	}
+	return parsed.String(), nil
+}
+
+// kupoBaseURL validates a Kupo endpoint and returns the base URL to request.
+// Kupo is a plain HTTP service; its paths are appended by the client, so any
+// trailing slash is dropped here.
+func kupoBaseURL(endpoint string) (string, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return "", errors.New("kupo endpoint is required")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid kupo endpoint %q: %w", endpoint, err)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		return "", fmt.Errorf(
+			"invalid kupo endpoint %q: scheme must be http or https",
+			endpoint,
+		)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf(
+			"invalid kupo endpoint %q: missing host", endpoint,
+		)
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+// ogmigoClient adapts the ogmigo client to OgmiosClient. Every ogmigo call
+// Apollo makes goes through this type, so moving to a new major version of
+// ogmigo is a change to this file alone.
+type ogmigoClient struct {
+	client *ogmigo.Client
+}
+
+var _ OgmiosClient = (*ogmigoClient)(nil)
+
+// newOgmigoClient builds the default OgmiosClient for an endpoint. It
+// performs no I/O; the connection is made per query.
+func newOgmigoClient(endpoint string) (*ogmigoClient, error) {
+	websocketURL, err := ogmiosWebsocketURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &ogmigoClient{
+		client: ogmigo.New(ogmigo.WithEndpoint(websocketURL)),
+	}, nil
+}
+
+func (c *ogmigoClient) ProtocolParameters(
+	ctx context.Context,
+) (json.RawMessage, error) {
+	return c.client.CurrentProtocolParameters(ctx)
+}
+
+func (c *ogmigoClient) GenesisConfig(
+	ctx context.Context,
+	era string,
+) (json.RawMessage, error) {
+	return c.client.GenesisConfig(ctx, era)
+}
+
+func (c *ogmigoClient) CurrentEpoch(ctx context.Context) (uint64, error) {
+	return c.client.CurrentEpoch(ctx)
+}
+
+func (c *ogmigoClient) Tip(ctx context.Context) (uint64, error) {
+	point, err := c.client.ChainTip(ctx)
+	if err != nil {
+		return 0, err
+	}
+	ps, ok := point.PointStruct()
+	if !ok || ps == nil {
+		return 0, errors.New("chain tip is origin")
+	}
+	return ps.Slot, nil
+}
+
+func (c *ogmigoClient) SubmitTx(
+	ctx context.Context,
+	txCbor []byte,
+) (common.Blake2b256, error) {
+	resp, err := c.client.SubmitTx(ctx, hex.EncodeToString(txCbor))
+	if err != nil {
+		return common.Blake2b256{}, err
+	}
+	if resp == nil {
+		return common.Blake2b256{}, errors.New("empty submit tx response")
+	}
+	if resp.Error != nil {
+		return common.Blake2b256{}, fmt.Errorf(
+			"submit tx error: %s", resp.Error.Message,
+		)
+	}
+	hashBytes, err := hex.DecodeString(resp.ID)
+	if err != nil {
+		return common.Blake2b256{}, err
+	}
+	if len(hashBytes) != common.Blake2b256Size {
+		return common.Blake2b256{}, fmt.Errorf(
+			"invalid tx hash length: expected %d bytes, got %d",
+			common.Blake2b256Size, len(hashBytes),
+		)
+	}
+	var result common.Blake2b256
+	copy(result[:], hashBytes)
+	return result, nil
+}
+
+func (c *ogmigoClient) EvaluateTx(
+	ctx context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	txHex := hex.EncodeToString(txCbor)
+	var resp *ogmigo.EvaluateTxResponse
+	var err error
+	if len(additionalUtxos) > 0 {
+		// Ogmios natively accepts a set of resolved UTxOs so it can evaluate
+		// inputs that are not yet visible on-chain.
+		sharedUtxos, convErr := commonUtxosToShared(additionalUtxos)
+		if convErr != nil {
+			return nil, convErr
+		}
+		resp, err = c.client.EvaluateTxWithAdditionalUtxos(
+			ctx, txHex, sharedUtxos,
+		)
+	} else {
+		resp, err = c.client.EvaluateTx(ctx, txHex)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return evaluateResponseToExUnits(resp)
+}
+
+func (c *ogmigoClient) UtxoByRef(
+	ctx context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
+	query := chainsync.TxInQuery{
+		Transaction: shared.UtxoTxID{
+			ID: hex.EncodeToString(txHash.Bytes()),
+		},
+		Index: index,
+	}
+	utxos, err := c.client.UtxosByTxIn(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(utxos) == 0 {
+		return nil, errors.New("utxo not found")
+	}
+
+	raw := utxos[0]
+	addr, err := common.NewAddress(raw.Address)
+	if err != nil {
+		return nil, err
+	}
+	result, err := ogmiosUtxoToCommon(raw, addr)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// kugoClient adapts the kugo client to KupoClient. As with ogmigoClient,
+// every kugo call Apollo makes goes through this type.
+type kugoClient struct {
+	client *kugo.Client
+}
+
+var _ KupoClient = (*kugoClient)(nil)
+
+// newKugoClient builds the default KupoClient for an endpoint. A zero timeout
+// leaves the kugo default in place.
+func newKugoClient(
+	endpoint string,
+	timeout time.Duration,
+) (*kugoClient, error) {
+	baseURL, err := kupoBaseURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	options := []kugo.Option{kugo.WithEndpoint(baseURL)}
+	if timeout > 0 {
+		options = append(options, kugo.WithTimeout(timeout))
+	}
+	return &kugoClient{client: kugo.New(options...)}, nil
+}
+
+func (c *kugoClient) UtxosAtAddress(
+	ctx context.Context,
+	address common.Address,
+) ([]common.Utxo, error) {
+	matches, err := c.client.Matches(
+		ctx, kugo.OnlyUnspent(), kugo.Address(address.String()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var utxos []common.Utxo
+	for _, match := range matches {
+		// The client doubles as the datum fetcher: kupo reports only the
+		// datum hash in a match, so inline datums are resolved separately.
+		utxo, err := matchToUtxo(ctx, match, address, c.client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse UTxO match: %w", err)
+		}
+		utxos = append(utxos, utxo)
+	}
+	return utxos, nil
+}
+
+func (c *kugoClient) ScriptCbor(
+	ctx context.Context,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
+	hashHex := hex.EncodeToString(scriptHash.Bytes())
+	script, err := c.client.Script(ctx, hashHex)
+	if err != nil {
+		return nil, err
+	}
+	if script == nil {
+		return nil, fmt.Errorf("kupo returned no script for %s", hashHex)
+	}
+	return hex.DecodeString(script.Script)
+}

--- a/backend/ogmios/client_test.go
+++ b/backend/ogmios/client_test.go
@@ -1,0 +1,619 @@
+package ogmios
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+
+	"github.com/Salvionied/apollo/v2/backend"
+)
+
+// testOgmiosEndpoint is a syntactically valid Ogmios endpoint. Constructing a
+// context performs no I/O, so no test that uses it reaches the network.
+const testOgmiosEndpoint = "ws://127.0.0.1:1337"
+
+// testChainContext builds a context from cfg, failing the test if the
+// configuration is rejected.
+func testChainContext(t *testing.T, cfg Config) *OgmiosChainContext {
+	t.Helper()
+	ctx, err := NewOgmiosChainContext(cfg)
+	if err != nil {
+		t.Fatalf("NewOgmiosChainContext(%+v): %v", cfg, err)
+	}
+	return ctx
+}
+
+// TestNewOgmiosChainContextRejectsInvalidConfig keeps an unusable
+// configuration from producing a context that fails - or panics - later. The
+// constructor is the only place that can still report the problem to the
+// caller as a configuration error.
+func TestNewOgmiosChainContextRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name:    "zero config",
+			cfg:     Config{},
+			wantErr: "ogmios endpoint is required",
+		},
+		{
+			name:    "blank ogmios endpoint",
+			cfg:     Config{OgmiosEndpoint: "   "},
+			wantErr: "ogmios endpoint is required",
+		},
+		{
+			name:    "bare host and port",
+			cfg:     Config{OgmiosEndpoint: "127.0.0.1:1337"},
+			wantErr: "invalid ogmios endpoint",
+		},
+		{
+			name:    "ogmios endpoint without scheme",
+			cfg:     Config{OgmiosEndpoint: "localhost:1337"},
+			wantErr: "scheme must be ws, wss, http, or https",
+		},
+		{
+			name:    "ogmios endpoint with unusable scheme",
+			cfg:     Config{OgmiosEndpoint: "ftp://127.0.0.1:1337"},
+			wantErr: "scheme must be ws, wss, http, or https",
+		},
+		{
+			name:    "ogmios endpoint without host",
+			cfg:     Config{OgmiosEndpoint: "ws:///tip"},
+			wantErr: "missing host",
+		},
+		{
+			name:    "unparseable ogmios endpoint",
+			cfg:     Config{OgmiosEndpoint: "://127.0.0.1:1337"},
+			wantErr: "invalid ogmios endpoint",
+		},
+		{
+			name: "kupo endpoint with unusable scheme",
+			cfg: Config{
+				OgmiosEndpoint: testOgmiosEndpoint,
+				KupoEndpoint:   "ws://127.0.0.1:1442",
+			},
+			wantErr: "scheme must be http or https",
+		},
+		{
+			name: "kupo endpoint without host",
+			cfg: Config{
+				OgmiosEndpoint: testOgmiosEndpoint,
+				KupoEndpoint:   "http:///matches",
+			},
+			wantErr: "missing host",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, err := NewOgmiosChainContext(test.cfg)
+			if err == nil {
+				t.Fatalf("expected %+v to be rejected", test.cfg)
+			}
+			if ctx != nil {
+				t.Fatal("a rejected configuration must not yield a context")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// TestNewOgmiosChainContextAcceptsEndpointSchemes covers the endpoints a
+// caller can reasonably supply. Ogmios speaks JSON-RPC over WebSocket, so an
+// http URL is dialed as ws rather than rejected.
+func TestNewOgmiosChainContextAcceptsEndpointSchemes(t *testing.T) {
+	for _, endpoint := range []string{
+		"ws://127.0.0.1:1337",
+		"wss://ogmios.example:443",
+		"http://127.0.0.1:1337",
+		"https://ogmios.example",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			testChainContext(t, Config{OgmiosEndpoint: endpoint})
+		})
+	}
+}
+
+// TestNewOgmiosChainContextDialsConfiguredEndpoint proves the constructor
+// wires its Config through to a working Ogmios client: the query reaches the
+// configured host as a WebSocket upgrade even though the endpoint was given
+// as an http URL. The server answers with a plain HTTP response, so the
+// handshake fails and the query returns an error rather than hanging.
+func TestNewOgmiosChainContextDialsConfiguredEndpoint(t *testing.T) {
+	var upgrades atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+				upgrades.Add(1)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+		},
+	))
+	t.Cleanup(server.Close)
+
+	ctx := testChainContext(t, Config{
+		OgmiosEndpoint: server.URL,
+		NetworkId:      1,
+	})
+	if got := ctx.NetworkId(); got != 1 {
+		t.Fatalf("NetworkId() = %d, want 1", got)
+	}
+	if _, err := ctx.CurrentEpochContext(t.Context()); err == nil {
+		t.Fatal("expected a handshake failure against a plain HTTP server")
+	}
+	if got := upgrades.Load(); got != 1 {
+		t.Fatalf("websocket upgrade attempts = %d, want 1", got)
+	}
+}
+
+// kupoServer serves the two Kupo endpoints Apollo queries: the match list
+// behind Utxos and the script lookup behind ScriptCbor.
+func kupoServer(t *testing.T, scriptCborHex string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/v1/matches"):
+				_, _ = w.Write([]byte(`[{
+					"transaction_id": "` + testTxHashHex + `",
+					"output_index": 1,
+					"value": {"ada": {"lovelace": 2000000}}
+				}]`))
+			case strings.HasPrefix(r.URL.Path, "/v1/scripts/"):
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"language": "plutus:v2",
+					"script":   scriptCborHex,
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		},
+	))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestNewOgmiosChainContextQueriesKupo exercises the Kupo half of a context
+// built from a Config end to end: settings in, client built internally,
+// responses decoded into gouroboros types.
+func TestNewOgmiosChainContextQueriesKupo(t *testing.T) {
+	const scriptCborHex = "49480100"
+	server := kupoServer(t, scriptCborHex)
+
+	ctx := testChainContext(t, Config{
+		OgmiosEndpoint: testOgmiosEndpoint,
+		KupoEndpoint:   server.URL,
+		KupoTimeout:    5 * time.Second,
+	})
+	if !backend.Supports(
+		ctx, backend.CapabilityUtxos|backend.CapabilityScriptCbor,
+	) {
+		t.Fatal("a context configured with Kupo must report its capabilities")
+	}
+
+	utxos, err := ctx.UtxosContext(t.Context(), testAddress(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) != 1 {
+		t.Fatalf("utxos = %d, want 1", len(utxos))
+	}
+	if got := utxos[0].Id.Index(); got != 1 {
+		t.Fatalf("output index = %d, want 1", got)
+	}
+	if got := hex.EncodeToString(utxos[0].Id.Id().Bytes()); got != testTxHashHex {
+		t.Fatalf("tx hash = %s, want %s", got, testTxHashHex)
+	}
+	if got := utxos[0].Output.Amount(); got.Int64() != 2_000_000 {
+		t.Fatalf("lovelace = %s, want 2000000", got)
+	}
+
+	var scriptHash common.Blake2b224
+	scriptCbor, err := ctx.ScriptCborContext(t.Context(), scriptHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(scriptCbor); got != scriptCborHex {
+		t.Fatalf("script cbor = %s, want %s", got, scriptCborHex)
+	}
+}
+
+// stubOgmiosClient is a canned OgmiosClient. Implementing the whole interface
+// in a handful of lines is the point: the injection seam stays usable without
+// a server, and without naming a type Apollo does not own.
+type stubOgmiosClient struct {
+	protocolParams json.RawMessage
+	genesis        json.RawMessage
+	epoch          uint64
+	tip            uint64
+	txHash         common.Blake2b256
+	exUnits        map[common.RedeemerKey]common.ExUnits
+	utxo           *common.Utxo
+
+	// Recorded arguments.
+	eras            []string
+	submitted       []byte
+	evaluated       []byte
+	additionalUtxos []common.Utxo
+	refs            []string
+}
+
+var _ OgmiosClient = (*stubOgmiosClient)(nil)
+
+func (s *stubOgmiosClient) ProtocolParameters(
+	_ context.Context,
+) (json.RawMessage, error) {
+	return s.protocolParams, nil
+}
+
+func (s *stubOgmiosClient) GenesisConfig(
+	_ context.Context,
+	era string,
+) (json.RawMessage, error) {
+	s.eras = append(s.eras, era)
+	return s.genesis, nil
+}
+
+func (s *stubOgmiosClient) CurrentEpoch(_ context.Context) (uint64, error) {
+	return s.epoch, nil
+}
+
+func (s *stubOgmiosClient) Tip(_ context.Context) (uint64, error) {
+	return s.tip, nil
+}
+
+func (s *stubOgmiosClient) SubmitTx(
+	_ context.Context,
+	txCbor []byte,
+) (common.Blake2b256, error) {
+	s.submitted = txCbor
+	return s.txHash, nil
+}
+
+func (s *stubOgmiosClient) EvaluateTx(
+	_ context.Context,
+	txCbor []byte,
+	additionalUtxos []common.Utxo,
+) (map[common.RedeemerKey]common.ExUnits, error) {
+	s.evaluated = txCbor
+	s.additionalUtxos = additionalUtxos
+	return s.exUnits, nil
+}
+
+func (s *stubOgmiosClient) UtxoByRef(
+	_ context.Context,
+	txHash common.Blake2b256,
+	index uint32,
+) (*common.Utxo, error) {
+	s.refs = append(
+		s.refs,
+		hex.EncodeToString(txHash.Bytes())+
+			"#"+strconv.FormatUint(uint64(index), 10),
+	)
+	return s.utxo, nil
+}
+
+// stubKupoClient is a canned KupoClient.
+type stubKupoClient struct {
+	utxos      []common.Utxo
+	scriptCbor []byte
+
+	addresses []string
+	hashes    []string
+}
+
+var _ KupoClient = (*stubKupoClient)(nil)
+
+func (s *stubKupoClient) UtxosAtAddress(
+	_ context.Context,
+	address common.Address,
+) ([]common.Utxo, error) {
+	s.addresses = append(s.addresses, address.String())
+	return s.utxos, nil
+}
+
+func (s *stubKupoClient) ScriptCbor(
+	_ context.Context,
+	scriptHash common.Blake2b224,
+) ([]byte, error) {
+	s.hashes = append(s.hashes, hex.EncodeToString(scriptHash.Bytes()))
+	return s.scriptCbor, nil
+}
+
+// testStubUtxo is a resolved UTxO the stubs can hand back.
+func testStubUtxo(t *testing.T) common.Utxo {
+	t.Helper()
+	var txId common.Blake2b256
+	for i := range txId {
+		txId[i] = 0x22
+	}
+	return common.Utxo{
+		Id: shelley.ShelleyTransactionInput{TxId: txId, OutputIndex: 7},
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: testAddress(t),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 3_000_000},
+		},
+	}
+}
+
+// TestInjectedClientsServeEveryChainContextMethod walks the whole
+// ChainContext surface against the stubs: every method must go through the
+// injected clients, and Apollo must still own the decoding of the responses
+// it asked for as raw JSON.
+func TestInjectedClientsServeEveryChainContextMethod(t *testing.T) {
+	var txHash common.Blake2b256
+	for i := range txHash {
+		txHash[i] = 0x33
+	}
+	utxo := testStubUtxo(t)
+	ogmiosClient := &stubOgmiosClient{
+		protocolParams: json.RawMessage(protocolParamsBody(adaLovelace)),
+		genesis:        json.RawMessage(ogmiosV6ShelleyGenesisBody),
+		epoch:          507,
+		tip:            123456,
+		txHash:         txHash,
+		exUnits: map[common.RedeemerKey]common.ExUnits{
+			{Tag: common.RedeemerTagSpend, Index: 0}: {
+				Memory: 1700,
+				Steps:  476468,
+			},
+		},
+		utxo: &utxo,
+	}
+	kupoClient := &stubKupoClient{
+		utxos:      []common.Utxo{utxo},
+		scriptCbor: []byte{0x49, 0x48, 0x01, 0x00},
+	}
+	ctx, err := NewOgmiosChainContextFromClients(ogmiosClient, kupoClient, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !backend.Supports(
+		ctx, backend.CapabilityUtxos|backend.CapabilityScriptCbor,
+	) {
+		t.Fatal("an injected Kupo client must report its capabilities")
+	}
+	if got := ctx.NetworkId(); got != 1 {
+		t.Fatalf("NetworkId() = %d, want 1", got)
+	}
+
+	pp, err := ctx.ProtocolParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOgmiosV6ProtocolParams(t, pp)
+
+	gp, err := ctx.GenesisParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := gp.NetworkMagic, 764824073; got != want {
+		t.Fatalf("NetworkMagic = %d, want %d", got, want)
+	}
+	if len(ogmiosClient.eras) != 1 || ogmiosClient.eras[0] != "shelley" {
+		t.Fatalf("genesis eras queried = %v, want [shelley]", ogmiosClient.eras)
+	}
+
+	if epoch, err := ctx.CurrentEpoch(); err != nil || epoch != 507 {
+		t.Fatalf("CurrentEpoch() = %d, %v, want 507, nil", epoch, err)
+	}
+	if tip, err := ctx.Tip(); err != nil || tip != 123456 {
+		t.Fatalf("Tip() = %d, %v, want 123456, nil", tip, err)
+	}
+	if fee, err := ctx.MaxTxFee(); err != nil || fee == 0 {
+		t.Fatalf("MaxTxFee() = %d, %v, want a nonzero fee", fee, err)
+	}
+
+	txCbor := []byte{0x84, 0xA0}
+	hash, err := ctx.SubmitTx(txCbor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != txHash {
+		t.Fatalf("SubmitTx hash = %x, want %x", hash, txHash)
+	}
+	if string(ogmiosClient.submitted) != string(txCbor) {
+		t.Fatalf("submitted CBOR = %x, want %x", ogmiosClient.submitted, txCbor)
+	}
+
+	additional := []common.Utxo{sampleCommonUtxo(t)}
+	exUnits, err := ctx.EvaluateTx(txCbor, additional)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	if eu := exUnits[key]; eu.Memory != 1700 || eu.Steps != 476468 {
+		t.Fatalf("unexpected budget %+v", eu)
+	}
+	if len(ogmiosClient.additionalUtxos) != 1 {
+		t.Fatalf(
+			"additional UTxOs forwarded = %d, want 1",
+			len(ogmiosClient.additionalUtxos),
+		)
+	}
+
+	byRef, err := ctx.UtxoByRef(txHash, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if byRef == nil || byRef.Id.Index() != 7 {
+		t.Fatalf("UtxoByRef() = %+v, want the stub UTxO", byRef)
+	}
+
+	utxos, err := ctx.Utxos(testAddress(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) != 1 {
+		t.Fatalf("Utxos() returned %d UTxOs, want 1", len(utxos))
+	}
+	if len(kupoClient.addresses) != 1 ||
+		kupoClient.addresses[0] != testAddress(t).String() {
+		t.Fatalf("queried addresses = %v", kupoClient.addresses)
+	}
+
+	scriptCbor, err := ctx.ScriptCbor(common.Blake2b224{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scriptCbor) != 4 {
+		t.Fatalf("ScriptCbor() = %x, want 4 bytes", scriptCbor)
+	}
+}
+
+// TestEvaluateTxValidatesAdditionalUtxosForEveryClient keeps the malformed
+// additional UTxO check in the context, where it holds no matter which client
+// is injected.
+func TestEvaluateTxValidatesAdditionalUtxosForEveryClient(t *testing.T) {
+	ogmiosClient := &stubOgmiosClient{}
+	ctx, err := NewOgmiosChainContextFromClients(ogmiosClient, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	malformed := []common.Utxo{{Output: sampleCommonUtxo(t).Output}}
+	if _, err := ctx.EvaluateTx([]byte{0x84}, malformed); err == nil {
+		t.Fatal("expected malformed UTxO error")
+	} else if !strings.Contains(err.Error(), "missing transaction input") {
+		t.Fatalf("error = %q, want a missing-input error", err)
+	}
+	if ogmiosClient.evaluated != nil {
+		t.Fatal("a malformed UTxO must not reach the client")
+	}
+}
+
+// TestNewOgmiosChainContextFromClientsRejectsNilOgmiosClient covers both
+// spellings of a missing client: an untyped nil and a nil pointer stored in
+// the interface. Neither may produce a context that fails on first use.
+func TestNewOgmiosChainContextFromClientsRejectsNilOgmiosClient(t *testing.T) {
+	var typedNil *stubOgmiosClient
+	clients := []struct {
+		name   string
+		client OgmiosClient
+	}{
+		{"untyped nil", nil},
+		{"typed nil", typedNil},
+	}
+	for _, test := range clients {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, err := NewOgmiosChainContextFromClients(test.client, nil, 0)
+			if err == nil {
+				t.Fatal("expected a missing Ogmios client to be rejected")
+			}
+			if ctx != nil {
+				t.Fatal("a rejected client must not yield a context")
+			}
+		})
+	}
+}
+
+// TestNewOgmiosChainContextFromClientsNormalizesTypedNilKupo keeps a nil
+// pointer passed as the Kupo client from being reported as a working one.
+func TestNewOgmiosChainContextFromClientsNormalizesTypedNilKupo(t *testing.T) {
+	var typedNil *stubKupoClient
+	ctx, err := NewOgmiosChainContextFromClients(
+		&stubOgmiosClient{}, typedNil, 0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if backend.Supports(
+		ctx, backend.CapabilityUtxos|backend.CapabilityScriptCbor,
+	) {
+		t.Fatal("a nil Kupo client must not report Kupo capabilities")
+	}
+	if _, err := ctx.Utxos(testAddress(t)); !errors.Is(
+		err, backend.ErrUnsupported,
+	) {
+		t.Fatalf("Utxos() error = %v, want ErrUnsupported", err)
+	}
+}
+
+// TestZeroValueChainContextReturnsErrors pins the audit fix: a context no
+// constructor produced has no client, and every method must report that
+// rather than dereference nil.
+func TestZeroValueChainContextReturnsErrors(t *testing.T) {
+	ctx := &OgmiosChainContext{}
+
+	if got := ctx.NetworkId(); got != 0 {
+		t.Fatalf("NetworkId() = %d, want 0", got)
+	}
+	if backend.Supports(ctx, backend.CapabilityUtxos) {
+		t.Fatal("a context without a Kupo client must not report Utxos")
+	}
+
+	tests := []struct {
+		name string
+		want error
+		call func() error
+	}{
+		{"ProtocolParams", errNoOgmiosClient, func() error {
+			_, err := ctx.ProtocolParams()
+			return err
+		}},
+		{"GenesisParams", errNoOgmiosClient, func() error {
+			_, err := ctx.GenesisParams()
+			return err
+		}},
+		{"CurrentEpoch", errNoOgmiosClient, func() error {
+			_, err := ctx.CurrentEpoch()
+			return err
+		}},
+		{"MaxTxFee", errNoOgmiosClient, func() error {
+			_, err := ctx.MaxTxFee()
+			return err
+		}},
+		{"Tip", errNoOgmiosClient, func() error {
+			_, err := ctx.Tip()
+			return err
+		}},
+		{"SubmitTx", errNoOgmiosClient, func() error {
+			_, err := ctx.SubmitTx([]byte{0x84})
+			return err
+		}},
+		{"EvaluateTx", errNoOgmiosClient, func() error {
+			_, err := ctx.EvaluateTx([]byte{0x84}, nil)
+			return err
+		}},
+		{"UtxoByRef", errNoOgmiosClient, func() error {
+			_, err := ctx.UtxoByRef(common.Blake2b256{}, 0)
+			return err
+		}},
+		{"Utxos", backend.ErrUnsupported, func() error {
+			_, err := ctx.Utxos(testAddress(t))
+			return err
+		}},
+		{"ScriptCbor", backend.ErrUnsupported, func() error {
+			_, err := ctx.ScriptCbor(common.Blake2b224{})
+			return err
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}

--- a/backend/ogmios/client_test.go
+++ b/backend/ogmios/client_test.go
@@ -555,8 +555,8 @@ func TestZeroValueChainContextReturnsErrors(t *testing.T) {
 	if got := ctx.NetworkId(); got != 0 {
 		t.Fatalf("NetworkId() = %d, want 0", got)
 	}
-	if backend.Supports(ctx, backend.CapabilityUtxos) {
-		t.Fatal("a context without a Kupo client must not report Utxos")
+	if got := ctx.Capabilities(); got != 0 {
+		t.Fatalf("Capabilities() = %v, want no capabilities", got)
 	}
 
 	tests := []struct {

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/SundaeSwap-finance/kugo"
 	ogmigo "github.com/SundaeSwap-finance/ogmigo/v6"
-	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -29,31 +29,141 @@ import (
 
 // OgmiosChainContext implements backend.ChainContext using Ogmios + Kupo.
 type OgmiosChainContext struct {
-	ogmios    *ogmigo.Client
-	kupo      *kugo.Client
+	ogmios    OgmiosClient
+	kupo      KupoClient
 	networkId uint8
 }
 
 var _ backend.ContextChainContext = (*OgmiosChainContext)(nil)
+
+// Config describes how an OgmiosChainContext reaches its services. Apollo
+// owns this type, so which client libraries this package builds - and which
+// major versions of them - stay an implementation detail.
+type Config struct {
+	// OgmiosEndpoint is the Ogmios JSON-RPC endpoint, e.g.
+	// "ws://localhost:1337". Ogmios is reached over WebSocket, so http and
+	// https URLs are accepted and dialed as ws and wss. Required.
+	OgmiosEndpoint string
+	// KupoEndpoint is the base URL of a Kupo instance, e.g.
+	// "http://localhost:1442". Optional: a context configured without one
+	// answers every query Ogmios serves on its own, and reports neither
+	// CapabilityUtxos nor CapabilityScriptCbor.
+	KupoEndpoint string
+	// NetworkId is the Cardano network identifier reported by NetworkId()
+	// (mainnet = 1, testnets = 0).
+	NetworkId uint8
+	// KupoTimeout bounds each Kupo HTTP request. Zero leaves the Kupo client
+	// default in place.
+	KupoTimeout time.Duration
+}
+
+// NewOgmiosChainContext creates an Ogmios chain context from connection
+// settings, building the Ogmios and Kupo clients internally. An endpoint that
+// is empty, or is not a URL Apollo can reach the service at, is rejected here
+// rather than failing on the first query.
+func NewOgmiosChainContext(cfg Config) (*OgmiosChainContext, error) {
+	ogmiosClient, err := newOgmigoClient(cfg.OgmiosEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	chainCtx := &OgmiosChainContext{
+		ogmios:    ogmiosClient,
+		networkId: cfg.NetworkId,
+	}
+	if cfg.KupoEndpoint != "" {
+		kupoClient, err := newKugoClient(cfg.KupoEndpoint, cfg.KupoTimeout)
+		if err != nil {
+			return nil, err
+		}
+		chainCtx.kupo = kupoClient
+	}
+	return chainCtx, nil
+}
+
+// NewOgmiosChainContextFromClients creates an Ogmios chain context from
+// caller-supplied clients. It is the escape hatch for tests and for callers
+// whose transport Config cannot express; both interfaces are Apollo's own, so
+// injecting a client does not pin Apollo to a client library.
+//
+// ogmiosClient is required. kupoClient may be nil, in which case the context
+// reports neither CapabilityUtxos nor CapabilityScriptCbor.
+func NewOgmiosChainContextFromClients(
+	ogmiosClient OgmiosClient,
+	kupoClient KupoClient,
+	networkId uint8,
+) (*OgmiosChainContext, error) {
+	if isNilClient(ogmiosClient) {
+		return nil, errors.New("ogmios client is required")
+	}
+	chainCtx := &OgmiosChainContext{
+		ogmios:    ogmiosClient,
+		networkId: networkId,
+	}
+	// A typed nil is normalized to a nil field so Capabilities reports the
+	// Kupo-less feature set instead of the context failing on first use.
+	if !isNilClient(kupoClient) {
+		chainCtx.kupo = kupoClient
+	}
+	return chainCtx, nil
+}
+
+// isNilClient reports whether an interface value is nil or holds a nil
+// pointer. A typed nil pointer still satisfies its interface, so without this
+// check it would pass the constructor and panic on first use.
+func isNilClient(client any) bool {
+	if client == nil {
+		return true
+	}
+	value := reflect.ValueOf(client)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// errNoOgmiosClient reports a context that no constructor produced - a zero
+// value, say - and so has no client to query. Methods return it instead of
+// dereferencing a nil client.
+var errNoOgmiosClient = errors.New(
+	"ogmios chain context has no Ogmios client: build it with" +
+		" NewOgmiosChainContext or NewOgmiosChainContextFromClients",
+)
+
+// client returns the configured Ogmios client, or errNoOgmiosClient.
+func (o *OgmiosChainContext) client() (OgmiosClient, error) {
+	if o == nil || o.ogmios == nil {
+		return nil, errNoOgmiosClient
+	}
+	return o.ogmios, nil
+}
+
+// kupoClient returns the configured Kupo client, or an UnsupportedError
+// naming the capability the missing client would have provided.
+func (o *OgmiosChainContext) kupoClient(
+	capability backend.Capability,
+) (KupoClient, error) {
+	if o == nil || o.kupo == nil {
+		return nil, backend.NewUnsupportedError(
+			"Ogmios without Kupo", capability,
+		)
+	}
+	return o.kupo, nil
+}
 
 // Capabilities reports the operations supported by the configured Ogmios
 // client. Address UTxO queries and script lookup require the optional Kupo
 // client; UTxO-by-reference queries are served directly by Ogmios.
 func (o *OgmiosChainContext) Capabilities() backend.CapabilitySet {
 	capabilities := backend.CapabilitySet(backend.AllCapabilities)
-	if o.kupo == nil {
-		capabilities &^= backend.CapabilitySet(backend.CapabilityUtxos | backend.CapabilityScriptCbor)
+	if o == nil || o.kupo == nil {
+		capabilities &^= backend.CapabilitySet(
+			backend.CapabilityUtxos | backend.CapabilityScriptCbor,
+		)
 	}
 	return capabilities
-}
-
-// NewOgmiosChainContext creates a new Ogmios chain context.
-func NewOgmiosChainContext(ogmiosClient *ogmigo.Client, kupoClient *kugo.Client, networkId uint8) *OgmiosChainContext {
-	return &OgmiosChainContext{
-		ogmios:    ogmiosClient,
-		kupo:      kupoClient,
-		networkId: networkId,
-	}
 }
 
 func (o *OgmiosChainContext) ProtocolParams() (backend.ProtocolParameters, error) {
@@ -61,7 +171,11 @@ func (o *OgmiosChainContext) ProtocolParams() (backend.ProtocolParameters, error
 }
 
 func (o *OgmiosChainContext) ProtocolParamsContext(ctx context.Context) (backend.ProtocolParameters, error) {
-	raw, err := o.ogmios.CurrentProtocolParameters(ctx)
+	client, err := o.client()
+	if err != nil {
+		return backend.ProtocolParameters{}, err
+	}
+	raw, err := client.ProtocolParameters(ctx)
 	if err != nil {
 		return backend.ProtocolParameters{}, err
 	}
@@ -79,7 +193,11 @@ func (o *OgmiosChainContext) GenesisParams() (backend.GenesisParameters, error) 
 }
 
 func (o *OgmiosChainContext) GenesisParamsContext(ctx context.Context) (backend.GenesisParameters, error) {
-	raw, err := o.ogmios.GenesisConfig(ctx, "shelley")
+	client, err := o.client()
+	if err != nil {
+		return backend.GenesisParameters{}, err
+	}
+	raw, err := client.GenesisConfig(ctx, "shelley")
 	if err != nil {
 		return backend.GenesisParameters{}, err
 	}
@@ -103,7 +221,11 @@ func (o *OgmiosChainContext) CurrentEpoch() (uint64, error) {
 }
 
 func (o *OgmiosChainContext) CurrentEpochContext(ctx context.Context) (uint64, error) {
-	return o.ogmios.CurrentEpoch(ctx)
+	client, err := o.client()
+	if err != nil {
+		return 0, err
+	}
+	return client.CurrentEpoch(ctx)
 }
 
 func (o *OgmiosChainContext) MaxTxFee() (uint64, error) {
@@ -123,15 +245,11 @@ func (o *OgmiosChainContext) Tip() (uint64, error) {
 }
 
 func (o *OgmiosChainContext) TipContext(ctx context.Context) (uint64, error) {
-	point, err := o.ogmios.ChainTip(ctx)
+	client, err := o.client()
 	if err != nil {
 		return 0, err
 	}
-	ps, ok := point.PointStruct()
-	if !ok || ps == nil {
-		return 0, errors.New("chain tip is origin")
-	}
-	return ps.Slot, nil
+	return client.Tip(ctx)
 }
 
 func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error) {
@@ -139,23 +257,11 @@ func (o *OgmiosChainContext) Utxos(address common.Address) ([]common.Utxo, error
 }
 
 func (o *OgmiosChainContext) UtxosContext(ctx context.Context, address common.Address) ([]common.Utxo, error) {
-	if o.kupo == nil {
-		return nil, backend.NewUnsupportedError("Ogmios without Kupo", backend.CapabilityUtxos)
-	}
-	matches, err := o.kupo.Matches(ctx, kugo.OnlyUnspent(), kugo.Address(address.String()))
+	client, err := o.kupoClient(backend.CapabilityUtxos)
 	if err != nil {
 		return nil, err
 	}
-
-	var utxos []common.Utxo
-	for _, match := range matches {
-		utxo, err := matchToUtxo(ctx, match, address, o.kupo)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse UTxO match: %w", err)
-		}
-		utxos = append(utxos, utxo)
-	}
-	return utxos, nil
+	return client.UtxosAtAddress(ctx, address)
 }
 
 func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) {
@@ -163,24 +269,11 @@ func (o *OgmiosChainContext) SubmitTx(txCbor []byte) (common.Blake2b256, error) 
 }
 
 func (o *OgmiosChainContext) SubmitTxContext(ctx context.Context, txCbor []byte) (common.Blake2b256, error) {
-	txHex := hex.EncodeToString(txCbor)
-	resp, err := o.ogmios.SubmitTx(ctx, txHex)
+	client, err := o.client()
 	if err != nil {
 		return common.Blake2b256{}, err
 	}
-	if resp.Error != nil {
-		return common.Blake2b256{}, fmt.Errorf("submit tx error: %s", resp.Error.Message)
-	}
-	hashBytes, err := hex.DecodeString(resp.ID)
-	if err != nil {
-		return common.Blake2b256{}, err
-	}
-	if len(hashBytes) != common.Blake2b256Size {
-		return common.Blake2b256{}, fmt.Errorf("invalid tx hash length: expected %d bytes, got %d", common.Blake2b256Size, len(hashBytes))
-	}
-	var result common.Blake2b256
-	copy(result[:], hashBytes)
-	return result, nil
+	return client.SubmitTx(ctx, txCbor)
 }
 
 func (o *OgmiosChainContext) EvaluateTx(txCbor []byte, additionalUtxos []common.Utxo) (map[common.RedeemerKey]common.ExUnits, error) {
@@ -192,24 +285,18 @@ func (o *OgmiosChainContext) EvaluateTxContext(
 	txCbor []byte,
 	additionalUtxos []common.Utxo,
 ) (map[common.RedeemerKey]common.ExUnits, error) {
-	txHex := hex.EncodeToString(txCbor)
-	var resp *ogmigo.EvaluateTxResponse
-	var err error
-	if len(additionalUtxos) > 0 {
-		// Ogmios natively accepts a set of resolved UTxOs so it can evaluate
-		// inputs that are not yet visible on-chain.
-		sharedUtxos, convErr := commonUtxosToShared(additionalUtxos)
-		if convErr != nil {
-			return nil, convErr
-		}
-		resp, err = o.ogmios.EvaluateTxWithAdditionalUtxos(ctx, txHex, sharedUtxos)
-	} else {
-		resp, err = o.ogmios.EvaluateTx(ctx, txHex)
-	}
+	client, err := o.client()
 	if err != nil {
 		return nil, err
 	}
-	return evaluateResponseToExUnits(resp)
+	// Validated here, not only where the UTxOs are encoded for the wire, so
+	// a malformed additional UTxO is rejected whichever client is in use.
+	for _, utxo := range additionalUtxos {
+		if err := backend.ValidateAdditionalUtxo(utxo); err != nil {
+			return nil, err
+		}
+	}
+	return client.EvaluateTx(ctx, txCbor, additionalUtxos)
 }
 
 // commonUtxosToShared converts resolved gouroboros UTxOs into the ogmigo
@@ -376,29 +463,11 @@ func (o *OgmiosChainContext) UtxoByRefContext(
 	txHash common.Blake2b256,
 	index uint32,
 ) (*common.Utxo, error) {
-	hashHex := hex.EncodeToString(txHash.Bytes())
-	query := chainsync.TxInQuery{
-		Transaction: shared.UtxoTxID{ID: hashHex},
-		Index:       index,
-	}
-	utxos, err := o.ogmios.UtxosByTxIn(ctx, query)
+	client, err := o.client()
 	if err != nil {
 		return nil, err
 	}
-	if len(utxos) == 0 {
-		return nil, errors.New("utxo not found")
-	}
-
-	raw := utxos[0]
-	addr, err := common.NewAddress(raw.Address)
-	if err != nil {
-		return nil, err
-	}
-	result, err := ogmiosUtxoToCommon(raw, addr)
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
+	return client.UtxoByRef(ctx, txHash, index)
 }
 
 func (o *OgmiosChainContext) ScriptCbor(scriptHash common.Blake2b224) ([]byte, error) {
@@ -409,15 +478,11 @@ func (o *OgmiosChainContext) ScriptCborContext(
 	ctx context.Context,
 	scriptHash common.Blake2b224,
 ) ([]byte, error) {
-	if o.kupo == nil {
-		return nil, backend.NewUnsupportedError("Ogmios without Kupo", backend.CapabilityScriptCbor)
-	}
-	hashHex := hex.EncodeToString(scriptHash.Bytes())
-	script, err := o.kupo.Script(ctx, hashHex)
+	client, err := o.kupoClient(backend.CapabilityScriptCbor)
 	if err != nil {
 		return nil, err
 	}
-	return hex.DecodeString(script.Script)
+	return client.ScriptCbor(ctx, scriptHash)
 }
 
 // --- Ogmios response types and conversion ---

--- a/backend/ogmios/ogmios.go
+++ b/backend/ogmios/ogmios.go
@@ -157,8 +157,11 @@ func (o *OgmiosChainContext) kupoClient(
 // client. Address UTxO queries and script lookup require the optional Kupo
 // client; UTxO-by-reference queries are served directly by Ogmios.
 func (o *OgmiosChainContext) Capabilities() backend.CapabilitySet {
+	if o == nil || o.ogmios == nil {
+		return 0
+	}
 	capabilities := backend.CapabilitySet(backend.AllCapabilities)
-	if o == nil || o.kupo == nil {
+	if o.kupo == nil {
 		capabilities &^= backend.CapabilitySet(
 			backend.CapabilityUtxos | backend.CapabilityScriptCbor,
 		)

--- a/backend/ogmios/ogmios_test.go
+++ b/backend/ogmios/ogmios_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestOgmiosCapabilitiesWithoutKupo(t *testing.T) {
-	ctx := NewOgmiosChainContext(nil, nil, 0)
+	ctx := testChainContext(t, Config{OgmiosEndpoint: testOgmiosEndpoint})
 	if !backend.Supports(ctx, backend.CapabilityEvaluateTx|backend.CapabilityUtxoByRef) {
 		t.Fatal("expected Ogmios-supported capabilities")
 	}
@@ -451,7 +451,7 @@ func TestEvaluateTxRejectsMalformedAdditionalUtxos(t *testing.T) {
 		},
 	}
 
-	ctx := NewOgmiosChainContext(ogmigo.New(), nil, 0)
+	ctx := testChainContext(t, Config{OgmiosEndpoint: testOgmiosEndpoint})
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := ctx.EvaluateTx([]byte{0x84}, []common.Utxo{test.utxo}); err == nil {


### PR DESCRIPTION
`NewOgmiosChainContext(ogmiosClient *ogmigo.Client, kupoClient *kugo.Client, networkId uint8)` was the **only** Apollo constructor naming third-party types in a public signature. Once 2.0 freezes it, `ogmigo/v7` would be unreachable — `ogmigo/v6.Client` and `ogmigo/v7.Client` are different Go types and the parameter cannot change in 2.x — so Apollo would be pinned to v6 permanently, and any consumer whose build selects a newer ogmigo via MVS would stop compiling. Same for `kugo`.

## New surface

```go
type Config struct {
    OgmiosEndpoint string        // required; ws/wss, http/https accepted
    KupoEndpoint   string        // optional; absent ⇒ no Utxos/ScriptCbor capability
    NetworkId      uint8
    KupoTimeout    time.Duration // 0 = client default
}
func NewOgmiosChainContext(cfg Config) (*OgmiosChainContext, error)

func NewOgmiosChainContextFromClients(
    ogmiosClient OgmiosClient, kupoClient KupoClient, networkId uint8,
) (*OgmiosChainContext, error)
```

`OgmiosClient` (7 methods) and `KupoClient` (2 methods) name only `context`, `encoding/json` and gouroboros types. Nothing outside `backend/ogmios` imports ogmigo or kugo.

## Why the seam sits where it does

A literal method-for-method extraction would not have helped. Apollo calls 11 methods across the two libraries, and **6 of those signatures name a third-party type** (`chainsync.Point`, `chainsync.TxInQuery`, `[]shared.Utxo`, `*ogmigo.EvaluateTxResponse`, `*ogmigo.SubmitTxResponse`, `[]kugo.Match`, `*kugo.Script`) — mirroring them would have re-frozen ogmigo/v6 inside the new interface. Transport injection is not available either: neither library accepts an `*http.Client` or `RoundTripper`.

So the interface is stated one level up, in Cardano terms: `json.RawMessage` where ogmigo already returns raw JSON (protocol parameters, genesis config — Apollo keeps that decoding, which is where the lovelace-shape and cost-model fixes live and where the tests are), and gouroboros values where ogmigo returns parsed structs. The documented consequence is that a custom-transport implementor must produce UTxOs rather than proxy bytes. Proven practical: the external consumer implements `OgmiosClient` in ~40 lines without importing ogmigo.

## Migration

```go
// before
ctx := ogmios.NewOgmiosChainContext(
    ogmigo.New(ogmigo.WithEndpoint("ws://localhost:1337")),
    kugo.New(kugo.WithEndpoint("http://localhost:1442")),
    1,
)

// after
ctx, err := ogmios.NewOgmiosChainContext(ogmios.Config{
    OgmiosEndpoint: "ws://localhost:1337",
    KupoEndpoint:   "http://localhost:1442",
    NetworkId:      1,
})
```

No occurrence in `readme.md` or `docs/` needed updating — `NewOgmiosChainContext` appears in neither.

## Nil-client panics closed too

The audit found a zero-value or nil-client Ogmios context panicking on eight methods while `Capabilities()` claimed they worked. Now: the constructor rejects an empty, unparseable or wrong-scheme endpoint; the injecting form rejects a nil **and typed-nil** Ogmios client and normalizes a typed-nil Kupo client so `Capabilities()` stays honest; a zero-value context returns an error from every Ogmios-backed method and `ErrUnsupported` from `Utxos`/`ScriptCbor`. Two further panic paths were closed in the adapters (nil submit response, nil script response), and `EvaluateTx` now validates additional UTxOs in the context so the check holds for any injected client.
