### PR TITLE
docs: document the plutusencoder struct tags

### DIFF
--- a/plutusencoder/doc.go
+++ b/plutusencoder/doc.go
@@ -1,4 +1,108 @@
 // Package plutusencoder marshals Go structs to and from Plutus data using
 // plutusType and plutusConstr struct tags, so datums and redeemers can be
 // declared as ordinary Go types instead of assembled by hand.
+//
+// MarshalPlutus takes a struct, or a pointer to one, and returns the encoded
+// data.PlutusData. UnmarshalPlutus takes data.PlutusData and a non-nil
+// pointer to a struct and fills it in.
+//
+// # The container marker
+//
+// An anonymous `_` field describes the struct itself rather than any single
+// value. Its plutusType selects the shape:
+//
+//	IndefList    indefinite-length list (the default)
+//	DefList      definite-length list
+//	Map          map keyed by field name
+//
+// An absent `_` field, or an empty plutusType, means IndefList. Any other
+// value is an error, so a typo cannot silently change the schema.
+//
+// A plutusConstr on the same field wraps the container in a constructor with
+// that tag. It is parsed as a uint32:
+//
+//	type Redeemer struct {
+//		_      struct{} `plutusType:"DefList" plutusConstr:"1"`
+//		Amount int64    `plutusType:"Int"`
+//	}
+//
+// # Field types
+//
+// plutusType on an exported field selects the codec for that field:
+//
+//	Int          any signed or unsigned integer kind
+//	BigInt       *big.Int or big.Int; a nil *big.Int encodes as 0
+//	Bytes        []byte
+//	StringBytes  string, encoded as its UTF-8 bytes
+//	HexString    string holding hex, decoded to the bytes it names
+//	Bool         constructor 0 for false, 1 for true, definite-length
+//	IndefBool    the same, indefinite-length
+//	DefList      a slice, or a nested struct forced definite-length
+//	IndefList    a slice, or a nested struct forced indefinite-length
+//	Map          a native Go map, or a slice of key-value structs
+//	Ignore       the field is skipped in both directions
+//	Custom       the field's type must implement PlutusMarshaler
+//
+// A field with no plutusType must be a struct, and is marshaled recursively
+// under its own container marker. Unexported fields are always skipped.
+//
+// When DefList or IndefList names a nested struct, the struct takes the
+// field's shape unless it carries its own `_` container marker, which wins.
+//
+// # Options
+//
+// plutusType accepts comma-separated options after the type name. Surrounding
+// whitespace is ignored, and a repeated option is an error. There is one
+// option, omitempty, which drops a field whose value is empty from an encoded
+// Map:
+//
+//	Memo string `plutusType:"StringBytes,omitempty"`
+//
+// Empty follows the encoding/json rules — false, numeric zero, a nil
+// pointer or interface, and a zero-length string, array, slice or map — and a
+// type may override them by implementing IsZero() bool.
+//
+// omitempty is rejected on the fields of a list container, where dropping one
+// element would shift the position of every element after it. Ignore accepts
+// no options at all.
+//
+// # Naming and optional fields
+//
+// In a Map container, a field's key is its Go name unless plutusKey overrides
+// it. Two fields resolving to the same key is an error rather than one
+// silently shadowing the other.
+//
+// plutusOptional:"true" lets a field be absent when decoding a Map; it is
+// left at its zero value. The tag is read with strconv.ParseBool, and a
+// value that does not parse is an error rather than being treated as
+// required. It has no effect when encoding.
+//
+//	type Datum struct {
+//		_     struct{} `plutusType:"Map"`
+//		Owner []byte   `plutusType:"Bytes"       plutusKey:"owner"`
+//		Memo  string   `plutusType:"StringBytes" plutusOptional:"true"`
+//	}
+//
+// # Maps
+//
+// A Map field holds either a native Go map or a slice of structs.
+//
+// A native map encodes its keys and values with the scalar codec matching
+// their Go kind, unless the field's plutusType names something other than
+// Map, in which case that codec is used for both. Entries are sorted by
+// encoded key bytes, so the output is deterministic, and two keys that encode
+// identically are an error. A nil map cannot be encoded.
+//
+// A slice of structs takes the first exported field of each element as the
+// key and the remaining fields as the value — a single remaining field
+// becomes the value directly, several become a list. Duplicate keys are
+// rejected here too.
+//
+// # Custom encoding
+//
+// A type implementing PlutusMarshaler encodes and decodes through its own
+// methods, which take precedence over any plutusType on the field. This
+// applies to whole fields, to slice elements, and to native map keys and
+// values. Tagging a field Custom asserts that its type implements
+// PlutusMarshaler, and is an error when it does not.
 package plutusencoder

--- a/plutusencoder/example_test.go
+++ b/plutusencoder/example_test.go
@@ -1,0 +1,84 @@
+package plutusencoder_test
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/blinklabs-io/plutigo/data"
+
+	"github.com/Salvionied/apollo/v2/plutusencoder"
+)
+
+// listDatum is a constructor-wrapped definite-length list. Fields are
+// positional, so their declaration order is the encoded order.
+type listDatum struct {
+	_      struct{} `plutusType:"DefList" plutusConstr:"1"`
+	Owner  []byte   `plutusType:"Bytes"`
+	Amount int64    `plutusType:"Int"`
+}
+
+// mapDatum is keyed by field name. plutusKey renames a key, omitempty drops an
+// empty value, and Ignore keeps a field out of the encoding entirely.
+type mapDatum struct {
+	_        struct{} `plutusType:"Map"`
+	Owner    string   `plutusType:"StringBytes"           plutusKey:"owner"`
+	Memo     string   `plutusType:"StringBytes,omitempty"`
+	Internal string   `plutusType:"Ignore"`
+}
+
+func encodeHex(pd data.PlutusData) string {
+	encoded, err := data.Encode(pd)
+	if err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(encoded)
+}
+
+// ExampleMarshalPlutus encodes a positional list datum wrapped in a
+// constructor.
+func ExampleMarshalPlutus() {
+	pd, err := plutusencoder.MarshalPlutus(listDatum{
+		Owner:  []byte{0xde, 0xad},
+		Amount: 42,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(encodeHex(pd))
+	// Output: d87a8242dead182a
+}
+
+// ExampleMarshalPlutus_map shows plutusKey, omitempty and Ignore. Memo is
+// empty and Internal is ignored, so only the renamed owner key is encoded.
+func ExampleMarshalPlutus_map() {
+	pd, err := plutusencoder.MarshalPlutus(mapDatum{
+		Owner:    "alice",
+		Internal: "not encoded",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(encodeHex(pd))
+	// Output: a1456f776e657245616c696365
+}
+
+// ExampleUnmarshalPlutus decodes back into the struct the value came from.
+func ExampleUnmarshalPlutus() {
+	pd, err := plutusencoder.MarshalPlutus(listDatum{
+		Owner:  []byte{0xde, 0xad},
+		Amount: 42,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	var decoded listDatum
+	if err := plutusencoder.UnmarshalPlutus(pd, &decoded); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%x %d\n", decoded.Owner, decoded.Amount)
+	// Output: dead 42
+}


### PR DESCRIPTION
`plutusencoder/doc.go` was a four-line package comment naming `plutusType` and `plutusConstr` without describing their values, and not mentioning `plutusKey` or `plutusOptional` at all. `Ignore`, `omitempty` and native map support shipped with no documentation anywhere.

Base is `master` — this touches no changelog, so it is independent of #327, #328 and #329 and can merge in any order.

## What it documents

Read off the source, not from commit messages:

- **Container marker** — the anonymous `_` field: `IndefList` (default), `DefList`, `Map`, and `plutusConstr` as a uint32 wrapper.
- **Field types** — `Int`, `BigInt`, `Bytes`, `StringBytes`, `HexString`, `Bool`, `IndefBool`, `DefList`, `IndefList`, `Map`, `Ignore`, `Custom`, plus the untagged-struct recursion rule.
- **`omitempty`** — map-only, `encoding/json` empty semantics with an `IsZero() bool` override, and why it is rejected on positional list fields.
- **`plutusKey` / `plutusOptional`** — key renaming with duplicate rejection; optional decoding via `strconv.ParseBool`, encode-side no-op.
- **Both map forms** — native Go maps (scalar codecs by kind, sorted by encoded key bytes, duplicate encoded keys and nil maps rejected) and slice-of-structs (first exported field is the key, excluded from the value; one remaining field becomes the value directly, several become a list).
- **`PlutusMarshaler` precedence** — it wins over any `plutusType`, on whole fields, slice elements, and native map keys and values.

## Verified, not asserted

`plutusencoder/example_test.go` adds three runnable examples following the root `example_test.go` convention (external `_test` package, `// Output:`). Their expected values were captured from actual runs, so the encodings in the docs are checked by `go test`:

- `ExampleMarshalPlutus` → `d87a8242dead182a` — `DefList` + `plutusConstr:"1"` gives CBOR tag 122 (constructor 1) over a definite 2-element array.
- `ExampleMarshalPlutus_map` → `a1456f776e657245616c696365` — a one-pair map: `plutusKey` renamed `Owner` to `owner`, `omitempty` dropped the empty `Memo`, `Ignore` dropped `Internal`.
- `ExampleUnmarshalPlutus` → `dead 42` — round-trip.

Doc-comment references to `data.PlutusData`, `encoding/json` and `strconv.ParseBool` are deliberately plain text rather than bracketed doc links: `doc.go` imports nothing, so bracketed forms risked rendering literally on pkg.go.dev.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all packages pass
- `go test ./plutusencoder/ -run Example -v` — 3/3 pass
- `golangci-lint run ./plutusencoder/...` — 0 issues
- `gofmt -l .` — clean; `golines --chain-split-dots` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
