### PR TITLE
feat: support ignored plutus encoder fields

### DIFF
--- a/plutusencoder/ignore_test.go
+++ b/plutusencoder/ignore_test.go
@@ -1,0 +1,117 @@
+package plutusencoder
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+type offChainData struct {
+	Value string
+}
+
+type ignoreListDatum struct {
+	_        struct{}     `plutusType:"DefList" plutusConstr:"1"`
+	Amount   int64        `plutusType:"Int"`
+	OffChain offChainData `plutusType:"Ignore"`
+	Name     []byte       `plutusType:"Bytes"`
+}
+
+type ignoreMapDatum struct {
+	_        struct{}     `plutusType:"Map"`
+	Name     string       `plutusType:"StringBytes" plutusKey:"name"`
+	OffChain offChainData `plutusType:"Ignore"`
+	Value    int64        `plutusType:"Int" plutusKey:"value"`
+}
+
+func TestIgnoreListField(t *testing.T) {
+	original := ignoreListDatum{
+		Amount:   42,
+		OffChain: offChainData{Value: "not on chain"},
+		Name:     []byte("order"),
+	}
+
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	constr, ok := pd.(*data.Constr)
+	if !ok {
+		t.Fatalf("expected Constr, got %T", pd)
+	}
+	if constr.Tag != 1 {
+		t.Fatalf("expected tag 1, got %d", constr.Tag)
+	}
+	if len(constr.Fields) != 2 {
+		t.Fatalf("ignored field consumed a wire slot: expected 2 fields, got %d", len(constr.Fields))
+	}
+
+	var decoded ignoreListDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Amount != 42 {
+		t.Errorf("expected amount 42, got %d", decoded.Amount)
+	}
+	if string(decoded.Name) != "order" {
+		t.Errorf("expected name 'order', got %q", string(decoded.Name))
+	}
+	if decoded.OffChain.Value != "" {
+		t.Errorf("expected ignored field to remain zero, got %q", decoded.OffChain.Value)
+	}
+}
+
+func TestIgnoreMapField(t *testing.T) {
+	original := ignoreMapDatum{
+		Name:     "order-1",
+		OffChain: offChainData{Value: "not on chain"},
+		Value:    99,
+	}
+
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapData, ok := pd.(*data.Map)
+	if !ok {
+		t.Fatalf("expected Map, got %T", pd)
+	}
+	if len(mapData.Pairs) != 2 {
+		t.Fatalf("ignored field became a map key: expected 2 pairs, got %d", len(mapData.Pairs))
+	}
+	for i, pair := range mapData.Pairs {
+		key, ok := pair[0].(*data.ByteString)
+		if !ok {
+			t.Fatalf("pair %d key: expected ByteString, got %T", i, pair[0])
+		}
+		if string(key.Inner) == "OffChain" {
+			t.Fatalf("ignored field became map key: %q", string(key.Inner))
+		}
+	}
+
+	var decoded ignoreMapDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Name != "order-1" || decoded.Value != 99 {
+		t.Errorf("expected order-1/99, got %s/%d", decoded.Name, decoded.Value)
+	}
+	if decoded.OffChain.Value != "" {
+		t.Errorf("expected ignored field to remain zero, got %q", decoded.OffChain.Value)
+	}
+}
+
+func TestIgnoreListFieldDoesNotConsumeTrailingWireValue(t *testing.T) {
+	pd := data.NewConstr(1,
+		data.NewInteger(big.NewInt(42)),
+		data.NewByteString([]byte("order")),
+	)
+	var decoded ignoreListDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Amount != 42 || string(decoded.Name) != "order" || decoded.OffChain.Value != "" {
+		t.Errorf("unexpected decoded datum: %+v", decoded)
+	}
+}

--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -19,6 +19,14 @@ func marshalList(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr 
 			continue
 		}
 
+		ignored, err := isIgnoredField(field)
+		if err != nil {
+			return nil, err
+		}
+		if ignored {
+			continue
+		}
+
 		fieldVal := val.Field(i)
 		pd, err := marshalField(fieldVal, field)
 		if err != nil {
@@ -103,11 +111,18 @@ func unmarshalFromList(pd data.PlutusData, val reflect.Value, typ reflect.Type) 
 		return fmt.Errorf("expected Constr or List, got %T", pd)
 	}
 
-	// Count exported fields (excluding the "_" tag field).
+	// Count exported wire fields (excluding the "_" tag field and ignored fields).
 	exportedCount := 0
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
-		if f.Name != "_" && f.IsExported() {
+		if f.Name == "_" || !f.IsExported() {
+			continue
+		}
+		ignored, err := isIgnoredField(f)
+		if err != nil {
+			return err
+		}
+		if !ignored {
 			exportedCount++
 		}
 	}
@@ -121,6 +136,13 @@ func unmarshalFromList(pd data.PlutusData, val reflect.Value, typ reflect.Type) 
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		if field.Name == "_" || !field.IsExported() {
+			continue
+		}
+		ignored, err := isIgnoredField(field)
+		if err != nil {
+			return err
+		}
+		if ignored {
 			continue
 		}
 

--- a/plutusencoder/map.go
+++ b/plutusencoder/map.go
@@ -16,6 +16,14 @@ func marshalMap(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr b
 			continue
 		}
 
+		ignored, err := isIgnoredField(field)
+		if err != nil {
+			return nil, err
+		}
+		if ignored {
+			continue
+		}
+
 		fieldVal := val.Field(i)
 
 		keyName := field.Tag.Get("plutusKey")
@@ -166,6 +174,13 @@ func unmarshalFromMap(pd data.PlutusData, val reflect.Value, typ reflect.Type) e
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		if field.Name == "_" || !field.IsExported() {
+			continue
+		}
+		ignored, err := isIgnoredField(field)
+		if err != nil {
+			return err
+		}
+		if ignored {
 			continue
 		}
 

--- a/plutusencoder/tags.go
+++ b/plutusencoder/tags.go
@@ -49,12 +49,28 @@ func parseFieldTag(raw string) (string, map[string]struct{}, error) {
 
 	optionSet := make(map[string]struct{}, len(options))
 	for _, option := range options {
-		if option != "omitempty" {
+		switch option {
+		case "omitempty":
+			optionSet[option] = struct{}{}
+		default:
 			return "", nil, fmt.Errorf("unknown field plutusType option %q in %q", option, raw)
 		}
-		optionSet[option] = struct{}{}
 	}
 	return tag, optionSet, nil
+}
+
+func isIgnoredField(field reflect.StructField) (bool, error) {
+	tag, options, err := parseFieldTag(field.Tag.Get("plutusType"))
+	if err != nil {
+		return false, fmt.Errorf("field %s: %w", field.Name, err)
+	}
+	if tag == "Ignore" {
+		if len(options) > 0 {
+			return false, fmt.Errorf("field %s: Ignore does not accept options", field.Name)
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 func splitPlutusType(raw string) (string, []string, error) {


### PR DESCRIPTION
## Summary
- Add `plutusType:"Ignore"` for off-chain fields that must not appear on the wire.
- Ignored fields skip list slots and map keys on marshal, are excluded from list arity checks, and stay at the Go zero value on unmarshal.
- Regression coverage matches the off-chain `OrderTxInfo` pattern (list and map containers).

## Compatibility
- **Accepted:** existing schemas without `Ignore` are unchanged. `Ignore` fields never consume a positional wire field and never become required map keys.
- **Newly rejected:** `Ignore` combined with tag options (e.g. `Ignore, omitempty`).
- **Encoding impact:** none for schemas that do not use `Ignore`. Golden CBOR fixtures are unchanged.
- **Test evidence:** `plutusencoder/ignore_test.go` plus `go test -count=1 -race ./plutusencoder` and `go test -count=1 -race ./...`.

## Base
Branched from current `master` after [#317](https://github.com/Salvionied/apollo/pull/317) (tag validation) and [#316](https://github.com/Salvionied/apollo/pull/316) (Bursa pin / gouroboros bump).

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Confirm ignored list fields do not occupy Constr/List slots
- [ ] Confirm ignored map fields do not become keys
- [ ] Confirm trailing wire values still bind to the next non-ignored field