### PR TITLE
docs: remove stale Maestro guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,6 @@ replacements or substitute forks merely to make a build pass.
 | --- | --- |
 | `backend/` | `ChainContext`, capability reporting, and common backend types |
 | `backend/blockfrost/` | Blockfrost adapter |
-| `backend/maestro/` | Maestro adapter |
 | `backend/ogmios/` | Ogmios and Kupo adapter |
 | `backend/utxorpc/` | UTxO RPC adapter |
 | `backend/fixed/` | deterministic in-memory backend for tests |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ small Claude Code operating checklist so the two guides do not drift.
    untracked changes, including work created by another developer or agent.
 2. Build context from the current source and tests. Apollo v2 uses `apollo.go`,
    `backend/`, and gouroboros ledger types; ignore advice that refers to the
-   removed v1 `ApolloBuilder.go`, `serialization/`, `txBuilding/`, or `crypto/`
-   trees.
+   removed `backend/maestro/` package or the v1 `ApolloBuilder.go`,
+   `serialization/`, `txBuilding/`, and `crypto/` trees.
 3. Search for all callers and implementations before changing an interface,
    response shape, CBOR representation, wallet behavior, or fluent builder
    method.


### PR DESCRIPTION
## Summary

- remove the deleted Maestro backend from the agent repository map
- direct Claude Code to disregard guidance for the removed Maestro package and v1 package trees