### PR TITLE
fix: tighten List and Bool Plutus shape validation

### DIFF
--- a/plutusencoder/list.go
+++ b/plutusencoder/list.go
@@ -179,15 +179,11 @@ func unmarshalFromList(pd data.PlutusData, val reflect.Value, typ reflect.Type) 
 
 func unmarshalSliceOrNested(pd data.PlutusData, fieldVal reflect.Value, field reflect.StructField) error {
 	if fieldVal.Kind() == reflect.Slice {
-		var items []data.PlutusData
-		switch v := pd.(type) {
-		case *data.List:
-			items = v.Items
-		case *data.Constr:
-			items = v.Fields
-		default:
-			return fmt.Errorf("expected List or Constr for slice, got %T", pd)
+		list, ok := pd.(*data.List)
+		if !ok {
+			return fmt.Errorf("expected List for slice field %s, got %T", field.Name, pd)
 		}
+		items := list.Items
 
 		elemType := fieldVal.Type().Elem()
 		result := reflect.MakeSlice(fieldVal.Type(), len(items), len(items))

--- a/plutusencoder/list_test.go
+++ b/plutusencoder/list_test.go
@@ -270,3 +270,36 @@ func TestMarshalIndefVsDefEncoding(t *testing.T) {
 		t.Logf("warning: String() representations are equal; if plutigo merges them, verify CBOR bytes differ")
 	}
 }
+
+func TestUnmarshalSliceRejectsConstr(t *testing.T) {
+	type sliceDatum struct {
+		_     struct{} `plutusType:"DefList" plutusConstr:"0"`
+		Items []int64  `plutusType:"DefList"`
+	}
+
+	pd := data.NewConstr(0, data.NewConstr(0, data.NewInteger(big.NewInt(1)), data.NewInteger(big.NewInt(2))))
+	var decoded sliceDatum
+	if err := UnmarshalPlutus(pd, &decoded); err == nil {
+		t.Fatal("expected error when Constr is provided where List is required for a slice")
+	}
+}
+
+func TestRoundTripSliceListShape(t *testing.T) {
+	type sliceDatum struct {
+		_     struct{} `plutusType:"DefList" plutusConstr:"0"`
+		Items []int64  `plutusType:"DefList"`
+	}
+
+	original := sliceDatum{Items: []int64{1, 2, 3}}
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded sliceDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Items) != 3 || decoded.Items[0] != 1 || decoded.Items[1] != 2 || decoded.Items[2] != 3 {
+		t.Fatalf("unexpected decoded slice: %+v", decoded.Items)
+	}
+}

--- a/plutusencoder/map.go
+++ b/plutusencoder/map.go
@@ -579,16 +579,12 @@ func unmarshalMapEntry(pair [2]data.PlutusData, elem reflect.Value) error {
 		return unmarshalField(pair[1], elem.Field(valueFieldIdxs[0]), f)
 	}
 
-	// Multiple value fields - expect pair[1] to be a List or Constr
-	var items []data.PlutusData
-	switch v := pair[1].(type) {
-	case *data.List:
-		items = v.Items
-	case *data.Constr:
-		items = v.Fields
-	default:
+	// Multiple value fields must be a bare List; Constr tags are not discarded.
+	list, ok := pair[1].(*data.List)
+	if !ok {
 		return fmt.Errorf("expected List for multi-field map value, got %T", pair[1])
 	}
+	items := list.Items
 	if len(items) < len(valueFieldIdxs) {
 		return fmt.Errorf("map value has %d items but struct expects %d non-key fields", len(items), len(valueFieldIdxs))
 	}

--- a/plutusencoder/map_test.go
+++ b/plutusencoder/map_test.go
@@ -406,6 +406,54 @@ func TestUnmarshalMapExtraKeysIgnored(t *testing.T) {
 	}
 }
 
+func TestUnmarshalMultiFieldMapValueRejectsConstr(t *testing.T) {
+	type mapEntry struct {
+		Key   string `plutusType:"StringBytes"`
+		Left  int64  `plutusType:"Int"`
+		Right int64  `plutusType:"Int"`
+	}
+	type sliceMapDatum struct {
+		_       struct{}   `plutusType:"DefList" plutusConstr:"0"`
+		Entries []mapEntry `plutusType:"Map"`
+	}
+
+	pd := data.NewConstr(0, data.NewMap([][2]data.PlutusData{
+		{
+			data.NewByteString([]byte("k")),
+			data.NewConstr(0, data.NewInteger(big.NewInt(1)), data.NewInteger(big.NewInt(2))),
+		},
+	}))
+	var decoded sliceMapDatum
+	if err := UnmarshalPlutus(pd, &decoded); err == nil {
+		t.Fatal("expected error when Constr is provided where List is required for multi-field map values")
+	}
+}
+
+func TestRoundTripMultiFieldMapValueList(t *testing.T) {
+	type mapEntry struct {
+		Key   string `plutusType:"StringBytes"`
+		Left  int64  `plutusType:"Int"`
+		Right int64  `plutusType:"Int"`
+	}
+	type sliceMapDatum struct {
+		_       struct{}   `plutusType:"DefList" plutusConstr:"0"`
+		Entries []mapEntry `plutusType:"Map"`
+	}
+
+	original := sliceMapDatum{Entries: []mapEntry{{Key: "k", Left: 1, Right: 2}}}
+	pd, err := MarshalPlutus(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded sliceMapDatum
+	if err := UnmarshalPlutus(pd, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Entries) != 1 || decoded.Entries[0] != (mapEntry{Key: "k", Left: 1, Right: 2}) {
+		t.Fatalf("unexpected decoded entries: %+v", decoded.Entries)
+	}
+}
+
 func TestRoundTripOptionalMapDatum(t *testing.T) {
 	// A well-formed map with all keys present still round-trips, including
 	// structs that carry optional tags.

--- a/plutusencoder/primitives.go
+++ b/plutusencoder/primitives.go
@@ -222,8 +222,11 @@ func unmarshalBool(pd data.PlutusData, fieldVal reflect.Value) error {
 	if !ok {
 		return fmt.Errorf("expected Constr for Bool, got %T", pd)
 	}
-	if constr.Tag > 1 {
+	if constr.Tag != 0 && constr.Tag != 1 {
 		return fmt.Errorf("expected Constr tag 0 or 1 for Bool, got %d", constr.Tag)
+	}
+	if len(constr.Fields) != 0 {
+		return fmt.Errorf("expected empty Constr for Bool, got %d fields", len(constr.Fields))
 	}
 	if fieldVal.Kind() != reflect.Bool {
 		return fmt.Errorf("bool tag requires bool, got %s", fieldVal.Kind())

--- a/plutusencoder/primitives_test.go
+++ b/plutusencoder/primitives_test.go
@@ -215,3 +215,41 @@ func TestRoundTripNegativeBigInt(t *testing.T) {
 		t.Errorf("round-trip failed: expected %s, got %s", negVal.String(), decoded.Value.String())
 	}
 }
+
+func TestUnmarshalBoolRejectsFields(t *testing.T) {
+	pd := data.NewConstr(0, data.NewConstr(1, data.NewInteger(big.NewInt(1))))
+	var decoded BoolDatum
+	if err := UnmarshalPlutus(pd, &decoded); err == nil {
+		t.Fatal("expected error for Bool Constr carrying fields")
+	}
+}
+
+func TestUnmarshalBoolRejectsOutOfRangeTag(t *testing.T) {
+	pd := data.NewConstr(0, data.NewConstr(2))
+	var decoded BoolDatum
+	if err := UnmarshalPlutus(pd, &decoded); err == nil {
+		t.Fatal("expected error for Bool Constr tag outside 0/1")
+	}
+}
+
+func TestRoundTripEmptyBoolConstructors(t *testing.T) {
+	for _, active := range []bool{false, true} {
+		original := BoolDatum{Active: active}
+		pd, err := MarshalPlutus(&original)
+		if err != nil {
+			t.Fatal(err)
+		}
+		constr := pd.(*data.Constr)
+		boolConstr := constr.Fields[0].(*data.Constr)
+		if len(boolConstr.Fields) != 0 {
+			t.Fatalf("expected empty Bool Constr, got %d fields", len(boolConstr.Fields))
+		}
+		var decoded BoolDatum
+		if err := UnmarshalPlutus(pd, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		if decoded.Active != active {
+			t.Fatalf("expected Active=%v, got %v", active, decoded.Active)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Reject `data.Constr` where a Plutus `List` is expected (slice fields and multi-field map values) instead of silently discarding the constructor tag.
- Accept only empty Bool/IndefBool constructors tagged 0 or 1; reject out-of-range tags and constructors that carry fields.

These two hardening fixes do not overlap (list/map codecs vs bool primitives), so they are combined in one PR.

## Compatibility
- **Accepted:** correctly typed List/constructor round trips and empty Bool Constr 0/1 are unchanged.
- **Newly rejected:** a Constr supplied where a slice or multi-field map value must be a bare List; Bool Constr tags other than 0/1; Bool Constr with any fields.
- **Encoding impact:** none for valid datums. Golden CBOR fixtures are unchanged.
- **Test evidence:** `TestUnmarshalSliceRejectsConstr`, `TestUnmarshalMultiFieldMapValueRejectsConstr`, `TestUnmarshalBoolRejectsFields`, `TestUnmarshalBoolRejectsOutOfRangeTag`, plus `go test -count=1 -race ./plutusencoder` and `go test -count=1 -race ./...`.

## Base
Branched from current `master` after [#324](https://github.com/Salvionied/apollo/pull/324) (native Go maps). Two commits: list-shape then bool-shape.

## Test plan
- [ ] CI lint, race, Go versions, format/vet/386
- [ ] Constr-as-list is rejected for slices and multi-field map values
- [ ] Valid lists and empty Bool Constr 0/1 still round-trip
- [ ] Bool Constr with fields or tag 2+ is rejected