### PR TITLE
fix: reject duplicate plutus map keys

### DIFF
--- a/plutusencoder/map.go
+++ b/plutusencoder/map.go
@@ -9,6 +9,7 @@ import (
 
 func marshalMap(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr bool) (data.PlutusData, error) {
 	var pairs [][2]data.PlutusData
+	seenKeys := make(map[string]struct{}, typ.NumField())
 
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
@@ -37,6 +38,10 @@ func marshalMap(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr b
 		if keyName == "" {
 			keyName = field.Name
 		}
+		if _, duplicate := seenKeys[keyName]; duplicate {
+			return nil, fmt.Errorf("field %s: duplicate map key %q", field.Name, keyName)
+		}
+		seenKeys[keyName] = struct{}{}
 
 		key := data.NewByteString([]byte(keyName))
 		value, err := marshalField(fieldVal, field)
@@ -56,6 +61,7 @@ func marshalMap(val reflect.Value, typ reflect.Type, constrTag uint, hasConstr b
 func marshalSliceAsMap(val reflect.Value, field reflect.StructField) (data.PlutusData, error) {
 	if val.Kind() == reflect.Slice {
 		var pairs [][2]data.PlutusData
+		seenKeys := make(map[string]struct{}, val.Len())
 		for i := 0; i < val.Len(); i++ {
 			elem := val.Index(i)
 			for elem.Kind() == reflect.Pointer {
@@ -69,6 +75,11 @@ func marshalSliceAsMap(val reflect.Value, field reflect.StructField) (data.Plutu
 			if err != nil {
 				return nil, fmt.Errorf("element %d key: %w", i, err)
 			}
+			keyString := key.String()
+			if _, duplicate := seenKeys[keyString]; duplicate {
+				return nil, fmt.Errorf("element %d: duplicate map key %s", i, keyString)
+			}
+			seenKeys[keyString] = struct{}{}
 			// Marshal only non-key fields as the value to avoid duplicating
 			// the key in both the map key and the value.
 			pd, err := marshalMapValueFields(elem, keyIdx)

--- a/plutusencoder/map_test.go
+++ b/plutusencoder/map_test.go
@@ -160,6 +160,62 @@ func TestUnmarshalMapDuplicateKey(t *testing.T) {
 	}
 }
 
+func TestMarshalMapDuplicatePlutusKey(t *testing.T) {
+	type duplicateKeyDatum struct {
+		_       struct{} `plutusType:"Map"`
+		Name    string   `plutusType:"StringBytes" plutusKey:"name"`
+		Alias   string   `plutusType:"StringBytes" plutusKey:"name"`
+		Version int64    `plutusType:"Int"`
+	}
+
+	_, err := MarshalPlutus(&duplicateKeyDatum{Name: "real", Alias: "shadow", Version: 1})
+	if err == nil {
+		t.Fatal("expected error for duplicate plutusKey")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate map key") || !strings.Contains(got, "name") {
+		t.Fatalf("expected descriptive duplicate-key error, got: %s", got)
+	}
+}
+
+func TestMarshalMapPlutusKeyCollidesWithDefaultName(t *testing.T) {
+	type collidingKeyDatum struct {
+		_     struct{} `plutusType:"Map"`
+		Name  string   `plutusType:"StringBytes"`
+		Alias string   `plutusType:"StringBytes" plutusKey:"Name"`
+	}
+
+	_, err := MarshalPlutus(&collidingKeyDatum{Name: "real", Alias: "shadow"})
+	if err == nil {
+		t.Fatal("expected error for plutusKey/default-name collision")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate map key") || !strings.Contains(got, "Name") {
+		t.Fatalf("expected descriptive duplicate-key error, got: %s", got)
+	}
+}
+
+func TestMarshalSliceMapDuplicateElementKey(t *testing.T) {
+	type mapEntry struct {
+		Key   string `plutusType:"StringBytes"`
+		Value int64  `plutusType:"Int"`
+	}
+	type duplicateSliceDatum struct {
+		_       struct{}   `plutusType:"DefList" plutusConstr:"0"`
+		Entries []mapEntry `plutusType:"Map"`
+	}
+
+	original := duplicateSliceDatum{Entries: []mapEntry{
+		{Key: "same", Value: 1},
+		{Key: "same", Value: 2},
+	}}
+	_, err := MarshalPlutus(&original)
+	if err == nil {
+		t.Fatal("expected error for duplicate slice-map element key")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate map key") {
+		t.Fatalf("expected descriptive duplicate-key error, got: %s", got)
+	}
+}
+
 func TestUnmarshalMapInvalidOptionalTag(t *testing.T) {
 	type badOptionalDatum struct {
 		_     struct{} `plutusType:"Map"`


### PR DESCRIPTION
## Summary
- Reject duplicate encoded keys when marshaling struct-backed Maps and slice-backed Maps.
- Covers explicit `plutusKey` collisions, explicit/default-name collisions, and duplicate slice element keys.

## Compatibility
- **Accepted:** Maps with unique keys (existing golden encodings unchanged).
- **Newly rejected:** two struct fields that encode to the same key; two slice-map elements whose keys stringify to the same value.
- **Encoding impact:** none for valid maps. Duplicate-key structs that previously encoded with last-write-wins now error.
- **Test evidence:** `TestMarshalMapDuplicatePlutusKey`, `TestMarshalSliceMapDuplicateElementKey`, plus `go test -count=1 -race ./plutusencoder` and `go test -count=1 -race ./...`.

## Base
Branched from current `master` after [#319](https://github.com/Salvionied/apollo/pull/319) (map omitempty).

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Duplicate `plutusKey` / default-name collisions fail marshal
- [ ] Duplicate slice-map element keys fail marshal