### PR TITLE
fix: validate plutus encoder tags

### DIFF
--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"math/big"
 	"reflect"
-	"strconv"
 
 	"github.com/blinklabs-io/plutigo/data"
 )
@@ -79,25 +78,15 @@ func marshalSliceElement(elem reflect.Value) (data.PlutusData, error) {
 }
 
 func unmarshalFromList(pd data.PlutusData, val reflect.Value, typ reflect.Type) error {
-	var fields []data.PlutusData
-
-	// Read expected Constr tag from struct tag
-	var expectedConstr uint
-	hasExpectedConstr := false
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.Name == "_" {
-			if constrStr := field.Tag.Get("plutusConstr"); constrStr != "" {
-				c, err := strconv.ParseUint(constrStr, 10, 32)
-				if err != nil {
-					return fmt.Errorf("invalid plutusConstr tag %q: %w", constrStr, err)
-				}
-				expectedConstr = uint(c)
-				hasExpectedConstr = true
-			}
-			break
-		}
+	container, expectedConstr, hasExpectedConstr, err := readContainerMetadata(typ)
+	if err != nil {
+		return err
 	}
+	if container == containerMap {
+		return fmt.Errorf("unmarshalFromList received map container")
+	}
+
+	var fields []data.PlutusData
 
 	switch v := pd.(type) {
 	case *data.Constr:

--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -83,7 +83,7 @@ func unmarshalFromList(pd data.PlutusData, val reflect.Value, typ reflect.Type) 
 		return err
 	}
 	if container == containerMap {
-		return fmt.Errorf("unmarshalFromList received map container")
+		return errors.New("unmarshalFromList received map container")
 	}
 
 	var fields []data.PlutusData

--- a/plutusencoder/map.go
+++ b/plutusencoder/map.go
@@ -3,7 +3,6 @@ package plutusencoder
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 
 	"github.com/blinklabs-io/plutigo/data"
 )
@@ -120,22 +119,12 @@ func extractMapKey(elem reflect.Value) (data.PlutusData, int, error) {
 }
 
 func unmarshalFromMap(pd data.PlutusData, val reflect.Value, typ reflect.Type) error {
-	// Read expected Constr tag from struct tag
-	var expectedConstr uint
-	hasExpectedConstr := false
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.Name == "_" {
-			if constrStr := field.Tag.Get("plutusConstr"); constrStr != "" {
-				c, err := strconv.ParseUint(constrStr, 10, 32)
-				if err != nil {
-					return fmt.Errorf("invalid plutusConstr tag %q: %w", constrStr, err)
-				}
-				expectedConstr = uint(c)
-				hasExpectedConstr = true
-			}
-			break
-		}
+	container, expectedConstr, hasExpectedConstr, err := readContainerMetadata(typ)
+	if err != nil {
+		return err
+	}
+	if container != containerMap {
+		return fmt.Errorf("unmarshalFromMap received non-map container: %d", container)
 	}
 
 	mapData, ok := pd.(*data.Map)

--- a/plutusencoder/marshal.go
+++ b/plutusencoder/marshal.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 
 	"github.com/blinklabs-io/plutigo/data"
 )
@@ -39,40 +38,31 @@ func marshalValue(val reflect.Value) (data.PlutusData, error) {
 
 	typ := val.Type()
 
-	// Read container tags from the anonymous `_` field
-	containerType := ""
-	constrTag := uint(0)
-	hasConstr := false
-
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.Name == "_" {
-			containerType = field.Tag.Get("plutusType")
-			if constrStr := field.Tag.Get("plutusConstr"); constrStr != "" {
-				c, err := strconv.ParseUint(constrStr, 10, 32)
-				if err != nil {
-					return nil, fmt.Errorf("invalid plutusConstr tag %q: %w", constrStr, err)
-				}
-				constrTag = uint(c)
-				hasConstr = true
-			}
-			break
-		}
+	container, constrTag, hasConstr, err := readContainerMetadata(typ)
+	if err != nil {
+		return nil, err
 	}
 
-	switch containerType {
-	case "Map":
+	switch container {
+	case containerMap:
 		return marshalMap(val, typ, constrTag, hasConstr)
+	case containerDefList:
+		return marshalList(val, typ, constrTag, hasConstr, false)
+	case containerIndefList:
+		return marshalList(val, typ, constrTag, hasConstr, true)
 	default:
-		// IndefList, DefList, or no tag. The reference Plutus encoder uses
-		// indefinite-length lists for the unannotated container form.
-		useIndef := containerType != "DefList"
-		return marshalList(val, typ, constrTag, hasConstr, useIndef)
+		return nil, fmt.Errorf("unknown plutus encoder container: %d", container)
 	}
 }
 
 func marshalField(fieldVal reflect.Value, field reflect.StructField) (data.PlutusData, error) {
-	plutusType := field.Tag.Get("plutusType")
+	plutusType, options, err := parseFieldTag(field.Tag.Get("plutusType"))
+	if err != nil {
+		return nil, fmt.Errorf("field %s: %w", field.Name, err)
+	}
+	if _, omit := options["omitempty"]; omit {
+		return nil, fmt.Errorf("field %s: omitempty is not supported on positional list fields", field.Name)
+	}
 
 	// BigInt handles nil *big.Int directly, so dispatch before pointer dereference
 	if plutusType == "BigInt" {

--- a/plutusencoder/tags.go
+++ b/plutusencoder/tags.go
@@ -4,7 +4,109 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 )
+
+// containerTag is the normalized form of the anonymous `_` field's
+// `plutusType` marker. Empty preserves the historical IndefList behavior;
+// unknown values are rejected so a typo cannot silently change the schema.
+type containerTag int
+
+const (
+	containerIndefList containerTag = iota
+	containerDefList
+	containerMap
+)
+
+func parseContainerTag(raw string) (containerTag, error) {
+	tag, options, err := splitPlutusType(raw)
+	if err != nil {
+		return containerIndefList, err
+	}
+	if len(options) > 0 {
+		return containerIndefList, fmt.Errorf("unknown container plutusType option %q in %q", options[0], raw)
+	}
+
+	switch tag {
+	case "", "IndefList":
+		return containerIndefList, nil
+	case "DefList":
+		return containerDefList, nil
+	case "Map":
+		return containerMap, nil
+	default:
+		return containerIndefList, fmt.Errorf("unknown container plutusType %q", tag)
+	}
+}
+
+// parseFieldTag normalizes a field's `plutusType` tag. Options are parsed
+// after the first comma, with surrounding whitespace ignored.
+func parseFieldTag(raw string) (string, map[string]struct{}, error) {
+	tag, options, err := splitPlutusType(raw)
+	if err != nil {
+		return "", nil, err
+	}
+
+	optionSet := make(map[string]struct{}, len(options))
+	for _, option := range options {
+		if option != "omitempty" {
+			return "", nil, fmt.Errorf("unknown field plutusType option %q in %q", option, raw)
+		}
+		optionSet[option] = struct{}{}
+	}
+	return tag, optionSet, nil
+}
+
+func splitPlutusType(raw string) (string, []string, error) {
+	parts := strings.Split(raw, ",")
+	tag := strings.TrimSpace(parts[0])
+	if tag == "" && len(parts) > 1 {
+		return "", nil, fmt.Errorf("invalid plutusType tag %q: missing field type", raw)
+	}
+
+	options := make([]string, 0, len(parts)-1)
+	seen := make(map[string]struct{}, len(parts)-1)
+	for _, part := range parts[1:] {
+		option := strings.TrimSpace(part)
+		if option == "" {
+			return "", nil, fmt.Errorf("invalid plutusType tag %q: empty option", raw)
+		}
+		lowerOption := strings.ToLower(option)
+		if _, duplicate := seen[lowerOption]; duplicate {
+			return "", nil, fmt.Errorf("invalid plutusType tag %q: duplicate option %q", raw, option)
+		}
+		seen[lowerOption] = struct{}{}
+		options = append(options, option)
+	}
+	return tag, options, nil
+}
+
+func readContainerMetadata(typ reflect.Type) (containerTag, uint, bool, error) {
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Name != "_" {
+			continue
+		}
+
+		container, err := parseContainerTag(field.Tag.Get("plutusType"))
+		if err != nil {
+			return containerIndefList, 0, false, err
+		}
+
+		var constrTag uint
+		hasConstr := false
+		if constrStr := field.Tag.Get("plutusConstr"); constrStr != "" {
+			c, err := strconv.ParseUint(constrStr, 10, 32)
+			if err != nil {
+				return containerIndefList, 0, false, fmt.Errorf("invalid plutusConstr tag %q: %w", constrStr, err)
+			}
+			constrTag = uint(c)
+			hasConstr = true
+		}
+		return container, constrTag, hasConstr, nil
+	}
+	return containerIndefList, 0, false, nil
+}
 
 // isOptionalField reports whether a struct field is marked optional via the
 // `plutusOptional:"true"` tag. Optional fields may be absent from an input

--- a/plutusencoder/tags_test.go
+++ b/plutusencoder/tags_test.go
@@ -1,0 +1,74 @@
+package plutusencoder
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+func TestMarshalUnknownContainerTag(t *testing.T) {
+	type typoContainerDatum struct {
+		_      struct{} `plutusType:"DefLists"`
+		Amount int64    `plutusType:"Int"`
+	}
+
+	_, err := MarshalPlutus(&typoContainerDatum{Amount: 42})
+	if err == nil {
+		t.Fatal("expected error for unknown container tag")
+	}
+	if got := err.Error(); !strings.Contains(got, "plutusType") || !strings.Contains(got, "DefLists") {
+		t.Fatalf("expected descriptive unknown-container error, got: %s", got)
+	}
+}
+
+func TestUnmarshalUnknownContainerTag(t *testing.T) {
+	type typoContainerDatum struct {
+		_      struct{} `plutusType:"DefLists"`
+		Amount int64    `plutusType:"Int"`
+	}
+
+	pd := data.NewList(data.NewInteger(new(big.Int).SetInt64(42)))
+	var decoded typoContainerDatum
+	err := UnmarshalPlutus(pd, &decoded)
+	if err == nil {
+		t.Fatal("expected error for unknown container tag")
+	}
+	if got := err.Error(); !strings.Contains(got, "plutusType") || !strings.Contains(got, "DefLists") {
+		t.Fatalf("expected descriptive unknown-container error, got: %s", got)
+	}
+}
+
+func TestMarshalUnknownFieldTagOption(t *testing.T) {
+	type unknownOptionDatum struct {
+		_      struct{} `plutusType:"DefList" plutusConstr:"0"`
+		Amount int64    `plutusType:"Int, unknownOption"`
+	}
+
+	_, err := MarshalPlutus(&unknownOptionDatum{Amount: 42})
+	if err == nil {
+		t.Fatal("expected error for unknown field tag option")
+	}
+	if got := err.Error(); !strings.Contains(got, "plutusType") || !strings.Contains(got, "unknownOption") {
+		t.Fatalf("expected descriptive unknown-option error, got: %s", got)
+	}
+}
+
+func TestMarshalEmptyContainerTagStillDefaultsToIndefList(t *testing.T) {
+	type untaggedContainerDatum struct {
+		Amount int64 `plutusType:"Int"`
+	}
+
+	pd, err := MarshalPlutus(&untaggedContainerDatum{Amount: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, ok := pd.(*data.List)
+	if !ok {
+		t.Fatalf("expected List, got %T", pd)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(list.Items))
+	}
+}

--- a/plutusencoder/unmarshal.go
+++ b/plutusencoder/unmarshal.go
@@ -34,26 +34,26 @@ func unmarshalValue(pd data.PlutusData, val reflect.Value) error {
 
 	typ := val.Type()
 
-	// Read container type
-	containerType := ""
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.Name == "_" {
-			containerType = field.Tag.Get("plutusType")
-			break
-		}
+	container, _, _, err := readContainerMetadata(typ)
+	if err != nil {
+		return err
 	}
 
-	switch containerType {
-	case "Map":
+	switch container {
+	case containerMap:
 		return unmarshalFromMap(pd, val, typ)
-	default:
+	case containerDefList, containerIndefList:
 		return unmarshalFromList(pd, val, typ)
+	default:
+		return fmt.Errorf("unknown plutus encoder container: %d", container)
 	}
 }
 
 func unmarshalField(pd data.PlutusData, fieldVal reflect.Value, field reflect.StructField) error {
-	plutusType := field.Tag.Get("plutusType")
+	plutusType, _, err := parseFieldTag(field.Tag.Get("plutusType"))
+	if err != nil {
+		return fmt.Errorf("field %s: %w", field.Name, err)
+	}
 
 	// BigInt handles *big.Int directly, so dispatch before pointer dereference
 	if plutusType == "BigInt" {


### PR DESCRIPTION
## Summary
- Centralize comma/whitespace-aware `plutusType` parsing in `tags.go`.
- Reject unknown container names and field options instead of silently treating typos as `IndefList`.
- Keep empty container tags and valid `DefList`, `IndefList`, and `Map` working as before.

## Compatibility
- **Accepted:** empty `_` container tags (still default to `IndefList`); `DefList`, `IndefList`, `Map`; valid field types with no options.
- **Newly rejected:** unknown container tags (e.g. `DefLists`), unknown field options, empty/duplicate comma options. These previously could encode as `IndefList` with no error.
- **Encoding impact:** none for valid schemas. Golden CBOR fixtures are unchanged.
- **Test evidence:** `plutusencoder/tags_test.go` plus `go test -count=1 -race ./plutusencoder` and `go test -count=1 -race ./...` on post-#309 master (plutigo v0.3.0).

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Confirm existing golden CBOR tests still pass
- [ ] Confirm unknown container/option tags now fail with a descriptive error