### PR TITLE
feat: omit empty fields in plutus maps

### DIFF
--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -26,6 +26,13 @@ func marshalList(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr 
 		if ignored {
 			continue
 		}
+		omitEmpty, err := fieldOmitEmpty(field)
+		if err != nil {
+			return nil, err
+		}
+		if omitEmpty {
+			return nil, fmt.Errorf("field %s: omitempty is not supported on positional list fields", field.Name)
+		}
 
 		fieldVal := val.Field(i)
 		pd, err := marshalField(fieldVal, field)

--- a/plutusencoder/map.go
+++ b/plutusencoder/map.go
@@ -25,6 +25,13 @@ func marshalMap(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr b
 		}
 
 		fieldVal := val.Field(i)
+		omitEmpty, err := fieldOmitEmpty(field)
+		if err != nil {
+			return nil, err
+		}
+		if omitEmpty && isEmptyField(fieldVal) {
+			continue
+		}
 
 		keyName := field.Tag.Get("plutusKey")
 		if keyName == "" {
@@ -194,6 +201,12 @@ func unmarshalFromMap(pd data.PlutusData, val reflect.Value, typ reflect.Type) e
 			optional, err := isOptionalField(field)
 			if err != nil {
 				return err
+			}
+			if !optional {
+				optional, err = fieldOmitEmpty(field)
+				if err != nil {
+					return err
+				}
 			}
 			if optional {
 				// Optional field absent from the map: leave the zero value.

--- a/plutusencoder/marshal.go
+++ b/plutusencoder/marshal.go
@@ -56,12 +56,9 @@ func marshalValue(val reflect.Value) (data.PlutusData, error) {
 }
 
 func marshalField(fieldVal reflect.Value, field reflect.StructField) (data.PlutusData, error) {
-	plutusType, options, err := parseFieldTag(field.Tag.Get("plutusType"))
+	plutusType, _, err := parseFieldTag(field.Tag.Get("plutusType"))
 	if err != nil {
 		return nil, fmt.Errorf("field %s: %w", field.Name, err)
-	}
-	if _, omit := options["omitempty"]; omit {
-		return nil, fmt.Errorf("field %s: omitempty is not supported on positional list fields", field.Name)
 	}
 
 	// BigInt handles nil *big.Int directly, so dispatch before pointer dereference

--- a/plutusencoder/omitempty_test.go
+++ b/plutusencoder/omitempty_test.go
@@ -1,0 +1,104 @@
+package plutusencoder
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+type omitMapDatum struct {
+	_       struct{} `plutusType:"Map"`
+	Name    string   `plutusType:"StringBytes" plutusKey:"name"`
+	Empty   string   `plutusType:"StringBytes, omitempty" plutusKey:"empty"`
+	Amount  int64    `plutusType:"Int,omitempty" plutusKey:"amount"`
+	Payload []byte   `plutusType:"Bytes,omitempty" plutusKey:"payload"`
+	Enabled bool     `plutusType:"Bool,omitempty" plutusKey:"enabled"`
+	Big     *big.Int `plutusType:"BigInt,omitempty" plutusKey:"big"`
+}
+
+func TestMapOmitEmptyValues(t *testing.T) {
+	original := omitMapDatum{Name: "order-1"}
+
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapData, ok := pd.(*data.Map)
+	if !ok {
+		t.Fatalf("expected Map, got %T", pd)
+	}
+	if len(mapData.Pairs) != 1 {
+		t.Fatalf("expected only the required name key, got %d pairs", len(mapData.Pairs))
+	}
+	key, ok := mapData.Pairs[0][0].(*data.ByteString)
+	if !ok {
+		t.Fatalf("expected ByteString key, got %T", mapData.Pairs[0][0])
+	}
+	if string(key.Inner) != "name" {
+		t.Fatalf("expected only name key, got %q", string(key.Inner))
+	}
+
+	var decoded omitMapDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Name != "order-1" || decoded.Empty != "" || decoded.Amount != 0 || len(decoded.Payload) != 0 || decoded.Enabled || decoded.Big != nil {
+		t.Errorf("unexpected decoded datum: %+v", decoded)
+	}
+}
+
+func TestMapOmitEmptyKeepsNonZeroValues(t *testing.T) {
+	original := omitMapDatum{
+		Name:    "order-1",
+		Empty:   "non-empty",
+		Amount:  42,
+		Payload: []byte{0x01},
+		Enabled: true,
+		Big:     big.NewInt(9),
+	}
+
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapData, ok := pd.(*data.Map)
+	if !ok {
+		t.Fatalf("expected Map, got %T", pd)
+	}
+	if len(mapData.Pairs) != 6 {
+		t.Fatalf("expected all 6 keys, got %d", len(mapData.Pairs))
+	}
+
+	var decoded omitMapDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Empty != "non-empty" || decoded.Amount != 42 || len(decoded.Payload) != 1 || !decoded.Enabled || decoded.Big.Cmp(big.NewInt(9)) != 0 {
+		t.Errorf("unexpected decoded datum: %+v", decoded)
+	}
+}
+
+func TestOmitEmptyOnListFieldReturnsError(t *testing.T) {
+	type invalidListDatum struct {
+		_      struct{} `plutusType:"DefList" plutusConstr:"0"`
+		Amount int64    `plutusType:"Int,omitempty"`
+	}
+
+	_, err := MarshalPlutus(&invalidListDatum{Amount: 0})
+	if err == nil {
+		t.Fatal("expected schema-safety error for omitempty on positional list field")
+	}
+}
+
+func TestOmitEmptyWithLeadingCommaReturnsError(t *testing.T) {
+	type invalidMapDatum struct {
+		_      struct{} `plutusType:"Map"`
+		Amount int64    `plutusType:",omitempty" plutusKey:"amount"`
+	}
+
+	_, err := MarshalPlutus(&invalidMapDatum{Amount: 0})
+	if err == nil {
+		t.Fatal("expected error for missing field type before omitempty")
+	}
+}

--- a/plutusencoder/tags.go
+++ b/plutusencoder/tags.go
@@ -73,6 +73,55 @@ func isIgnoredField(field reflect.StructField) (bool, error) {
 	return false, nil
 }
 
+func fieldOmitEmpty(field reflect.StructField) (bool, error) {
+	_, options, err := parseFieldTag(field.Tag.Get("plutusType"))
+	if err != nil {
+		return false, fmt.Errorf("field %s: %w", field.Name, err)
+	}
+	_, omit := options["omitempty"]
+	return omit, nil
+}
+
+// isEmptyField uses Go's established encoding/json empty-value semantics:
+// false, numeric zero, nil pointer/interface, and zero-length strings,
+// arrays, slices, or maps. Types may override this with IsZero.
+func isEmptyField(fieldVal reflect.Value) bool {
+	for fieldVal.Kind() == reflect.Interface {
+		if fieldVal.IsNil() {
+			return true
+		}
+		fieldVal = fieldVal.Elem()
+	}
+
+	if fieldVal.CanInterface() {
+		if zeroer, ok := fieldVal.Interface().(interface{ IsZero() bool }); ok {
+			return zeroer.IsZero()
+		}
+	}
+
+	switch fieldVal.Kind() {
+	case reflect.Bool:
+		return !fieldVal.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fieldVal.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return fieldVal.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return fieldVal.Float() == 0
+	case reflect.Complex64, reflect.Complex128:
+		return fieldVal.Complex() == 0
+	case reflect.String, reflect.Array, reflect.Slice, reflect.Map:
+		return fieldVal.Len() == 0
+	case reflect.Pointer:
+		if fieldVal.IsNil() {
+			return true
+		}
+		return isEmptyField(fieldVal.Elem())
+	default:
+		return fieldVal.IsZero()
+	}
+}
+
 func splitPlutusType(raw string) (string, []string, error) {
 	parts := strings.Split(raw, ",")
 	tag := strings.TrimSpace(parts[0])


### PR DESCRIPTION
## Summary
- Support comma-syntax `omitempty` on Map fields, including `plutusType:"StringBytes, omitempty"`.
- Empty means false, numeric zero, empty string/bytes/list/map/array, nil pointer/interface, zero/nil `big.Int`, or `IsZero()`.
- `omitempty` implies optional-on-decode for that map key; existing `plutusOptional:"true"` remains decode-only.
- Reject `omitempty` on positional `DefList`/`IndefList` with a schema-safety error.

## Compatibility
- **Accepted:** Map fields with `omitempty` (spaces around the comma allowed). Non-empty values still encode. Decode of a missing omitted key leaves the Go zero value.
- **Newly rejected:** `omitempty` on list/constructor fields; missing type before `omitempty` (` ,omitempty`).
- **Encoding impact:** none unless a Map schema opts in. Golden CBOR fixtures are unchanged.
- **Migration note:** former positional list `omitempty` fields (e.g. trade-token / collateral off-chain data) should use `Ignore` from #318, not this option.

## Base
Branched from current `master` after [#318](https://github.com/Salvionied/apollo/pull/318) (Ignore) and [#310](https://github.com/Salvionied/apollo/pull/310) (gouroboros bump).

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Empty Map fields with omitempty are dropped; non-zero values remain
- [ ] omitempty on a list field returns a clear error