### PR TITLE
feat: support custom marshalers in slices

### DIFF
--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -73,6 +73,16 @@ func marshalSliceElement(elem reflect.Value) (data.PlutusData, error) {
 		}
 		elem = elem.Elem()
 	}
+
+	if elem.CanAddr() {
+		if m, ok := elem.Addr().Interface().(PlutusMarshaler); ok {
+			return m.ToPlutusData()
+		}
+	}
+	if m, ok := elem.Interface().(PlutusMarshaler); ok {
+		return m.ToPlutusData()
+	}
+
 	switch elem.Kind() {
 	case reflect.Struct:
 		return marshalValue(elem)
@@ -201,6 +211,15 @@ func unmarshalSliceOrNested(pd data.PlutusData, fieldVal reflect.Value, field re
 
 // unmarshalSliceElement unmarshals a single slice element, handling both struct and primitive types.
 func unmarshalSliceElement(pd data.PlutusData, elem reflect.Value) error {
+	if elem.CanAddr() {
+		if m, ok := elem.Addr().Interface().(PlutusMarshaler); ok {
+			return m.FromPlutusData(pd, elem.Addr().Interface())
+		}
+	}
+	if m, ok := elem.Interface().(PlutusMarshaler); ok {
+		return m.FromPlutusData(pd, elem.Interface())
+	}
+
 	switch elem.Kind() {
 	case reflect.Struct:
 		return unmarshalValue(pd, elem)

--- a/plutusencoder/marshaler_test.go
+++ b/plutusencoder/marshaler_test.go
@@ -1,0 +1,110 @@
+package plutusencoder
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+type customQuantity int64
+
+func (q customQuantity) ToPlutusData() (data.PlutusData, error) {
+	return data.NewInteger(big.NewInt(int64(q) + 100)), nil
+}
+
+func (q customQuantity) FromPlutusData(pd data.PlutusData, res any) error {
+	integer, ok := pd.(*data.Integer)
+	if !ok {
+		return fmt.Errorf("expected Integer, got %T", pd)
+	}
+	target, ok := res.(*customQuantity)
+	if !ok {
+		return fmt.Errorf("expected *customQuantity result, got %T", res)
+	}
+	*target = customQuantity(integer.Inner.Int64() - 100)
+	return nil
+}
+
+func (q customQuantity) IsZero() bool {
+	return q == 0
+}
+
+type customSliceDatum struct {
+	_          struct{}         `plutusType:"DefList" plutusConstr:"0"`
+	Quantities []customQuantity `plutusType:"DefList"`
+}
+
+func TestRoundTripCustomMarshalerSliceElements(t *testing.T) {
+	original := customSliceDatum{Quantities: []customQuantity{1, 2}}
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	constr, ok := pd.(*data.Constr)
+	if !ok {
+		t.Fatalf("expected Constr, got %T", pd)
+	}
+	list, ok := constr.Fields[0].(*data.List)
+	if !ok {
+		t.Fatalf("expected quantity list, got %T", constr.Fields[0])
+	}
+	first, ok := list.Items[0].(*data.Integer)
+	if !ok {
+		t.Fatalf("expected custom integer, got %T", list.Items[0])
+	}
+	if first.Inner.Int64() != 101 {
+		t.Fatalf("expected custom marshaler to add offset 100, got %d", first.Inner.Int64())
+	}
+
+	var decoded customSliceDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Quantities) != 2 || decoded.Quantities[0] != 1 || decoded.Quantities[1] != 2 {
+		t.Fatalf("unexpected decoded quantities: %+v", decoded.Quantities)
+	}
+}
+
+type customPointerDatum struct {
+	_     struct{}      `plutusType:"DefList" plutusConstr:"0"`
+	Token customTokenID `plutusType:"Custom"`
+	Count *big.Int      `plutusType:"BigInt"`
+}
+
+type customTokenID string
+
+func (id customTokenID) ToPlutusData() (data.PlutusData, error) {
+	return data.NewByteString([]byte(id)), nil
+}
+
+func (id customTokenID) FromPlutusData(pd data.PlutusData, res any) error {
+	bs, ok := pd.(*data.ByteString)
+	if !ok {
+		return fmt.Errorf("expected ByteString, got %T", pd)
+	}
+	target, ok := res.(*customTokenID)
+	if !ok {
+		return fmt.Errorf("expected *customTokenID result, got %T", res)
+	}
+	*target = customTokenID(bs.Inner)
+	return nil
+}
+
+func TestCustomMarshalerFieldStillWorks(t *testing.T) {
+	original := customPointerDatum{Token: "alpha", Count: big.NewInt(42)}
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded customPointerDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Token != "alpha" || decoded.Count.Cmp(big.NewInt(42)) != 0 {
+		t.Fatalf("unexpected decoded datum: %+v", decoded)
+	}
+}


### PR DESCRIPTION
## Summary
- Invoke `PlutusMarshaler` for value and pointer slice elements before primitive-kind dispatch.
- Preserve existing struct-element and field-level custom marshaler behavior.

## Compatibility
- **Accepted:** slices of structs and primitives still encode as before. Types that implement `PlutusMarshaler` in a slice now use `ToPlutusData` / `FromPlutusData` instead of the default integer/bytes codec.
- **Newly rejected:** none for schemas that do not use custom slice elements. A failing custom `FromPlutusData` still surfaces as a field error.
- **Encoding impact:** only slice elements that implement `PlutusMarshaler`. Golden CBOR fixtures are unchanged.
- **Test evidence:** `TestRoundTripCustomMarshalerSliceElements` plus `go test -count=1 -race ./plutusencoder` and `go test -count=1 -race ./...`.

## Base
Branched from current `master` after [#321](https://github.com/Salvionied/apollo/pull/321) (slice map key round-trip).

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Custom slice element marshaler applies offset on encode and reverses on decode
- [ ] Existing field-level custom marshalers still work