### PR TITLE
fix(transaction): support uniform set-tag policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `SetTransactionBodySetTagPolicy` supports a uniform untagged encoding for
+  Conway body inputs, collateral, required signers, and reference inputs while
+  preserving Apollo's historical mixed encoding as the default.
 - `plutusType:"Ignore"` skips a struct field entirely, in both directions. It
   takes no options.
 - `omitempty` is honored on map fields, dropping a field whose value is empty

--- a/apollo.go
+++ b/apollo.go
@@ -30,6 +30,20 @@ const (
 	StakeDeposit   = 2_000_000
 )
 
+// TransactionBodySetTagPolicy controls CBOR tag 258 on set-valued Conway
+// transaction-body fields. It does not affect witness-set or Plutus-data sets.
+type TransactionBodySetTagPolicy uint8
+
+const (
+	// TransactionBodySetTagPolicyLegacy preserves Apollo's historical encoding:
+	// inputs are untagged while collateral, required signers, and reference
+	// inputs use CBOR tag 258.
+	TransactionBodySetTagPolicyLegacy TransactionBodySetTagPolicy = iota
+	// TransactionBodySetTagPolicyUntagged encodes every set-valued Conway body
+	// field as an untagged array.
+	TransactionBodySetTagPolicyUntagged
+)
+
 // ErrPlutusV4RequiresDijkstra reports that an operation needs a Dijkstra-era
 // transaction witness set, while Apollo currently builds Conway transactions.
 var ErrPlutusV4RequiresDijkstra = errors.New("plutus V4 requires Dijkstra transaction support; Apollo currently builds Conway transactions")
@@ -92,6 +106,7 @@ type Apollo struct {
 	estimateExUnits            bool
 	forceFee                   bool
 	coinSelector               CoinSelector
+	bodySetTagPolicy           TransactionBodySetTagPolicy
 	err                        error
 }
 
@@ -310,6 +325,27 @@ func (a *Apollo) SetFeePadding(padding int64) *Apollo {
 // choose inputs. When unset, the package default selector is used.
 func (a *Apollo) SetCoinSelector(selector CoinSelector) *Apollo {
 	a.coinSelector = selector
+	return a
+}
+
+// SetTransactionBodySetTagPolicy selects the CBOR set-tag policy for Conway
+// transaction-body inputs, collateral, required signers, and reference inputs.
+// The default is TransactionBodySetTagPolicyLegacy for byte compatibility with
+// earlier Apollo releases. Selecting another policy changes the transaction ID
+// and therefore every signature.
+func (a *Apollo) SetTransactionBodySetTagPolicy(
+	policy TransactionBodySetTagPolicy,
+) *Apollo {
+	switch policy {
+	case TransactionBodySetTagPolicyLegacy,
+		TransactionBodySetTagPolicyUntagged:
+		a.bodySetTagPolicy = policy
+	default:
+		a.setErrOnce(fmt.Errorf(
+			"SetTransactionBodySetTagPolicy: unsupported policy %d",
+			policy,
+		))
+	}
 	return a
 }
 
@@ -1174,6 +1210,7 @@ func (a *Apollo) Clone() *Apollo {
 		treasuryDonation:           a.treasuryDonation,
 		estimateExUnits:            a.estimateExUnits,
 		coinSelector:               a.coinSelector,
+		bodySetTagPolicy:           a.bodySetTagPolicy,
 		wallet:                     a.wallet,
 		evaluationWitnessProviders: append([]EvaluationWitnessProvider(nil), a.evaluationWitnessProviders...),
 		err:                        a.err,
@@ -2804,6 +2841,12 @@ func (a *Apollo) buildBody(
 	}
 
 	inputSet := conway.NewConwayTransactionInputSet(txInputs)
+	// The current gouroboros constructor always creates an untagged input set.
+	// Apollo therefore supports its historical mixed policy and a uniform
+	// untagged policy. A uniform tagged policy would first require a supported
+	// gouroboros API for selecting tag use on ConwayTransactionInputSet.
+	useTagOnNonInputBodySets :=
+		a.bodySetTagPolicy == TransactionBodySetTagPolicyLegacy
 
 	body := conway.ConwayTransactionBody{
 		TxInputs:  inputSet,
@@ -2829,12 +2872,18 @@ func (a *Apollo) buildBody(
 
 	// Required signers
 	if len(a.requiredSigners) > 0 {
-		body.TxRequiredSigners = cbor.NewSetType(a.requiredSigners, true)
+		body.TxRequiredSigners = cbor.NewSetType(
+			a.requiredSigners,
+			useTagOnNonInputBodySets,
+		)
 	}
 
 	// Reference inputs
 	if len(a.referenceInputs) > 0 {
-		body.TxReferenceInputs = cbor.NewSetType(a.referenceInputs, true)
+		body.TxReferenceInputs = cbor.NewSetType(
+			a.referenceInputs,
+			useTagOnNonInputBodySets,
+		)
 	}
 
 	// Certificates
@@ -2885,7 +2934,10 @@ func (a *Apollo) buildBody(
 				OutputIndex: idx,
 			})
 		}
-		body.TxCollateral = cbor.NewSetType(collInputs, true)
+		body.TxCollateral = cbor.NewSetType(
+			collInputs,
+			useTagOnNonInputBodySets,
+		)
 		if a.totalCollateral > 0 {
 			body.TxTotalCollateral = uint64(a.totalCollateral)
 		}

--- a/docs/transaction_building/README.md
+++ b/docs/transaction_building/README.md
@@ -14,6 +14,26 @@ builder, err = builder.Sign()
 txId, err := builder.Submit()
 ```
 
+## Transaction-body set tags
+
+Apollo preserves its historical Conway body encoding by default: inputs (body
+key 0) are untagged arrays, while collateral, required signers, and reference
+inputs (keys 13, 14, and 18) use CBOR tag 258. Reconstructing hardware-wallet
+APIs commonly expose one set-tag choice for the entire body. Select Apollo's
+uniform untagged policy when the external signer must reproduce the exact body:
+
+```go
+builder := apollo.New(chainContext).
+    SetTransactionBodySetTagPolicy(
+        apollo.TransactionBodySetTagPolicyUntagged,
+    )
+```
+
+The policy applies only to the four set-valued transaction-body fields. It does
+not change witness-set or Plutus-data set tags. Changing the policy changes the
+encoded body, transaction ID, and every signature, so choose it before
+`Complete()` and give reconstructing signers the same choice.
+
 ## Sections in this chapter
 
 - [Inputs and payments](inputs_and_payments.md) — UTxOs, `PayToAddress`,

--- a/transaction_body_set_tag_policy_test.go
+++ b/transaction_body_set_tag_policy_test.go
@@ -1,0 +1,248 @@
+package apollo
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+const (
+	bodyInputsKey          = uint64(0)
+	bodyCollateralKey      = uint64(13)
+	bodyRequiredSignersKey = uint64(14)
+	bodyReferenceInputsKey = uint64(18)
+)
+
+func transactionBodyFields(
+	t *testing.T,
+	body any,
+) map[uint64]cbor.RawMessage {
+	t.Helper()
+	encoded, err := cbor.Encode(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fields := make(map[uint64]cbor.RawMessage)
+	if _, err := cbor.Decode(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	return fields
+}
+
+func TestTransactionBodySetTagPolicyVectors(t *testing.T) {
+	spendingHash := common.Blake2b256{0x01}
+	collateralHash := common.Blake2b256{0x02}
+	referenceHash := common.Blake2b256{0x03}
+	signer := common.Blake2b224{0x04}
+
+	inputVector := "81825820" + "01" + strings.Repeat("00", 31) + "00"
+	collateralVector := "81825820" + "02" + strings.Repeat("00", 31) + "01"
+	referenceVector := "81825820" + "03" + strings.Repeat("00", 31) + "02"
+	signerVector := "81581c" + "04" + strings.Repeat("00", 27)
+	tagged := func(vector string) string { return "d90102" + vector }
+
+	tests := []struct {
+		name      string
+		configure func(*Apollo)
+		want      map[uint64]string
+	}{
+		{
+			name:      "legacy default",
+			configure: func(*Apollo) {},
+			want: map[uint64]string{
+				bodyInputsKey:          inputVector,
+				bodyCollateralKey:      tagged(collateralVector),
+				bodyRequiredSignersKey: tagged(signerVector),
+				bodyReferenceInputsKey: tagged(referenceVector),
+			},
+		},
+		{
+			name: "legacy explicit",
+			configure: func(a *Apollo) {
+				a.SetTransactionBodySetTagPolicy(
+					TransactionBodySetTagPolicyLegacy,
+				)
+			},
+			want: map[uint64]string{
+				bodyInputsKey:          inputVector,
+				bodyCollateralKey:      tagged(collateralVector),
+				bodyRequiredSignersKey: tagged(signerVector),
+				bodyReferenceInputsKey: tagged(referenceVector),
+			},
+		},
+		{
+			name: "uniform untagged",
+			configure: func(a *Apollo) {
+				a.SetTransactionBodySetTagPolicy(
+					TransactionBodySetTagPolicyUntagged,
+				)
+			},
+			want: map[uint64]string{
+				bodyInputsKey:          inputVector,
+				bodyCollateralKey:      collateralVector,
+				bodyRequiredSignersKey: signerVector,
+				bodyReferenceInputsKey: referenceVector,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := New(setupFixedContext())
+			test.configure(a)
+			a.requiredSigners = []common.Blake2b224{signer}
+			a.referenceInputs = []shelley.ShelleyTransactionInput{{
+				TxId:        referenceHash,
+				OutputIndex: 2,
+			}}
+			a.collaterals = []common.Utxo{
+				makeTestUtxo(t, collateralHash, 1, 5_000_000),
+			}
+
+			body, err := a.buildBody(
+				[]common.Utxo{
+					makeTestUtxo(t, spendingHash, 0, 10_000_000),
+				},
+				nil,
+				1,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fields := transactionBodyFields(t, &body)
+			for key, want := range test.want {
+				raw, ok := fields[key]
+				if !ok {
+					t.Fatalf("body field %d is absent", key)
+				}
+				if got := hex.EncodeToString(raw); got != want {
+					t.Errorf("body field %d CBOR = %s, want %s", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestTransactionBodySetTagPolicySurvivesCompleteAndSigning(t *testing.T) {
+	wallet, err := NewBursaWallet(signingTestMnemonic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cc := networkTestContext(t, common.AddressNetworkMainnet)
+	addTestUtxo(cc, wallet.Address(), 10_000_000, 0x01, 0)
+	addTestUtxo(cc, wallet.Address(), 5_000_000, 0x02, 1)
+	addTestUtxo(cc, wallet.Address(), 5_000_000, 0x03, 2)
+	utxos, err := cc.Utxos(wallet.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) != 3 {
+		t.Fatalf("fixture has %d UTxOs, want 3", len(utxos))
+	}
+
+	payee := syntheticAddress(
+		t,
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+	)
+	a := New(cc).
+		SetTransactionBodySetTagPolicy(
+			TransactionBodySetTagPolicyUntagged,
+		).
+		SetWallet(wallet).
+		AddLoadedUTxOs(utxos[0]).
+		AddCollateral(utxos[1]).
+		AddRequiredSigner(wallet.PubKeyHash()).
+		SetTtl(50_000_000).
+		PayToAddress(payee, 2_000_000)
+	a, err = a.AddReferenceInput(hex.EncodeToString(utxos[2].Id.Id().Bytes()), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err = a.Complete()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unsignedCBOR, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsignedElements := txTopLevelElements(t, unsignedCBOR)
+	fields := make(map[uint64]cbor.RawMessage)
+	if _, err := cbor.Decode(unsignedElements[0], &fields); err != nil {
+		t.Fatal(err)
+	}
+	setTag := []byte{0xd9, 0x01, 0x02}
+	for _, key := range []uint64{
+		bodyInputsKey,
+		bodyCollateralKey,
+		bodyRequiredSignersKey,
+		bodyReferenceInputsKey,
+	} {
+		raw, ok := fields[key]
+		if !ok {
+			t.Fatalf("completed body field %d is absent", key)
+		}
+		if bytes.HasPrefix(raw, setTag) {
+			t.Errorf("completed body field %d unexpectedly uses CBOR tag 258", key)
+		}
+	}
+
+	a, err = a.Sign()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedCBOR, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedElements := txTopLevelElements(t, signedCBOR)
+	if !bytes.Equal(unsignedElements[0], signedElements[0]) {
+		t.Fatal("Sign changed the exact transaction-body bytes")
+	}
+	assertSignsSubmittedBodyHash(t, signedCBOR, wallet.PubKeyHash())
+
+	witnessFields := make(map[uint64]cbor.RawMessage)
+	if _, err := cbor.Decode(signedElements[1], &witnessFields); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(witnessFields[0], setTag) {
+		t.Fatal("transaction-body policy changed vkey witness-set tagging")
+	}
+
+	datumBuilder := New(cc).SetTransactionBodySetTagPolicy(
+		TransactionBodySetTagPolicyUntagged,
+	)
+	datumBuilder.datums = []common.Datum{{}}
+	witnessSet := datumBuilder.buildWitnessSet(nil)
+	datumCBOR, err := cbor.Encode(&witnessSet.WsPlutusData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(datumCBOR, setTag) {
+		t.Fatal("transaction-body policy changed Plutus-data set tagging")
+	}
+}
+
+func TestTransactionBodySetTagPolicyCloneAndValidation(t *testing.T) {
+	a := New(setupFixedContext()).SetTransactionBodySetTagPolicy(
+		TransactionBodySetTagPolicyUntagged,
+	)
+	if got := a.Clone().bodySetTagPolicy; got != TransactionBodySetTagPolicyUntagged {
+		t.Fatalf("cloned policy = %d, want untagged", got)
+	}
+
+	invalid := New(setupFixedContext()).SetTransactionBodySetTagPolicy(
+		TransactionBodySetTagPolicy(255),
+	)
+	_, err := invalid.Complete()
+	if err == nil || !strings.Contains(err.Error(), "unsupported policy 255") {
+		t.Fatalf("invalid policy error = %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #343.

- Add explicit legacy/default and uniform untagged Conway body set-tag policies.
- Apply the selected policy consistently to body keys 0, 13, 14, and 18 without changing witness-set or Plutus-data tagging.
- Cover exact CBOR vectors, `Complete()` rebuilds, cloning, validation, and signing the exact final body bytes.
