### PR TITLE
feat(coinselection)!: cancellable Select, and make MACS fee-competitive

### DIFF
--- a/apollo.go
+++ b/apollo.go
@@ -2230,7 +2230,11 @@ func (a *Apollo) selectCoins(required, currentInput Value) ([]common.Utxo, error
 			selector = defaultCoinSelector
 		}
 		var selErr error
-		selected, selErr = selector.Select(available, remaining)
+		selected, selErr = selector.Select(
+			a.requestContext,
+			available,
+			remaining,
+		)
 		if selErr != nil {
 			return nil, selErr
 		}

--- a/builder_hardening_test.go
+++ b/builder_hardening_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"context"
 	"errors"
 	"math/big"
 	"strings"
@@ -22,7 +23,11 @@ type staticSelector struct {
 
 func (s *staticSelector) Name() string { return "static" }
 
-func (s *staticSelector) Select([]common.Utxo, Value) ([]common.Utxo, error) {
+func (s *staticSelector) Select(
+	context.Context,
+	[]common.Utxo,
+	Value,
+) ([]common.Utxo, error) {
 	return s.selected, s.err
 }
 
@@ -169,7 +174,7 @@ func TestCloneCopiesOwnedMutableStateAndSelector(t *testing.T) {
 	if clone.err != nil {
 		t.Fatalf("Clone() recorded error: %v", clone.err)
 	}
-	if clone.coinSelector != selector {
+	if clone.coinSelector != CoinSelector(selector) {
 		t.Fatal("Clone() did not preserve the configured coin selector")
 	}
 

--- a/coinselection.go
+++ b/coinselection.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -16,14 +17,43 @@ type CoinSelector interface {
 	// Select returns a subset of available whose summed value covers target.
 	// The available pool has already been filtered of in-use UTxOs. It
 	// returns an error if the pool cannot cover the target.
-	Select(available []common.Utxo, target Value) ([]common.Utxo, error)
+	//
+	// Selection over a large pool is expensive, so implementations must
+	// observe ctx while searching and abandon the search with an error
+	// wrapping ctx.Err() once it is done, instead of running to completion.
+	Select(
+		ctx context.Context,
+		available []common.Utxo,
+		target Value,
+	) ([]common.Utxo, error)
+}
+
+// selectionCancelStride is how many pool entries a selector may process
+// between context checks. Small enough that cancellation is observed
+// promptly even on a pool of hundreds of thousands of UTxOs, large enough
+// that the check does not dominate the inner loops.
+const selectionCancelStride = 256
+
+// selectionInterrupted reports whether ctx is done, as an error wrapping
+// ctx.Err() so callers can still match it with errors.Is. A nil context is
+// treated as never done: Select is exported and must not panic on one.
+func selectionInterrupted(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("coin selection interrupted: %w", err)
+	}
+	return nil
 }
 
 // defaultCoinSelector is used by Complete when no selector is configured.
-// MACS is the default: benchmarks (see docs/design/2026-06-11-macs-coin-
-// selection-design.md) show it selects far fewer inputs on multi-asset
-// targets and produces much smaller change than largest-first, at comparable
-// speed. Use SetCoinSelector(&LargestFirstSelector{}) for the legacy behavior.
+// MACS is the default on measured fees, not on input counts: over a
+// 150-transaction wallet lifetime of plain ADA payments it costs within 0.56%
+// of largest-first while ending with one dust UTxO rather than ninety, and on a
+// multi-asset payment it is about three times cheaper (200,437 lovelace over 20
+// inputs against 623,629 over 286). Use
+// SetCoinSelector(&LargestFirstSelector{}) for the legacy greedy behavior.
 var defaultCoinSelector CoinSelector = NewMACSSelector()
 
 // LargestFirstSelector selects UTxOs greedily by descending lovelace amount,
@@ -34,15 +64,25 @@ type LargestFirstSelector struct{}
 func (s *LargestFirstSelector) Name() string { return "largest-first" }
 
 // Select returns a subset of available whose summed value covers target.
-func (s *LargestFirstSelector) Select(available []common.Utxo, target Value) ([]common.Utxo, error) {
+func (s *LargestFirstSelector) Select(
+	ctx context.Context,
+	available []common.Utxo,
+	target Value,
+) ([]common.Utxo, error) {
 	remaining := target.Clone()
 	if remaining.Coin == 0 && !remaining.HasAssets() {
 		return nil, nil
+	}
+	if err := selectionInterrupted(ctx); err != nil {
+		return nil, err
 	}
 	if err := validateUtxos(available); err != nil {
 		return nil, fmt.Errorf("invalid coin-selection input: %w", err)
 	}
 	sorted := SortUtxos(available)
+	if err := selectionInterrupted(ctx); err != nil {
+		return nil, err
+	}
 	// Stabilize ordering for equal-amount UTxOs to preserve deterministic selection.
 	for i := 0; i < len(sorted); {
 		hasAssets := sorted[i].Output.Assets() != nil
@@ -68,12 +108,20 @@ func (s *LargestFirstSelector) Select(available []common.Utxo, target Value) ([]
 		i = j
 	}
 	var selected []common.Utxo
-	for _, utxo := range sorted {
+	for i, utxo := range sorted {
+		if i%selectionCancelStride == 0 {
+			if err := selectionInterrupted(ctx); err != nil {
+				return nil, err
+			}
+		}
 		amt := utxo.Output.Amount()
 		// Amounts come from a remote backend; reject anything outside the
 		// uint64 lovelace range (big.Int.Uint64 is undefined out of range).
 		if amt == nil || !amt.IsUint64() {
-			return nil, fmt.Errorf("UTxO %s has an invalid lovelace amount", utxoRef(utxo))
+			return nil, fmt.Errorf(
+				"UTxO %s has an invalid lovelace amount",
+				utxoRef(utxo),
+			)
 		}
 
 		selected = append(selected, utxo)

--- a/coinselection_bench_test.go
+++ b/coinselection_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -162,7 +163,9 @@ func BenchmarkCoinSelection(b *testing.B) {
 				var totalInputs, totalExcess float64
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					selected, err := sel.Select(sc.pool, sc.target)
+					selected, err := sel.Select(
+						b.Context(), sc.pool, sc.target,
+					)
 					if err != nil {
 						b.Fatalf("Select failed: %v", err)
 					}
@@ -175,6 +178,32 @@ func BenchmarkCoinSelection(b *testing.B) {
 				}
 				b.ReportMetric(totalInputs/float64(b.N), "inputs/op")
 				b.ReportMetric(totalExcess/float64(b.N)/1e6, "excessAda/op")
+			})
+		}
+	}
+}
+
+// BenchmarkCoinSelectionFullSweep is the near-full-sweep case: a pool of
+// equal UTxOs and a target needing 90% of them, so the number of picks scales
+// with the pool. It is the shape that made selection quadratic while every
+// pick rescanned the pool, so it is the one to watch for regressions.
+func BenchmarkCoinSelectionFullSweep(b *testing.B) {
+	selectors := []CoinSelector{&LargestFirstSelector{}, &MACSSelector{}}
+	for _, n := range []int{500, 1000, 2000, 4000} {
+		pool, target := sweepSelectionPool(b, n)
+		for _, sel := range selectors {
+			name := strconv.Itoa(n) + "/" + sel.Name()
+			b.Run(name, func(b *testing.B) {
+				var totalInputs float64
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					selected, err := sel.Select(b.Context(), pool, target)
+					if err != nil {
+						b.Fatalf("Select failed: %v", err)
+					}
+					totalInputs += float64(len(selected))
+				}
+				b.ReportMetric(totalInputs/float64(b.N), "inputs/op")
 			})
 		}
 	}
@@ -242,7 +271,7 @@ func TestCoinSelectionComparison(t *testing.T) {
 					}
 				}
 
-				selected, err := sel.Select(pool, target)
+				selected, err := sel.Select(t.Context(), pool, target)
 				if err != nil {
 					t.Fatalf("round %d: Select failed: %v", r, err)
 				}

--- a/coinselection_test.go
+++ b/coinselection_test.go
@@ -1,9 +1,13 @@
 package apollo
 
 import (
+	"context"
+	"errors"
 	"math/big"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -56,7 +60,7 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 			makeSelectorUtxo(t, 0x03, 0, 5_000_000, nil),
 		}
 		target := NewSimpleValue(12_000_000)
-		selected, err := newSelector().Select(pool, target)
+		selected, err := newSelector().Select(t.Context(), pool, target)
 		if err != nil {
 			t.Fatalf("Select failed: %v", err)
 		}
@@ -72,7 +76,7 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 			makeSelectorUtxo(t, 0x03, 0, 2_000_000, makeTestAssets(0xBB, "tokenB", 7)),
 		}
 		target := NewValue(5_000_000, makeTestAssets(0xAA, "tokenA", 50))
-		selected, err := newSelector().Select(pool, target)
+		selected, err := newSelector().Select(t.Context(), pool, target)
 		if err != nil {
 			t.Fatalf("Select failed: %v", err)
 		}
@@ -88,7 +92,7 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 			makeSelectorUtxo(t, 0x03, 0, 4_000_000, nil),
 		}
 		target := NewValue(8_000_000, makeTestAssets(0xAA, "tokenA", 100))
-		selected, err := newSelector().Select(pool, target)
+		selected, err := newSelector().Select(t.Context(), pool, target)
 		if err != nil {
 			t.Fatalf("Select failed: %v", err)
 		}
@@ -106,7 +110,9 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 		pool := []common.Utxo{
 			makeSelectorUtxo(t, 0x01, 0, 1_000_000, nil),
 		}
-		_, err := newSelector().Select(pool, NewSimpleValue(100_000_000))
+		_, err := newSelector().Select(
+			t.Context(), pool, NewSimpleValue(100_000_000),
+		)
 		if err == nil {
 			t.Fatal("expected error for insufficient coin")
 		}
@@ -120,7 +126,7 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 			makeSelectorUtxo(t, 0x01, 0, 10_000_000, nil),
 		}
 		target := NewValue(1_000_000, makeTestAssets(0xAA, "tokenA", 1))
-		_, err := newSelector().Select(pool, target)
+		_, err := newSelector().Select(t.Context(), pool, target)
 		if err == nil {
 			t.Fatal("expected error for missing asset")
 		}
@@ -133,7 +139,7 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 		pool := []common.Utxo{
 			makeSelectorUtxo(t, 0x01, 0, 1_000_000, nil),
 		}
-		selected, err := newSelector().Select(pool, Value{})
+		selected, err := newSelector().Select(t.Context(), pool, Value{})
 		if err != nil {
 			t.Fatalf("Select failed: %v", err)
 		}
@@ -150,11 +156,11 @@ func runSelectorConformance(t *testing.T, newSelector func() CoinSelector) {
 			makeSelectorUtxo(t, 0x04, 0, 5_000_000, nil),
 		}
 		target := NewValue(6_000_000, makeTestAssets(0xAA, "tokenA", 40))
-		first, err := newSelector().Select(pool, target)
+		first, err := newSelector().Select(t.Context(), pool, target)
 		if err != nil {
 			t.Fatalf("Select failed: %v", err)
 		}
-		second, err := newSelector().Select(pool, target)
+		second, err := newSelector().Select(t.Context(), pool, target)
 		if err != nil {
 			t.Fatalf("Select failed: %v", err)
 		}
@@ -187,6 +193,7 @@ func TestCoinSelectorsRejectMalformedUTxOs(t *testing.T) {
 	for _, selector := range selectors {
 		t.Run(selector.Name(), func(t *testing.T) {
 			if _, err := selector.Select(
+				t.Context(),
 				[]common.Utxo{{}},
 				NewSimpleValue(1),
 			); err == nil {
@@ -207,7 +214,9 @@ func TestLargestFirstSelectorOrder(t *testing.T) {
 		makeSelectorUtxo(t, 0x02, 0, 10_000_000, nil),
 		makeSelectorUtxo(t, 0x03, 0, 5_000_000, nil),
 	}
-	selected, err := (&LargestFirstSelector{}).Select(pool, NewSimpleValue(12_000_000))
+	selected, err := (&LargestFirstSelector{}).Select(
+		t.Context(), pool, NewSimpleValue(12_000_000),
+	)
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}
@@ -231,9 +240,13 @@ type recordingSelector struct {
 
 func (r *recordingSelector) Name() string { return "recording" }
 
-func (r *recordingSelector) Select(available []common.Utxo, target Value) ([]common.Utxo, error) {
+func (r *recordingSelector) Select(
+	ctx context.Context,
+	available []common.Utxo,
+	target Value,
+) ([]common.Utxo, error) {
 	r.called = true
-	return r.inner.Select(available, target)
+	return r.inner.Select(ctx, available, target)
 }
 
 func TestSetCoinSelectorUsedByComplete(t *testing.T) {
@@ -257,5 +270,156 @@ func TestSetCoinSelectorUsedByComplete(t *testing.T) {
 	}
 	if !rec.called {
 		t.Error("custom coin selector was not invoked by Complete")
+	}
+}
+
+// contextSelectors returns one instance of every in-tree selector, for the
+// context tests below.
+func contextSelectors() []CoinSelector {
+	return []CoinSelector{
+		&LargestFirstSelector{},
+		&MACSSelector{},
+		NewMACSSelector(),
+	}
+}
+
+// sweepSelectionPool builds n equal 1 ADA UTxOs and a target needing 90% of
+// them, so covering it takes thousands of picks: long enough that abandoning
+// the search early is observable.
+func sweepSelectionPool(tb testing.TB, n int) ([]common.Utxo, Value) {
+	tb.Helper()
+	addr := benchAddress(tb)
+	pool := make([]common.Utxo, 0, n)
+	var total uint64
+	for i := 0; i < n; i++ {
+		pool = append(pool, benchUtxo(addr, uint64(i)+1, 1_000_000, nil))
+		total += 1_000_000
+	}
+	return pool, NewSimpleValue(total / 10 * 9)
+}
+
+// TestSelectorsAbortOnCanceledContext verifies a cancelled context abandons
+// selection promptly, rather than after the whole pool has been searched.
+func TestSelectorsAbortOnCanceledContext(t *testing.T) {
+	pool, target := sweepSelectionPool(t, 10_000)
+	for _, selector := range contextSelectors() {
+		t.Run(selector.Name(), func(t *testing.T) {
+			start := time.Now()
+			if _, err := selector.Select(t.Context(), pool, target); err != nil {
+				t.Fatalf("uncancelled Select failed: %v", err)
+			}
+			whole := time.Since(start)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			start = time.Now()
+			selected, err := selector.Select(ctx, pool, target)
+			aborted := time.Since(start)
+
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("Select() error = %v, want context.Canceled", err)
+			}
+			if selected != nil {
+				t.Errorf(
+					"abandoned selection returned %d UTxOs, want none",
+					len(selected),
+				)
+			}
+			if aborted > whole/4 {
+				t.Errorf(
+					"cancellation took %v, close to the full %v search",
+					aborted, whole,
+				)
+			}
+			t.Logf("full=%v cancelled=%v", whole, aborted)
+		})
+	}
+}
+
+// countdownContext reports itself done only after n calls to Err, so a test
+// can prove a selector rechecks the context while searching instead of only
+// on entry. Done is never closed: selectors poll Err.
+type countdownContext struct {
+	context.Context
+	mu sync.Mutex
+	n  int
+}
+
+func (c *countdownContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.n > 0 {
+		c.n--
+		return nil
+	}
+	return context.Canceled
+}
+
+// TestSelectorsAbortMidSelection verifies the context is honoured inside the
+// selection loops: a context that only reports itself done after the first few
+// checks must still abort the search.
+func TestSelectorsAbortMidSelection(t *testing.T) {
+	pool, target := sweepSelectionPool(t, 4_000)
+	for _, selector := range contextSelectors() {
+		t.Run(selector.Name(), func(t *testing.T) {
+			ctx := &countdownContext{Context: context.Background(), n: 3}
+			selected, err := selector.Select(ctx, pool, target)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("Select() error = %v, want context.Canceled", err)
+			}
+			if selected != nil {
+				t.Errorf(
+					"abandoned selection returned %d UTxOs, want none",
+					len(selected),
+				)
+			}
+		})
+	}
+}
+
+// TestSelectorsTolerateNilContext pins that a third-party caller passing no
+// context gets a selection rather than a panic.
+func TestSelectorsTolerateNilContext(t *testing.T) {
+	pool := []common.Utxo{
+		makeSelectorUtxo(t, 0x01, 0, 10_000_000, nil),
+	}
+	// Deliberately nil: Select is exported and must not dereference it.
+	var ctx context.Context
+	for _, selector := range contextSelectors() {
+		t.Run(selector.Name(), func(t *testing.T) {
+			selected, err := selector.Select(
+				ctx, pool, NewSimpleValue(1_000_000),
+			)
+			if err != nil {
+				t.Fatalf("Select failed: %v", err)
+			}
+			if len(selected) != 1 {
+				t.Fatalf("expected 1 input, got %d", len(selected))
+			}
+		})
+	}
+}
+
+// TestCompletePropagatesContextCancellation verifies WithContext reaches coin
+// selection through the builder.
+func TestCompletePropagatesContextCancellation(t *testing.T) {
+	cc := setupFixedContext()
+	addr := testAddress(t)
+	addTestUtxo(cc, addr, 10_000_000, 0x01, 0)
+
+	p, err := NewPayment(validTestAddrBech32, 2_000_000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	a := New(cc).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50000000).
+		WithContext(ctx)
+
+	if _, err := a.Complete(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Complete() error = %v, want context.Canceled", err)
 	}
 }

--- a/macs.go
+++ b/macs.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -19,12 +20,29 @@ import (
 //
 //	P(u,c) = v(u,c) / (|v(u,c) - avg(S,c)| + 1)
 //
-// which favors valuable UTxOs near the pool-wide average value, keeping
-// change small and the wallet's UTxO pool diverse. The paper's confirmation
-// age and linkage factors are constant here because common.Utxo carries no
-// such metadata. A final pass drops inputs made redundant by later picks,
-// lowest priority first. Priorities are compared exactly via big.Int
-// cross-multiplication, so selection is deterministic.
+// which favors valuable UTxOs near the pool-wide average value, keeping the
+// wallet's UTxO pool diverse. The paper's confirmation age and linkage factors
+// are constant here because common.Utxo carries no such metadata. A final pass
+// drops inputs made redundant by later picks, lowest priority first.
+// Priorities are compared exactly via big.Int cross-multiplication, so
+// selection is deterministic.
+//
+// Note that small change is not a virtue on Cardano, whatever the priority
+// function's shape suggests: a change amount below the minimum UTxO value
+// cannot be emitted as an output at all, so the builder folds it into the fee
+// and the user loses it. MinChange steers around that dead band.
+//
+// Priority alone is not enough to keep the input count low. Because avg(S,c)
+// is a pool-wide mean, a pool of many dust UTxOs plus a few large ones pulls
+// the mean down next to the dust, so every dust UTxO scores far above a large
+// one and the deficit is covered by accumulating dust — 90 inputs where one
+// would do, for a pool of 1000 1-ADA UTxOs and one of 100 ADA. Recomputing
+// the mean over the unselected pool each round does not help: consuming dust
+// barely moves a dust-dominated mean. So a candidate that covers the whole
+// remaining deficit of the class on its own ("closer") is always preferred,
+// and priority decides only which closer to take. Priority still governs
+// every pick that cannot finish the class alone, so MACS keeps consuming
+// mid-range UTxOs rather than degenerating into largest-first.
 //
 // The paper's dust-avoidance requirement is met with a bounded sweep: when a
 // selection exists and sweeping is enabled, up to MaxDustInputs ADA-only
@@ -38,7 +56,22 @@ type MACSSelector struct {
 	DustThreshold uint64
 	// MaxDustInputs caps how many dust UTxOs one selection may sweep.
 	MaxDustInputs int
+	// MinChange is the smallest lovelace leftover worth emitting as a change
+	// output. A pick whose leftover falls between zero and this value is
+	// avoided where the pool allows, because the builder cannot emit a change
+	// output below the ledger's minimum UTxO value and folds the remainder
+	// into the fee instead, where the user simply loses it. Zero uses
+	// macsSelectorMinChange.
+	MinChange uint64
 }
+
+// macsSelectorMinChange is the default MinChange: comfortably above the
+// minimum UTxO value of a plain ADA-only change output, which at mainnet's
+// 4310 coins-per-UTxO-byte is about 0.86 ADA. Priority alone steers picks
+// toward the pool mean, which is exactly where a payment near that mean leaves
+// change inside the dead band, so without this the selector burns the leftover
+// as fee on a majority of transactions against a realistic pool.
+const macsSelectorMinChange = 1_500_000
 
 // NewMACSSelector returns a MACS selector with dust sweeping enabled:
 // UTxOs below 1 ADA (the order of Cardano's minimum UTxO value) are swept,
@@ -47,6 +80,7 @@ func NewMACSSelector() *MACSSelector {
 	return &MACSSelector{
 		DustThreshold: 1_000_000,
 		MaxDustInputs: 2,
+		MinChange:     macsSelectorMinChange,
 	}
 }
 
@@ -87,16 +121,160 @@ func (c *macsCandidate) value(cls macsClass) *big.Int {
 // macsPick records a selected candidate with the priority terms it was
 // chosen under, for the pruning pass.
 type macsPick struct {
+	idx    int
 	cand   *macsCandidate
 	v, dev *big.Int
 	pruned bool
 }
 
+// macsClassView holds one asset class's precomputed per-candidate terms.
+// avg(S,c) is a pool-wide constant, so a candidate's priority for the class
+// never changes during a selection: the terms are computed once per class
+// instead of once per pick, which is what made picking cost O(n) every time.
+type macsClassView struct {
+	// vals holds each candidate's quantity of the class, and devs the
+	// matching |v - avg(S,c)|, both indexed by candidate index. devs is
+	// only populated where vals is positive.
+	vals []*big.Int
+	devs []*big.Int
+	// held lists the candidate indexes with a positive quantity, in pool
+	// order, and poolMax is the largest quantity among them.
+	held    []int
+	poolMax *big.Int
+	// byPriority is held ordered by descending priority and byValue by
+	// descending quantity. Both are built on first use, since a class covered
+	// by a single closer needs neither. The cursors only move forward, so
+	// walking either ordering costs O(n) across a whole selection.
+	byPriority []int
+	byValue    []int
+	prioCur    int
+	valCur     int
+}
+
+// availableMax returns an upper bound on the quantity still unselected: the
+// pool-wide maximum until a scan proves that bound stale, and the exact
+// maximum afterwards, so no later round repeats a scan that cannot succeed.
+func (v *macsClassView) availableMax(selected []bool) *big.Int {
+	if v.byValue == nil {
+		return v.poolMax
+	}
+	for v.valCur < len(v.byValue) && selected[v.byValue[v.valCur]] {
+		v.valCur++
+	}
+	if v.valCur >= len(v.byValue) {
+		return new(big.Int)
+	}
+	return v.vals[v.byValue[v.valCur]]
+}
+
+// next returns the index of the candidate to pick for this class given the
+// quantity still deficient, or -1 when no unselected candidate holds the
+// class at all.
+//
+// minChange is the smallest leftover worth emitting as a change output, and is
+// nil for every class but the coin. See macsSelectorMinChange for why the coin
+// class needs it.
+func (v *macsClassView) next(
+	cands []*macsCandidate,
+	selected []bool,
+	deficit *big.Int,
+	cmp *macsPriorityCmp,
+	minChange *big.Int,
+) int {
+	// No candidate covers the deficit alone unless the largest one does, so
+	// the scan below is skipped in the common case, and once it succeeds the
+	// class is covered and never scanned again.
+	if v.availableMax(selected).Cmp(deficit) >= 0 {
+		best, largest := -1, -1
+		leftover := new(big.Int)
+		for _, idx := range v.held {
+			if selected[idx] || v.vals[idx].Cmp(deficit) < 0 {
+				continue
+			}
+			// Track the largest closer as the fallback for when no candidate
+			// leaves an emittable change amount, so the leftover is at least
+			// as far above the dead band as this pool allows.
+			if largest == -1 || betterFallback(
+				v.vals[idx], cands[idx].ref,
+				v.vals[largest], cands[largest].ref,
+			) {
+				largest = idx
+			}
+			// Skip a candidate whose leftover would be stranded: too small to
+			// become a change output, so the builder folds it into the fee.
+			if minChange != nil {
+				leftover.Sub(v.vals[idx], deficit)
+				if leftover.Sign() != 0 && leftover.Cmp(minChange) < 0 {
+					continue
+				}
+			}
+			if best == -1 || cmp.better(
+				v.vals[idx], v.devs[idx], cands[idx].ref,
+				v.vals[best], v.devs[best], cands[best].ref,
+			) {
+				best = idx
+			}
+		}
+		if best >= 0 {
+			return best
+		}
+		// Closers exist but every one strands its leftover. Take the largest:
+		// a bigger input cannot make the change smaller, and one input still
+		// beats accumulating several.
+		if largest >= 0 {
+			return largest
+		}
+		// The pool-wide bound was stale, because the largest candidates went
+		// to earlier picks. Order by quantity so availableMax is exact from
+		// here on.
+		v.byValue = v.orderHeld(func(x, y int) bool {
+			if cmp := v.vals[x].Cmp(v.vals[y]); cmp != 0 {
+				return cmp > 0
+			}
+			return cands[x].ref < cands[y].ref
+		})
+	}
+
+	if v.byPriority == nil {
+		v.byPriority = v.orderHeld(func(x, y int) bool {
+			return cmp.better(
+				v.vals[x], v.devs[x], cands[x].ref,
+				v.vals[y], v.devs[y], cands[y].ref,
+			)
+		})
+	}
+	for v.prioCur < len(v.byPriority) && selected[v.byPriority[v.prioCur]] {
+		v.prioCur++
+	}
+	if v.prioCur >= len(v.byPriority) {
+		return -1
+	}
+	return v.byPriority[v.prioCur]
+}
+
+// orderHeld returns the class's candidate indexes sorted by less, which
+// compares two candidate indexes.
+func (v *macsClassView) orderHeld(less func(x, y int) bool) []int {
+	order := make([]int, len(v.held))
+	copy(order, v.held)
+	sort.Slice(order, func(a, b int) bool {
+		return less(order[a], order[b])
+	})
+	return order
+}
+
 // Select returns a subset of available whose summed value covers target.
-func (s *MACSSelector) Select(available []common.Utxo, target Value) ([]common.Utxo, error) {
+func (s *MACSSelector) Select(
+	ctx context.Context,
+	available []common.Utxo,
+	target Value,
+) ([]common.Utxo, error) {
 	remaining := target.Clone()
 	if remaining.Coin == 0 && !remaining.HasAssets() {
 		return nil, nil
+	}
+	if err := selectionInterrupted(ctx); err != nil {
+		return nil, err
 	}
 
 	// MACS reads every amount to compute pool averages, so the whole pool is
@@ -107,9 +285,17 @@ func (s *MACSSelector) Select(available []common.Utxo, target Value) ([]common.U
 	}
 	cands := make([]*macsCandidate, 0, len(available))
 	for i := range available {
+		if i%selectionCancelStride == 0 {
+			if err := selectionInterrupted(ctx); err != nil {
+				return nil, err
+			}
+		}
 		amt := available[i].Output.Amount()
 		if amt == nil || !amt.IsUint64() {
-			return nil, fmt.Errorf("UTxO %s has an invalid lovelace amount", utxoRef(available[i]))
+			return nil, fmt.Errorf(
+				"UTxO %s has an invalid lovelace amount",
+				utxoRef(available[i]),
+			)
 		}
 		cands = append(cands, &macsCandidate{
 			utxo: available[i],
@@ -119,43 +305,75 @@ func (s *MACSSelector) Select(available []common.Utxo, target Value) ([]common.U
 	}
 
 	classes := macsTargetClasses(target)
-	avgs := macsClassAverages(classes, cands)
+	views, err := macsClassViews(ctx, classes, cands)
+	if err != nil {
+		return nil, err
+	}
 
-	selected := make(map[string]bool)
+	cmp := newMACSPriorityCmp()
+	// A zero MinChange means "unset" rather than "no floor": the zero value of
+	// MACSSelector runs the paper's algorithm, and only the configured
+	// selector steers away from the dead band.
+	var minChangeFloor *big.Int
+	if s.MinChange > 0 {
+		minChangeFloor = new(big.Int).SetUint64(s.MinChange)
+	}
+	selected := make([]bool, len(cands))
 	var picks []*macsPick
-	for {
-		clsIdx, deficient := macsFirstDeficit(remaining, classes)
+	for round := 0; ; round++ {
+		if round%selectionCancelStride == 0 {
+			if err := selectionInterrupted(ctx); err != nil {
+				return nil, err
+			}
+		}
+		clsIdx, deficit, deficient := macsFirstDeficit(remaining, classes)
 		if !deficient {
 			break
 		}
-		pick := macsBestCandidate(cands, selected, classes[clsIdx], avgs[clsIdx])
-		if pick == nil {
-			return nil, errors.New("insufficient UTxOs to cover required value")
+		view := views[clsIdx]
+		var minChange *big.Int
+		if classes[clsIdx].isCoin {
+			minChange = minChangeFloor
 		}
-		selected[pick.cand.ref] = true
-		picks = append(picks, pick)
+		idx := view.next(cands, selected, deficit, cmp, minChange)
+		if idx < 0 {
+			return nil, errors.New(
+				"insufficient UTxOs to cover required value",
+			)
+		}
+		selected[idx] = true
+		cand := cands[idx]
+		picks = append(picks, &macsPick{
+			idx:  idx,
+			cand: cand,
+			v:    view.vals[idx],
+			dev:  view.devs[idx],
+		})
 
-		if remaining.Coin <= pick.cand.coin {
+		if remaining.Coin <= cand.coin {
 			remaining.Coin = 0
 		} else {
-			remaining.Coin -= pick.cand.coin
+			remaining.Coin -= cand.coin
 		}
-		if remaining.Assets != nil && pick.cand.utxo.Output.Assets() != nil {
-			subtractAssetsSaturating(remaining.Assets, pick.cand.utxo.Output.Assets())
+		if remaining.Assets != nil && cand.utxo.Output.Assets() != nil {
+			subtractAssetsSaturating(
+				remaining.Assets,
+				cand.utxo.Output.Assets(),
+			)
 		}
 	}
 
-	macsPruneRedundant(picks, classes, target)
+	macsPruneRedundant(picks, views, classes, target, cmp)
 
 	result := make([]common.Utxo, 0, len(picks))
-	selectedAfterPrune := make(map[string]bool, len(picks))
+	keep := make([]bool, len(cands))
 	for _, p := range picks {
 		if !p.pruned {
 			result = append(result, p.cand.utxo)
-			selectedAfterPrune[p.cand.ref] = true
+			keep[p.idx] = true
 		}
 	}
-	result = s.sweepDust(result, selectedAfterPrune, cands)
+	result = s.sweepDust(result, keep, cands)
 	return result, nil
 }
 
@@ -163,13 +381,17 @@ func (s *MACSSelector) Select(available []common.Utxo, target Value) ([]common.U
 // DustThreshold, smallest first (ties by ref), consolidating dust into the
 // transaction's change. Token-carrying UTxOs are never swept so change
 // outputs do not accumulate assets the target did not ask for.
-func (s *MACSSelector) sweepDust(result []common.Utxo, selected map[string]bool, cands []*macsCandidate) []common.Utxo {
+func (s *MACSSelector) sweepDust(
+	result []common.Utxo,
+	keep []bool,
+	cands []*macsCandidate,
+) []common.Utxo {
 	if s.DustThreshold == 0 || s.MaxDustInputs <= 0 || len(result) == 0 {
 		return result
 	}
 	var dust []*macsCandidate
-	for _, c := range cands {
-		if selected[c.ref] || c.coin >= s.DustThreshold {
+	for i, c := range cands {
+		if keep[i] || c.coin >= s.DustThreshold {
 			continue
 		}
 		if c.utxo.Output.Assets() != nil {
@@ -216,31 +438,71 @@ func macsTargetClasses(target Value) []macsClass {
 	return append(classes, macsClass{isCoin: true})
 }
 
-// macsClassAverages computes avg(S,c) for each class over the whole pool,
-// counting UTxOs that lack the asset as zero, per the paper.
-func macsClassAverages(classes []macsClass, cands []*macsCandidate) []*big.Int {
-	avgs := make([]*big.Int, len(classes))
+// macsClassViews computes each class's per-candidate quantities and their
+// deviations from avg(S,c). Absent assets count as zero in the average, per
+// the paper.
+func macsClassViews(
+	ctx context.Context,
+	classes []macsClass,
+	cands []*macsCandidate,
+) ([]*macsClassView, error) {
+	views := make([]*macsClassView, len(classes))
 	n := big.NewInt(int64(len(cands)))
 	for i, cls := range classes {
-		total := big.NewInt(0)
-		for _, c := range cands {
-			total.Add(total, c.value(cls))
+		vals := make([]*big.Int, len(cands))
+		avg := big.NewInt(0)
+		poolMax := big.NewInt(0)
+		count := 0
+		for j, c := range cands {
+			if j%selectionCancelStride == 0 {
+				if err := selectionInterrupted(ctx); err != nil {
+					return nil, err
+				}
+			}
+			vals[j] = c.value(cls)
+			avg.Add(avg, vals[j])
+			if vals[j].Sign() > 0 {
+				count++
+				if vals[j].Cmp(poolMax) > 0 {
+					poolMax = vals[j]
+				}
+			}
 		}
 		if len(cands) > 0 {
-			total.Div(total, n)
+			avg.Div(avg, n)
 		}
-		avgs[i] = total
+
+		devs := make([]*big.Int, len(cands))
+		held := make([]int, 0, count)
+		for j, v := range vals {
+			if v.Sign() <= 0 {
+				continue
+			}
+			dev := new(big.Int).Sub(v, avg)
+			devs[j] = dev.Abs(dev)
+			held = append(held, j)
+		}
+
+		views[i] = &macsClassView{
+			vals:    vals,
+			devs:    devs,
+			held:    held,
+			poolMax: poolMax,
+		}
 	}
-	return avgs
+	return views, nil
 }
 
 // macsFirstDeficit returns the index of the first class the remaining target
-// still needs, in class order.
-func macsFirstDeficit(remaining Value, classes []macsClass) (int, bool) {
+// still needs, in class order, along with the quantity still missing.
+func macsFirstDeficit(
+	remaining Value,
+	classes []macsClass,
+) (int, *big.Int, bool) {
 	for i, cls := range classes {
 		if cls.isCoin {
 			if remaining.Coin > 0 {
-				return i, true
+				return i, new(big.Int).SetUint64(remaining.Coin), true
 			}
 			continue
 		}
@@ -249,43 +511,47 @@ func macsFirstDeficit(remaining Value, classes []macsClass) (int, bool) {
 		}
 		qty := remaining.Assets.Asset(cls.policy, cls.name)
 		if qty != nil && qty.Sign() > 0 {
-			return i, true
+			return i, qty, true
 		}
 	}
-	return 0, false
+	return 0, nil, false
 }
 
-// macsBestCandidate returns the unselected candidate holding the class with
-// the highest priority, or nil if none holds it.
-func macsBestCandidate(cands []*macsCandidate, selected map[string]bool, cls macsClass, avg *big.Int) *macsPick {
-	var best *macsPick
-	for _, c := range cands {
-		if selected[c.ref] {
-			continue
-		}
-		v := c.value(cls)
-		if v.Sign() <= 0 {
-			continue
-		}
-		dev := new(big.Int).Sub(v, avg)
-		dev.Abs(dev)
-		if best == nil || macsBetter(v, dev, c.ref, best.v, best.dev, best.cand.ref) {
-			best = &macsPick{cand: c, v: v, dev: dev}
-		}
+// betterFallback reports whether the closer (v1, ref1) is the better fallback
+// than (v2, ref2): the larger quantity, ties broken by the smaller UTxO ref so
+// selection stays deterministic.
+func betterFallback(v1 *big.Int, ref1 string, v2 *big.Int, ref2 string) bool {
+	if cmp := v1.Cmp(v2); cmp != 0 {
+		return cmp > 0
 	}
-	return best
+	return ref1 < ref2
 }
 
-// macsBetter reports whether priority v1/(d1+1) beats v2/(d2+1), compared
-// exactly by cross-multiplication. Ties prefer the larger value, then the
-// smaller UTxO ref, so selection is deterministic.
-func macsBetter(v1, d1 *big.Int, ref1 string, v2, d2 *big.Int, ref2 string) bool {
-	one := big.NewInt(1)
-	left := new(big.Int).Add(d2, one)
-	left.Mul(left, v1)
-	right := new(big.Int).Add(d1, one)
-	right.Mul(right, v2)
-	if cmp := left.Cmp(right); cmp != 0 {
+// macsPriorityCmp compares MACS priorities, reusing its own scratch space so
+// that sorting a pool by priority does not allocate per comparison. It holds
+// mutable state, so each selection makes its own.
+type macsPriorityCmp struct {
+	left, right, one big.Int
+}
+
+func newMACSPriorityCmp() *macsPriorityCmp {
+	cmp := &macsPriorityCmp{}
+	cmp.one.SetInt64(1)
+	return cmp
+}
+
+// better reports whether priority v1/(d1+1) beats v2/(d2+1), compared exactly
+// by cross-multiplication. Ties prefer the larger value, then the smaller
+// UTxO ref, so selection is deterministic.
+func (c *macsPriorityCmp) better(
+	v1, d1 *big.Int, ref1 string,
+	v2, d2 *big.Int, ref2 string,
+) bool {
+	c.left.Add(d2, &c.one)
+	c.left.Mul(&c.left, v1)
+	c.right.Add(d1, &c.one)
+	c.right.Mul(&c.right, v2)
+	if cmp := c.left.Cmp(&c.right); cmp != 0 {
 		return cmp > 0
 	}
 	if cmp := v1.Cmp(v2); cmp != 0 {
@@ -298,7 +564,13 @@ func macsBetter(v1, d1 *big.Int, ref1 string, v2, d2 *big.Int, ref2 string) bool
 // trying lowest-priority picks first. Greedy per-class coverage can select a
 // UTxO for one asset that a later pick (chosen for a different asset) also
 // carries, leaving the earlier pick redundant.
-func macsPruneRedundant(picks []*macsPick, classes []macsClass, target Value) {
+func macsPruneRedundant(
+	picks []*macsPick,
+	views []*macsClassView,
+	classes []macsClass,
+	target Value,
+	cmp *macsPriorityCmp,
+) {
 	if len(picks) < 2 {
 		return
 	}
@@ -310,7 +582,7 @@ func macsPruneRedundant(picks []*macsPick, classes []macsClass, target Value) {
 	for i, cls := range classes {
 		sums[i] = big.NewInt(0)
 		for _, p := range picks {
-			sums[i].Add(sums[i], p.cand.value(cls))
+			sums[i].Add(sums[i], views[i].vals[p.idx])
 		}
 		if cls.isCoin {
 			need[i] = new(big.Int).SetUint64(target.Coin)
@@ -322,13 +594,16 @@ func macsPruneRedundant(picks []*macsPick, classes []macsClass, target Value) {
 	order := make([]*macsPick, len(picks))
 	copy(order, picks)
 	sort.SliceStable(order, func(i, j int) bool {
-		return macsBetter(order[j].v, order[j].dev, order[j].cand.ref, order[i].v, order[i].dev, order[i].cand.ref)
+		return cmp.better(
+			order[j].v, order[j].dev, order[j].cand.ref,
+			order[i].v, order[i].dev, order[i].cand.ref,
+		)
 	})
 
 	for _, p := range order {
 		redundant := true
-		for i, cls := range classes {
-			rest := new(big.Int).Sub(sums[i], p.cand.value(cls))
+		for i := range classes {
+			rest := new(big.Int).Sub(sums[i], views[i].vals[p.idx])
 			if rest.Cmp(need[i]) < 0 {
 				redundant = false
 				break
@@ -336,8 +611,8 @@ func macsPruneRedundant(picks []*macsPick, classes []macsClass, target Value) {
 		}
 		if redundant {
 			p.pruned = true
-			for i, cls := range classes {
-				sums[i].Sub(sums[i], p.cand.value(cls))
+			for i := range classes {
+				sums[i].Sub(sums[i], views[i].vals[p.idx])
 			}
 		}
 	}

--- a/macs_change_test.go
+++ b/macs_change_test.go
@@ -1,0 +1,207 @@
+package apollo
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// The ledger cannot hold a change output below the minimum UTxO value, so a
+// selection whose leftover lands between zero and that minimum leaves the
+// builder no choice but to fold the remainder into the fee, where the user
+// loses it outright. MACS scores candidates by
+//
+//	P(u,c) = v / (|v - avg| + 1)
+//
+// which peaks near the pool mean, so a payment near the mean is exactly the
+// case that strands its change — and preferring the candidate that covers the
+// deficit alone makes it worse, because the tightest cover leaves the smallest
+// change. These tests pin the floor that steers around the dead band.
+
+// realisticPool is a mixed wallet of ADA-only UTxOs from 1 to 21 ADA, the shape
+// where the mean sits in the middle of the payment range.
+func realisticPool(t *testing.T, n int, seed int64) []common.Utxo {
+	t.Helper()
+	addr := testAddress(t)
+	rng := rand.New(rand.NewSource(seed))
+	pool := make([]common.Utxo, 0, n)
+	for i := range n {
+		//nolint:gosec // test sequence
+		pool = append(pool, benchUtxo(
+			addr, uint64(i), 1_000_000+rng.Uint64()%20_000_000, nil,
+		))
+	}
+	return pool
+}
+
+// buildWith builds a real transfer of pay lovelace out of pool using sel.
+func buildWith(
+	t *testing.T,
+	sel CoinSelector,
+	pool []common.Utxo,
+	pay int64,
+) (*Apollo, error) {
+	t.Helper()
+	addr := testAddress(t)
+	cc := setupFixedContext()
+	for _, u := range pool {
+		cc.AddUtxo(addr, u)
+	}
+	p, err := NewPayment(validTestAddrBech32, pay, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return New(cc).
+		SetCoinSelector(sel).
+		SetWallet(NewExternalWallet(addr)).
+		AddPayment(p).
+		SetTtl(50_000_000).
+		Complete()
+}
+
+// TestMACSDoesNotStrandChangeAsFee is the regression guard. Without the
+// MinChange floor the configured selector burned its change on a majority of
+// payment amounts against this pool, paying up to 1,011,827 lovelace where the
+// size-based fee is 168,537 — six times the fee, with the difference simply
+// lost.
+func TestMACSDoesNotStrandChangeAsFee(t *testing.T) {
+	pool := realisticPool(t, 400, 7)
+
+	var stranded, n int
+	var worst uint64
+	for pay := int64(2_000_000); pay <= 18_000_000; pay += 250_000 {
+		a, err := buildWith(t, NewMACSSelector(), pool, pay)
+		if err != nil {
+			t.Fatalf("pay=%d: %v", pay, err)
+		}
+		n++
+		body := a.GetTx().Body
+		if body.TxFee > worst {
+			worst = body.TxFee
+		}
+		// A single output means the change output was dropped, so its value
+		// went into the fee.
+		if len(body.Outputs()) == 1 {
+			stranded++
+			t.Errorf(
+				"pay=%d stranded its change: fee=%d with one output",
+				pay, body.TxFee,
+			)
+		}
+	}
+	if n == 0 {
+		t.Fatal("no transactions were built")
+	}
+	// Every transaction here is one input and two outputs, so the fee should
+	// not exceed the size-based fee for that shape by any margin.
+	const plainTransferFee = 168_537
+	if worst > plainTransferFee {
+		t.Errorf(
+			"worst fee %d exceeds the plain 1-in 2-out fee %d, so change is "+
+				"still being absorbed",
+			worst, plainTransferFee,
+		)
+	}
+	t.Logf("%d payment amounts, %d stranded, worst fee %d", n, stranded, worst)
+}
+
+// TestMACSSelectsWhenEveryCloserStrandsChange covers the cost of the floor: it
+// must steer selection, never block it. When no candidate can leave an
+// emittable change amount the selector still has to return a covering set.
+func TestMACSSelectsWhenEveryCloserStrandsChange(t *testing.T) {
+	addr := testAddress(t)
+	// One UTxO, and it leaves change far inside the dead band.
+	pool := []common.Utxo{benchUtxo(addr, 1, 10_400_000, nil)}
+
+	a, err := buildWith(t, NewMACSSelector(), pool, 10_000_000)
+	if err != nil {
+		t.Fatalf("selection blocked by the MinChange floor: %v", err)
+	}
+	body := a.GetTx().Body
+	if len(body.Inputs()) != 1 {
+		t.Errorf("expected the single UTxO to be spent, got %d inputs",
+			len(body.Inputs()))
+	}
+	// The leftover is genuinely unemittable, so it is expected to be absorbed;
+	// what matters is that the transaction was built at all.
+	t.Logf("fee=%d outputs=%d", body.TxFee, len(body.Outputs()))
+}
+
+// TestMACSPrefersLargerCloserOverStrandedChange pins the choice directly: given
+// a tight cover that strands its change and a larger one that does not, the
+// larger is taken even though the tight one scores higher on priority.
+func TestMACSPrefersLargerCloserOverStrandedChange(t *testing.T) {
+	addr := testAddress(t)
+	// Paying 10 ADA: the 10.4 ADA UTxO leaves 0.4 ADA (unemittable), the
+	// 14 ADA UTxO leaves 4 ADA (fine). Filler pulls the mean toward 10.4 so
+	// priority alone would take the tight one.
+	pool := make([]common.Utxo, 0, 22)
+	pool = append(pool,
+		benchUtxo(addr, 1, 10_400_000, nil),
+		benchUtxo(addr, 2, 14_000_000, nil),
+	)
+	for i := range 20 {
+		//nolint:gosec // test sequence
+		pool = append(pool, benchUtxo(addr, uint64(100+i), 10_400_000, nil))
+	}
+
+	selected, err := NewMACSSelector().
+		Select(t.Context(), pool, NewSimpleValue(10_000_000))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(selected) == 0 {
+		t.Fatal("nothing selected")
+	}
+	// The first pick covers the target; dust sweeping may append more.
+	got := selected[0].Output.Amount().Uint64()
+	if got != 14_000_000 {
+		t.Errorf(
+			"selected a %d lovelace UTxO, want 14000000: a tight cover that "+
+				"strands its change was preferred over one that does not",
+			got,
+		)
+	}
+}
+
+// TestMACSZeroValueKeepsPaperBehavior confirms the floor is opt-in through the
+// constructor, so the zero value still runs the published algorithm.
+func TestMACSZeroValueKeepsPaperBehavior(t *testing.T) {
+	if got := (&MACSSelector{}).MinChange; got != 0 {
+		t.Errorf("zero value MinChange = %d, want 0", got)
+	}
+	if got := NewMACSSelector().MinChange; got != macsSelectorMinChange {
+		t.Errorf(
+			"NewMACSSelector MinChange = %d, want %d",
+			got, macsSelectorMinChange,
+		)
+	}
+}
+
+// TestMACSMinChangeIsDeterministic guards the fallback comparator: equal-value
+// closers must break ties by ref, or selection stops being reproducible.
+func TestMACSMinChangeIsDeterministic(t *testing.T) {
+	pool := realisticPool(t, 300, 19)
+	target := NewSimpleValue(9_500_000)
+
+	first, err := NewMACSSelector().Select(t.Context(), pool, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		again, err := NewMACSSelector().Select(t.Context(), pool, target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("selection size changed: %d then %d", len(first), len(again))
+		}
+		for i := range first {
+			if utxoRef(first[i]) != utxoRef(again[i]) {
+				t.Fatalf("selection differs at %d: %s vs %s",
+					i, utxoRef(first[i]), utxoRef(again[i]))
+			}
+		}
+	}
+}

--- a/macs_test.go
+++ b/macs_test.go
@@ -1,6 +1,7 @@
 package apollo
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -34,7 +35,9 @@ func TestMACSPrefersNearAverageUtxo(t *testing.T) {
 	}
 	// Pool average is 17 ADA; the 12 ADA UTxO has the highest priority
 	// (12/(5M+1) beats 50/(33M+1) and 10/(7M+1)).
-	selected, err := (&MACSSelector{}).Select(pool, NewSimpleValue(5_000_000))
+	selected, err := (&MACSSelector{}).Select(
+		t.Context(), pool, NewSimpleValue(5_000_000),
+	)
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}
@@ -43,6 +46,135 @@ func TestMACSPrefersNearAverageUtxo(t *testing.T) {
 	}
 	if got := selected[0].Output.Amount().Uint64(); got != 12_000_000 {
 		t.Errorf("expected the near-average 12 ADA UTxO, got %d lovelace", got)
+	}
+}
+
+// TestMACSPrefersSingleSufficientUtxo pins the fix for the dust trap in the
+// priority formula: avg(S,c) is a pool-wide mean, so a pool of many dust
+// UTxOs pulls it down next to the dust and every dust UTxO then outscores the
+// one UTxO that covers the whole target. A candidate that closes the deficit
+// on its own must be preferred instead, at any dust count.
+func TestMACSPrefersSingleSufficientUtxo(t *testing.T) {
+	variants := []struct {
+		label     string
+		sel       *MACSSelector
+		maxInputs int
+	}{
+		{label: "pure", sel: &MACSSelector{}, maxInputs: 1},
+		// The default selector may also sweep dust, but nothing more.
+		{
+			label:     "default",
+			sel:       NewMACSSelector(),
+			maxInputs: 1 + NewMACSSelector().MaxDustInputs,
+		},
+	}
+	for _, dust := range []int{10, 200, 1000} {
+		for _, v := range variants {
+			name := v.label + "/" + strconv.Itoa(dust)
+			t.Run(name, func(t *testing.T) {
+				pool := make([]common.Utxo, 0, dust+1)
+				for i := 0; i < dust; i++ {
+					pool = append(pool, makeSelectorUtxo(
+						t, 0x10, uint32(i), 1_000_000, nil,
+					))
+				}
+				sufficient := makeSelectorUtxo(
+					t, 0x20, 0, 100_000_000, nil,
+				)
+				pool = append(pool, sufficient)
+
+				target := NewSimpleValue(90_000_000)
+				selected, err := v.sel.Select(t.Context(), pool, target)
+				if err != nil {
+					t.Fatalf("Select failed: %v", err)
+				}
+				if !sumSelected(t, selected).GreaterOrEqual(target) {
+					t.Fatal("selection does not cover target")
+				}
+				if len(selected) > v.maxInputs {
+					t.Errorf(
+						"selected %d inputs for a target one UTxO covers, want at most %d",
+						len(selected), v.maxInputs,
+					)
+				}
+				found := false
+				for _, u := range selected {
+					if utxoRef(u) == utxoRef(sufficient) {
+						found = true
+					}
+				}
+				if !found {
+					t.Error("the single sufficient UTxO was not selected")
+				}
+			})
+		}
+	}
+}
+
+// TestMACSStillPrefersMidRangeOverLargest guards the dust fix from
+// degenerating MACS into largest-first: priority still decides between the
+// UTxOs that cover the target alone, so the closer of the two to the pool
+// average wins even though largest-first would take the biggest.
+func TestMACSStillPrefersMidRangeOverLargest(t *testing.T) {
+	pool := make([]common.Utxo, 0, 202)
+	for i := 0; i < 200; i++ {
+		pool = append(pool, makeSelectorUtxo(t, 0x10, uint32(i), 1_000_000, nil))
+	}
+	midRange := makeSelectorUtxo(t, 0x20, 0, 30_000_000, nil)
+	largest := makeSelectorUtxo(t, 0x30, 0, 100_000_000, nil)
+	pool = append(pool, midRange, largest)
+
+	// The pool average is 1.63 ADA, so dust has the highest priority of all
+	// but cannot cover 20 ADA alone; of the two that can, 30 ADA scores
+	// 30/28.37 against 100 ADA's 100/98.37.
+	selected, err := (&MACSSelector{}).Select(
+		t.Context(), pool, NewSimpleValue(20_000_000),
+	)
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("expected 1 input, got %d", len(selected))
+	}
+	if utxoRef(selected[0]) != utxoRef(midRange) {
+		t.Errorf(
+			"expected the mid-range 30 ADA UTxO, got %s",
+			utxoRef(selected[0]),
+		)
+	}
+}
+
+// TestMACSCoversDeficitAfterAssetPickTookTheLargest exercises the path where
+// the class's largest holder has already gone to an earlier asset class, so
+// no single candidate can close the coin deficit and the remainder has to be
+// accumulated before a closer finishes the job.
+func TestMACSCoversDeficitAfterAssetPickTookTheLargest(t *testing.T) {
+	tokenHolder := makeSelectorUtxo(
+		t, 0x01, 0, 100_000_000, makeTestAssets(0xAA, "tokenA", 50),
+	)
+	pool := []common.Utxo{
+		tokenHolder,
+		makeSelectorUtxo(t, 0x02, 0, 30_000_000, nil),
+		makeSelectorUtxo(t, 0x03, 0, 30_000_000, nil),
+		makeSelectorUtxo(t, 0x04, 0, 30_000_000, nil),
+	}
+	target := NewValue(160_000_000, makeTestAssets(0xAA, "tokenA", 50))
+
+	selected, err := (&MACSSelector{}).Select(t.Context(), pool, target)
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+	if !sumSelected(t, selected).GreaterOrEqual(target) {
+		t.Fatal("selection does not cover target")
+	}
+	if len(selected) != 3 {
+		t.Fatalf("expected 3 inputs, got %d", len(selected))
+	}
+	if utxoRef(selected[0]) != utxoRef(tokenHolder) {
+		t.Errorf(
+			"expected the token holder first, got %s",
+			utxoRef(selected[0]),
+		)
 	}
 }
 
@@ -57,7 +189,7 @@ func TestMACSMultiAssetSingleInput(t *testing.T) {
 		makeSelectorUtxo(t, 0x03, 0, 2_000_000, makeTestAssets(0xAA, "tokenA", 10)),
 	}
 	target := NewValue(1_000_000, makeTestAssets(0xAA, "tokenA", 50))
-	selected, err := (&MACSSelector{}).Select(pool, target)
+	selected, err := (&MACSSelector{}).Select(t.Context(), pool, target)
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}
@@ -82,7 +214,9 @@ func TestMACSDustSweep(t *testing.T) {
 	pool := []common.Utxo{dust1, dust2, dust3, tokenDust, big1, big2}
 
 	sel := &MACSSelector{DustThreshold: 1_000_000, MaxDustInputs: 2}
-	selected, err := sel.Select(pool, NewSimpleValue(5_000_000))
+	selected, err := sel.Select(
+		t.Context(), pool, NewSimpleValue(5_000_000),
+	)
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}
@@ -111,7 +245,9 @@ func TestMACSDustSweepDisabledByDefault(t *testing.T) {
 		makeSelectorUtxo(t, 0x01, 0, 400_000, nil),
 		makeSelectorUtxo(t, 0x02, 0, 10_000_000, nil),
 	}
-	selected, err := (&MACSSelector{}).Select(pool, NewSimpleValue(5_000_000))
+	selected, err := (&MACSSelector{}).Select(
+		t.Context(), pool, NewSimpleValue(5_000_000),
+	)
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}
@@ -146,7 +282,7 @@ func TestMACSPrunesRedundantInputs(t *testing.T) {
 	targetAssets.Add(makeTestAssets(0xBB, "tokenB", 50))
 	target := NewValue(4_000_000, targetAssets)
 
-	selected, err := (&MACSSelector{}).Select(pool, target)
+	selected, err := (&MACSSelector{}).Select(t.Context(), pool, target)
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -1,68 +1,117 @@
 package apollo
 
 import (
-	"encoding/hex"
+	"bytes"
+	"math/big"
 	"sort"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// The sort helpers below derive what they compare once per element, into a key
+// slice, and sort a permutation of indexes over it. Validating a UTxO and
+// reading its id or amount cost far more than the comparison itself, and a
+// comparator runs O(n log n) times.
+//
+// Only valid UTxOs are inspected further: a malformed one has no usable input
+// or output to read.
+
+// utxoSortKey holds the terms SortUtxos compares.
+type utxoSortKey struct {
+	valid     bool
+	hasAssets bool
+	amount    *big.Int
+}
+
+// inputSortKey holds the terms SortInputs compares.
+type inputSortKey struct {
+	valid bool
+	id    []byte
+	index uint32
+}
+
+// identityOrder returns the permutation the comparators sort, initially the
+// slice's own order so that tied elements keep it.
+func identityOrder(n int) []int {
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	return order
+}
+
+// permute returns utxos rearranged into the given order.
+func permute(utxos []common.Utxo, order []int) []common.Utxo {
+	res := make([]common.Utxo, len(utxos))
+	for i, idx := range order {
+		res[i] = utxos[idx]
+	}
+	return res
+}
+
 // SortUtxos sorts a slice of UTxOs with ADA-only UTxOs first (by descending amount),
 // then UTxOs with assets.
 func SortUtxos(utxos []common.Utxo) []common.Utxo {
-	res := make([]common.Utxo, len(utxos))
-	copy(res, utxos)
-	sort.SliceStable(res, func(i, j int) bool {
-		iValid := validateUtxo(res[i]) == nil
-		jValid := validateUtxo(res[j]) == nil
-		if iValid != jValid {
-			return iValid
+	keys := make([]utxoSortKey, len(utxos))
+	for i, utxo := range utxos {
+		if validateUtxo(utxo) != nil {
+			continue
 		}
-		if !iValid {
+		keys[i] = utxoSortKey{
+			valid:     true,
+			hasAssets: utxo.Output.Assets() != nil,
+			amount:    utxo.Output.Amount(),
+		}
+	}
+	order := identityOrder(len(utxos))
+	sort.SliceStable(order, func(a, b int) bool {
+		i, j := &keys[order[a]], &keys[order[b]]
+		if i.valid != j.valid {
+			return i.valid
+		}
+		if !i.valid {
 			return false
 		}
-		iHasAssets := res[i].Output.Assets() != nil
-		jHasAssets := res[j].Output.Assets() != nil
-		if !iHasAssets && !jHasAssets {
-			iAmt := res[i].Output.Amount()
-			jAmt := res[j].Output.Amount()
-			if iAmt != nil && jAmt != nil {
-				return iAmt.Cmp(jAmt) > 0
+		if i.hasAssets == j.hasAssets {
+			if i.amount != nil && j.amount != nil {
+				return i.amount.Cmp(j.amount) > 0
 			}
 			return false
 		}
-		if iHasAssets && jHasAssets {
-			iAmt := res[i].Output.Amount()
-			jAmt := res[j].Output.Amount()
-			if iAmt != nil && jAmt != nil {
-				return iAmt.Cmp(jAmt) > 0
-			}
-			return false
-		}
-		return jHasAssets
+		return j.hasAssets
 	})
-	return res
+	return permute(utxos, order)
 }
 
 // SortInputs sorts UTxOs by transaction ID and index for deterministic ordering.
 func SortInputs(inputs []common.Utxo) []common.Utxo {
-	sorted := make([]common.Utxo, len(inputs))
-	copy(sorted, inputs)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		iValid := validateUtxo(sorted[i]) == nil
-		jValid := validateUtxo(sorted[j]) == nil
-		if iValid != jValid {
-			return iValid
+	keys := make([]inputSortKey, len(inputs))
+	for i, utxo := range inputs {
+		if validateUtxo(utxo) != nil {
+			continue
 		}
-		if !iValid {
+		keys[i] = inputSortKey{
+			valid: true,
+			id:    utxo.Id.Id().Bytes(),
+			index: utxo.Id.Index(),
+		}
+	}
+	order := identityOrder(len(inputs))
+	sort.SliceStable(order, func(a, b int) bool {
+		i, j := &keys[order[a]], &keys[order[b]]
+		if i.valid != j.valid {
+			return i.valid
+		}
+		if !i.valid {
 			return false
 		}
-		iId := hex.EncodeToString(sorted[i].Id.Id().Bytes())
-		jId := hex.EncodeToString(sorted[j].Id.Id().Bytes())
-		if iId != jId {
-			return iId < jId
+		// Transaction ids are all Blake2b256, so they are of equal width and
+		// comparing the raw bytes orders them exactly as comparing their hex
+		// encodings did.
+		if cmp := bytes.Compare(i.id, j.id); cmp != 0 {
+			return cmp < 0
 		}
-		return sorted[i].Id.Index() < sorted[j].Id.Index()
+		return i.index < j.index
 	})
-	return sorted
+	return permute(inputs, order)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,8 +1,11 @@
 package apollo
 
 import (
+	"encoding/hex"
+	"fmt"
 	"math"
 	"math/big"
+	"sort"
 	"strings"
 	"testing"
 
@@ -142,6 +145,168 @@ func TestUtxoRefPreservesUint32Index(t *testing.T) {
 	utxo := makeTestUtxo(t, common.Blake2b256{1}, math.MaxUint32, 1_000_000)
 	if got := utxoRef(utxo); !strings.HasSuffix(got, "#4294967295") {
 		t.Fatalf("UTxO ref = %q, want uint32 index preserved", got)
+	}
+}
+
+// BenchmarkSortUtxos and BenchmarkSortInputs cover the cost the sort keys
+// were hoisted out of the comparators for: validating and hex-encoding once
+// per element instead of once per comparison.
+func BenchmarkSortUtxos(b *testing.B) {
+	pool, _ := sweepSelectionPool(b, 10_000)
+	for i := 0; i < b.N; i++ {
+		SortUtxos(pool)
+	}
+}
+
+func BenchmarkSortInputs(b *testing.B) {
+	pool, _ := sweepSelectionPool(b, 10_000)
+	for i := 0; i < b.N; i++ {
+		SortInputs(pool)
+	}
+}
+
+// referenceSortUtxos is SortUtxos as it was before the per-element sort keys
+// were hoisted out of the comparator, kept to prove the hoisting changed no
+// ordering. Do not optimize: it is the oracle, not production code.
+func referenceSortUtxos(utxos []common.Utxo) []common.Utxo {
+	res := make([]common.Utxo, len(utxos))
+	copy(res, utxos)
+	sort.SliceStable(res, func(i, j int) bool {
+		iValid := validateUtxo(res[i]) == nil
+		jValid := validateUtxo(res[j]) == nil
+		if iValid != jValid {
+			return iValid
+		}
+		if !iValid {
+			return false
+		}
+		iHasAssets := res[i].Output.Assets() != nil
+		jHasAssets := res[j].Output.Assets() != nil
+		if !iHasAssets && !jHasAssets {
+			iAmt := res[i].Output.Amount()
+			jAmt := res[j].Output.Amount()
+			if iAmt != nil && jAmt != nil {
+				return iAmt.Cmp(jAmt) > 0
+			}
+			return false
+		}
+		if iHasAssets && jHasAssets {
+			iAmt := res[i].Output.Amount()
+			jAmt := res[j].Output.Amount()
+			if iAmt != nil && jAmt != nil {
+				return iAmt.Cmp(jAmt) > 0
+			}
+			return false
+		}
+		return jHasAssets
+	})
+	return res
+}
+
+// referenceSortInputs is the pre-hoist SortInputs; see referenceSortUtxos.
+func referenceSortInputs(inputs []common.Utxo) []common.Utxo {
+	sorted := make([]common.Utxo, len(inputs))
+	copy(sorted, inputs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		iValid := validateUtxo(sorted[i]) == nil
+		jValid := validateUtxo(sorted[j]) == nil
+		if iValid != jValid {
+			return iValid
+		}
+		if !iValid {
+			return false
+		}
+		iId := hex.EncodeToString(sorted[i].Id.Id().Bytes())
+		jId := hex.EncodeToString(sorted[j].Id.Id().Bytes())
+		if iId != jId {
+			return iId < jId
+		}
+		return sorted[i].Id.Index() < sorted[j].Id.Index()
+	})
+	return sorted
+}
+
+// sortIdentity identifies a UTxO by its output's address, which is safe to
+// read for the malformed entries too and unique per element in the pool the
+// test below builds.
+func sortIdentity(utxo common.Utxo) string {
+	return fmt.Sprintf("%p/%p", utxo.Id, utxo.Output)
+}
+
+// orderingPool builds a slice exercising every branch of both comparators:
+// ADA-only and asset-carrying UTxOs, repeated amounts, repeated transaction
+// ids with differing indexes, and malformed entries with a nil input or a nil
+// output. Every element has a distinct identity so any reordering shows up.
+func orderingPool(t *testing.T) []common.Utxo {
+	t.Helper()
+	amounts := []uint64{1_000_000, 2_000_000, 3_000_000}
+	var pool []common.Utxo
+	// The transaction ids straddle the hex digit/letter boundary, where a
+	// lexicographic hex comparison and a raw byte comparison could disagree
+	// if the encodings were not of equal width.
+	for _, hash := range []byte{0x01, 0x0f, 0xa0, 0xff} {
+		for index := uint32(0); index < 2; index++ {
+			for _, amount := range amounts {
+				pool = append(
+					pool,
+					makeSelectorUtxo(t, hash, index, amount, nil),
+					makeSelectorUtxo(
+						t, hash, index, amount,
+						makeTestAssets(0xAA, "tokenA", 1),
+					),
+				)
+			}
+		}
+	}
+	var nilInput *shelley.ShelleyTransactionInput
+	var nilOutput *babbage.BabbageTransactionOutput
+	valid := makeSelectorUtxo(t, 0x09, 0, 4_000_000, nil)
+	pool = append(pool,
+		common.Utxo{Id: nilInput, Output: valid.Output},
+		common.Utxo{Id: valid.Id, Output: nilOutput},
+	)
+	return pool
+}
+
+// TestSortOrderingMatchesPreHoistReference proves hoisting validation and hex
+// encoding out of the sort comparators left both orderings byte-identical,
+// including the stable order of tied elements, for every rotation of a pool
+// full of ties.
+func TestSortOrderingMatchesPreHoistReference(t *testing.T) {
+	pool := orderingPool(t)
+	sorts := []struct {
+		name      string
+		got       func([]common.Utxo) []common.Utxo
+		reference func([]common.Utxo) []common.Utxo
+	}{
+		{"SortUtxos", SortUtxos, referenceSortUtxos},
+		{"SortInputs", SortInputs, referenceSortInputs},
+	}
+	for _, s := range sorts {
+		t.Run(s.name, func(t *testing.T) {
+			for shift := range pool {
+				input := make([]common.Utxo, 0, len(pool))
+				input = append(input, pool[shift:]...)
+				input = append(input, pool[:shift]...)
+
+				got := s.got(input)
+				want := s.reference(input)
+				if len(got) != len(want) {
+					t.Fatalf(
+						"shift %d: got %d UTxOs, want %d",
+						shift, len(got), len(want),
+					)
+				}
+				for i := range want {
+					if sortIdentity(got[i]) != sortIdentity(want[i]) {
+						t.Fatalf(
+							"shift %d: ordering differs at %d",
+							shift, i,
+						)
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Three related changes to coin selection. The interface change is the reason this cannot wait: `CoinSelector` is a public interface third parties implement, so adding a parameter after 2.0 would need a 3.0.

## 1. `Select` takes a `context.Context`

```go
Select(ctx context.Context, available []common.Utxo, target Value) ([]common.Utxo, error)
```

Threaded from `Apollo.selectCoins` via `a.requestContext`, so `WithContext` finally reaches selection. Both selectors poll at a 256-entry stride and wrap `ctx.Err()` with `%w`, so `errors.Is(err, context.Canceled)` works. A nil context is tolerated, since `Select` is exported and must not panic.

Verified: a pre-cancelled context on a 10,000-UTxO sweep returns `coin selection interrupted: context canceled` in **7µs**. A separate test uses a context reporting done only after three `Err()` calls, proving cancellation is honoured *inside* the loops rather than only on entry.

## 2. MACS no longer prefers dust over a single sufficient UTxO

Target 90 ADA against N dust UTxOs (1 ADA) plus one 100 ADA UTxO:

| Dust UTxOs | before | after | LargestFirst |
|---|---|---|---|
| 10 | 1 | 1 | 1 |
| 200 | **90** | **1** | 1 |
| 1,000 | **90** | **1** | 1 |

**The audit's suggested fix does not work, and this PR does not use it.** Recomputing `avg` over the *unselected* pool each round was simulated and still yields 90 picks: dust outscores the large UTxO while `avg < 1,980,197`, i.e. while more than ~100 dust UTxOs remain — and the deficit is exhausted after 90 picks, long before that. Consuming dust barely moves a dust-dominated mean.

Instead: a candidate that covers a class's entire remaining deficit alone always beats accumulation, and priority decides only *which* such candidate to take. `avg` stays pool-wide as the paper defines it, and the `dustThreshold`/`maxDustInputs` sweep is untouched.

Crucially this does **not** degenerate into largest-first — `TestMACSStillPrefersMidRangeOverLargest` pins it: with 200 dust plus a 30 ADA and a 100 ADA UTxO and a 20 ADA target, MACS picks the 30 where largest-first takes the 100.

**Trade-off to be aware of:** in a 200-round wallet simulation the default selector now averages 2.58 inputs/tx (was 3.09) with 7.77 ADA change (was 3.1), and the final pool grows to 307 (was 204). It consolidates less aggressively, because it consumes fewer inputs per transaction. Dust is still swept away (final dust count 1). Preferring one covering UTxO and consolidating aggressively are in tension; this trades some consolidation for not paying 90 inputs' worth of fee to do a 1-input job.

## 3. O(n²) removed

`avg(S,c)` is constant for a selection, so each candidate's priority is too. Per-class values and deviations are now computed once and picking walks a forward-only cursor over an ordering built on first use — a class covered by one candidate needs no ordering at all.

Near-full sweep, measured:

| Pool | before | after |
|---|---|---|
| 500 | 152.5 ms | **2.2 ms** |
| 1,000 | 615.5 ms | **4.8 ms** |
| 2,000 | 2.502 s | **11.4 ms** |
| 4,000 | 10.173 s | **25.6 ms** |

Scaling drops from ~4.05× per doubling (quadratic) to ~2.1× (near-linear). At 2,000 UTxOs that is ~216× faster.

Selection results are unchanged where the dust fix does not apply: all `runSelectorConformance` cases and every existing MACS test pass unmodified.

## `utils.go` sort hoisting

`SortUtxos`/`SortInputs` called `hex.EncodeToString` and `validateUtxo` **inside the comparator**. Hoisted: `SortUtxos` 6.21 ms/49,630 allocs → **2.92 ms/21,007**; `SortInputs` 10.16 ms/49,630 → **3.26 ms/11,005** at 10,000 elements. That accounts for most of the largest-first speedup too (Ada10k 118.9 M → 20.7 M ns/op, same inputs selected).

Ordering is proven unchanged by `TestSortOrderingMatchesPreHoistReference`, which runs both sorts against copies of the *pre-hoist* comparators over **every rotation** of a tie-heavy pool — repeated amounts, repeated tx ids with differing indexes, asset-carrying and ADA-only entries, ids straddling the hex digit/letter boundary, plus nil-input and nil-output entries. Confirmed non-vacuous by flipping the index comparison and the assets branch; each break makes it fail. `SortInputs` now compares raw id bytes rather than hex, which is identical ordering for fixed-width Blake2b256 ids and is pinned by that test.

## Follow-ups not in this PR

- `CHANGELOG.md` needs the breaking-change entry for the `Select` signature.
- `docs/design/2026-06-11-macs-coin-selection-design.md` now under-describes the algorithm: it documents priority-only picking and carries the old benchmark table.


---

## The default was costing fees, and now it is not

`SetCoinSelector` defaults to MACS, and MACS was adopted on an input-count benchmark ("785 inputs against MACS's 15"). Input count is a proxy. Measuring the thing that matters — the fee on a transaction actually built through `Complete()`, with mainnet parameters — showed the default losing money on ordinary ADA payments.

A change amount below the minimum UTxO value cannot be emitted as an output, so the builder folds it into the fee and **the user loses it outright**. MACS's priority function peaks at the pool mean, so a payment near the mean lands its leftover inside that dead band. Preferring the tightest cover (this PR's dust fix) puts it there far more often, because the tightest cover leaves the smallest change.

Against a 400-UTxO wallet of 1–21 ADA UTxOs, sweeping the payment from 2 to 18 ADA:

| | before | after |
|---|---|---|
| transactions stranding their change | **33 of 65** | **0 of 65** |
| worst fee | **1,011,827** | 168,537 |
| avg fee | 221,009 | **168,537** (the size-based minimum) |
| overpay across 65 payments | **3.411 ADA** | **0.000 ADA** |

The worst case pays six times the fee, `outputs=1` with the change output gone. The bug predates the closer preference — 4 of 65 on current master — but the preference multiplied its frequency eightfold, so it is this PR's to fix.

`MACSSelector` gains `MinChange`, defaulted by `NewMACSSelector` to 1.5 ADA. A closer whose leftover would land in the dead band is skipped where the pool offers an alternative; when every closer strands its leftover the largest is taken, since a bigger input cannot produce smaller change. **The floor steers selection and never blocks it** — `TestMACSSelectsWhenEveryCloserStrandsChange` pins that with a one-UTxO wallet. The zero value keeps `MinChange: 0` and runs the published algorithm unchanged.

## Is MACS still the right default?

This was worth re-asking rather than assuming. Measured on real built transactions:

| | MACS before | **MACS after** | largest-first |
|---|---|---|---|
| 150-tx wallet lifetime, ADA only | 38.58 ADA | **25.42 ADA** | 25.28 ADA |
| multi-asset payment (500-UTxO pool) | 200,437 / 20 in | **200,437 / 20 in** | 623,629 / 286 in |
| final dust UTxOs | 1 | **1** | 90 |

Before this change the answer was no: MACS cost 34% more over a wallet's life. After it, MACS is within **0.56%** of largest-first on plain ADA while staying **3.1× cheaper** on multi-asset, and it ends with 1 dust UTxO instead of 90. That 0.56% is the dust sweep, and it buys a pool that does not degrade. So MACS stays the default on merit rather than novelty.

Guards: disabling only the `MinChange` default turns 34 assertions red across `TestMACSDoesNotStrandChangeAsFee` and `TestMACSPrefersLargerCloserOverStrandedChange`.
