### PR TITLE
fix: honor nested list encoding tags

### DIFF
--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -61,8 +61,13 @@ func marshalSliceOrNested(val reflect.Value, field reflect.StructField, useIndef
 		}
 		return data.NewListDefIndef(useIndef, items...), nil
 	}
-	// Nested struct
-	return marshalValue(val)
+	// Nested struct without its own container marker honors the field's
+	// DefList/IndefList tag. An explicit nested `_` container takes precedence.
+	fieldContainer := containerIndefList
+	if !useIndef {
+		fieldContainer = containerDefList
+	}
+	return marshalValueWithContainer(val, fieldContainer, true)
 }
 
 // marshalSliceElement marshals a single slice element, handling both struct and primitive types.

--- a/plutusencoder/list_test.go
+++ b/plutusencoder/list_test.go
@@ -1,6 +1,7 @@
 package plutusencoder
 
 import (
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -177,6 +178,53 @@ func TestUnmarshalTooFewFields(t *testing.T) {
 	err := UnmarshalPlutus(tooFew, &decoded)
 	if err == nil {
 		t.Error("expected error when PlutusData has fewer fields than struct expects")
+	}
+}
+
+func TestMarshalNestedFieldHonorsDefListTag(t *testing.T) {
+	type innerWithoutContainer struct {
+		Value int64 `plutusType:"Int"`
+	}
+	type outerDatum struct {
+		_     struct{}              `plutusType:"DefList" plutusConstr:"0"`
+		Inner innerWithoutContainer `plutusType:"DefList"`
+	}
+
+	pd, err := MarshalPlutus(&outerDatum{Inner: innerWithoutContainer{Value: 42}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoded, err := data.Encode(pd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(encoded); got != "d8798181182a" {
+		t.Fatalf("expected nested definite list CBOR d8798181182a, got %s", got)
+	}
+}
+
+func TestMarshalNestedExplicitContainerPrecedence(t *testing.T) {
+	type innerWithContainer struct {
+		_     struct{} `plutusType:"IndefList" plutusConstr:"1"`
+		Value int64    `plutusType:"Int"`
+	}
+	type outerDatum struct {
+		_     struct{}           `plutusType:"DefList" plutusConstr:"0"`
+		Inner innerWithContainer `plutusType:"DefList"`
+	}
+
+	pd, err := MarshalPlutus(&outerDatum{Inner: innerWithContainer{Value: 42}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoded, err := data.Encode(pd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(encoded); got != "d87981d87a9f182aff" {
+		t.Fatalf("expected nested explicit container CBOR d87981d87a9f182aff, got %s", got)
 	}
 }
 

--- a/plutusencoder/marshal.go
+++ b/plutusencoder/marshal.go
@@ -14,6 +14,10 @@ func MarshalPlutus(v any) (data.PlutusData, error) {
 }
 
 func marshalValue(val reflect.Value) (data.PlutusData, error) {
+	return marshalValueWithContainer(val, containerIndefList, false)
+}
+
+func marshalValueWithContainer(val reflect.Value, fieldContainer containerTag, hasFieldContainer bool) (data.PlutusData, error) {
 	// Dereference pointers
 	for val.Kind() == reflect.Pointer {
 		if val.IsNil() {
@@ -41,6 +45,9 @@ func marshalValue(val reflect.Value) (data.PlutusData, error) {
 	container, constrTag, hasConstr, err := readContainerMetadata(typ)
 	if err != nil {
 		return nil, err
+	}
+	if !hasConstr && hasFieldContainer {
+		container = fieldContainer
 	}
 
 	switch container {


### PR DESCRIPTION
## Summary
- Honor field-level `DefList`/`IndefList` for nested structs that lack their own `_` container marker.
- The nested type's own explicit `_` container marker still takes precedence over the field tag.

## Compatibility
- **Accepted:** nested structs with their own `_` container are unchanged. Nested structs without `_` now follow the field's `DefList`/`IndefList` instead of always using indefinite lists.
- **Newly rejected:** none. Invalid container tags still fail via the existing tag parser.
- **Encoding impact:** nested structs without `_` that were tagged `DefList` previously encoded as indefinite lists; they now use definite encoding. Golden CBOR for types with explicit nested containers is unchanged.
- **Test evidence:** `TestMarshalNestedFieldHonorsDefListTag`, `TestMarshalNestedExplicitContainerPrecedence`, plus `go test -count=1 -race ./plutusencoder` and `go test -count=1 -race ./...`.

## Base
Branched from current `master` after [#322](https://github.com/Salvionied/apollo/pull/322) (custom slice marshalers).

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Nested struct without `_` tagged `DefList` encodes as definite list CBOR
- [ ] Nested struct with its own `_` container keeps that encoding